### PR TITLE
[ECO-1546] Add swap func stubs

### DIFF
--- a/doc/blackpaper/calculations.py
+++ b/doc/blackpaper/calculations.py
@@ -1,8 +1,8 @@
 # cspell:words texttt
-from math import sqrt
+from math import isclose, sqrt
 
-A = 1_000_000.0
-R = 1.5**2
+A = 100_000.0
+R = 3.5**2
 T = 10_000.0
 
 F_P = 25.0
@@ -18,8 +18,8 @@ def get_q_r_c(m_a, c_e, p_s):
     return m_a - c_e * p_s
 
 
-def get_r_e(m_a, c_e, p_s):
-    return (m_a - c_e * p_s) / p_s
+def get_r_e(A, T):
+    return A * T
 
 
 def get_s_e(m_a, p_s):
@@ -34,8 +34,8 @@ def get_q_v_f(m_a, c_e, p_s):
     return ((m_a - c_e * p_s) ** 2) / (2 * c_e * p_s - m_a)
 
 
-def get_b_v_c(m_a, c_e, p_s):
-    return (c_e**2) * p_s / (2 * c_e * p_s - m_a)
+def get_b_v_c(A, R, T):
+    return A * T * R / (sqrt(R) - 1)
 
 
 def get_q_v_c(m_a, c_e, p_s):
@@ -55,11 +55,11 @@ def get_L_i(m_a, c_e, p_s):
 
 
 q_r_c = get_q_r_c(M_A, C_E, P_S)
-r_e = get_r_e(M_A, C_E, P_S)
+r_e = get_r_e(A, T)
 s_e = get_s_e(M_A, P_S)
 b_v_f = get_b_v_f(M_A, C_E, P_S)
 q_v_f = get_q_v_f(M_A, C_E, P_S)
-b_v_c = get_b_v_c(M_A, C_E, P_S)
+b_v_c = get_b_v_c(A, R, T)
 q_v_c = get_q_v_c(M_A, C_E, P_S)
 d_p = get_d_p(M_A, C_E, P_S)
 p_l = get_p_l(M_A, C_E, P_S)
@@ -85,7 +85,7 @@ def print_latex_nominals(vars):
             assert val.is_integer()
             val = f"{int(var[1]):,}"  # noqa: E231
         else:
-            val = f"{var[1]:.10f}"  # noqa: E231
+            val = f"{var[1]:,.15f}"  # noqa: E231
         print(f"${var[0]}$ & {val} \\\\ \\hline")
     print()
 
@@ -93,10 +93,12 @@ def print_latex_nominals(vars):
 def print_constants(vars):
     vals = []
     for var in vars:
-        assert var[1].is_integer()
-        val = int(var[1])
+        if var[0] != "LP_TOKENS_INITIAL":
+            assert var[1].is_integer()
+        val = var[1]
         if var[0] != "POOL_FEE_RATE_BPS":
             val = val * SCALE_TO_SUBUNITS
+        val = int(val)
         vals.append(val)
         left_col = f"\\texttt{{{var[0]}}} &"
         right_col = f"\\texttt{{{val:_}}} \\\\ \\hline"  # noqa: E231
@@ -158,7 +160,7 @@ print_latex_nominals(
         ["d_\\%", d_p, False],
         ["p_s = p_h", P_S, False],
         ["p_l", p_l, False],
-        ["L_i", L_i],
+        ["L_i", L_i, False],
         ["f_p", F_P],
         ["b_{v, f}", b_v_f],
         ["q_{v, f}", q_v_f],
@@ -186,20 +188,20 @@ print_constants(
 )
 
 # Check assorted systems of equations.
-assert q_r_c / P_S == r_e
+assert isclose(q_r_c / P_S, r_e)
 assert P_S == M_A / (C_E + r_e)
 assert s_e == C_E + r_e
-assert r_e == q_r_c / P_S
+assert isclose(r_e, q_r_c / P_S)
 assert (C_E + b_v_f) * q_v_f == b_v_f * (q_r_c + q_v_f)
 assert q_v_c / b_v_f == P_S
 assert q_v_c * b_v_f == q_v_f * b_v_c
 assert b_v_c == C_E + b_v_f
 assert q_v_c == q_r_c + q_v_f
-assert p_l == q_v_f / b_v_c
+assert isclose(p_l, q_v_f / b_v_c)
 assert C_E == (b_v_c * q_r_c) / (q_v_f + q_r_c)
 assert q_r_c == (C_E * q_v_c) / (b_v_f + C_E)
-assert L_i == sqrt(q_r_c * r_e)
-assert A == 1 / P_S
-assert P_S / p_l == R
+assert isclose(L_i, sqrt(q_r_c * r_e))
+assert isclose(A, 1 / P_S)
+assert isclose(P_S / p_l, R)
 assert T == q_r_c
 assert d_p == C_E / s_e * 100

--- a/doc/blackpaper/calculations.py
+++ b/doc/blackpaper/calculations.py
@@ -90,13 +90,20 @@ def print_latex_nominals(vars):
     print()
 
 
-def print_latex_constants(vars):
+def print_constants(vars):
+    vals = []
     for var in vars:
         assert var[1].is_integer()
-        val = int(var[1]) * SCALE_TO_SUBUNITS
+        val = int(var[1])
+        if var[0] != "POOL_FEE_RATE_BPS":
+            val = val * SCALE_TO_SUBUNITS
+        vals.append(val)
         left_col = f"\\texttt{{{var[0]}}} &"
         right_col = f"\\texttt{{{val:_}}} \\\\ \\hline"  # noqa: E231
         print((left_col + right_col).replace("_", "\\_"))
+    print()
+    for var, val in zip(vars, vals):
+        print(f"const {var[0]}: u64 = {val:_};")  # noqa: E231,E702
 
 
 print_vars(
@@ -160,7 +167,7 @@ print_latex_nominals(
     ]
 )
 
-print_latex_constants(
+print_constants(
     [
         ["MARKET_CAP", M_A],
         ["EMOJICOIN_REMAINDER", r_e],

--- a/doc/blackpaper/calculations.py
+++ b/doc/blackpaper/calculations.py
@@ -105,7 +105,8 @@ def print_constants(vars):
         print((left_col + right_col).replace("_", "\\_"))
     print()
     for var, val in zip(vars, vals):
-        print(f"const {var[0]}: u64 = {val:_};")  # noqa: E231,E702
+        var_type = "u8" if var[0] == "POOL_FEE_RATE_BPS" else "u64"
+        print(f"const {var[0]}: {var_type} = {val:_};")  # noqa: E231,E702
 
 
 print_vars(

--- a/doc/blackpaper/main.tex
+++ b/doc/blackpaper/main.tex
@@ -550,7 +550,7 @@ For a feeless swap sell:
 \subsection{Alternative economic variable selection} \label{sec:alt-vars}
 
 Define the inverse of spot price, roughly interpreted as the number of emojicoins that 1
-\texttt{APT} will buy at the \gls*{st} $A$:
+\texttt{APT} will buy at the \gls*{st}, $A$:
 
 \begin{equation} \label{eqn:alt-define-a}
   A = \frac{1}{p_s}
@@ -562,7 +562,7 @@ Define the ratio of bonding curve price endpoints $R$:
   R = \frac{p_s}{p_l}
 \end{equation}
 
-Define the total amount of \texttt{APT} required to initiate a \gls*{st} $T$:
+Define the total amount of \texttt{APT} required to initiate the \gls*{st}, $T$:
 
 \begin{equation} \label{eqn:alt-define-t}
   T = q_{r, c}

--- a/doc/blackpaper/main.tex
+++ b/doc/blackpaper/main.tex
@@ -324,7 +324,7 @@ Applying the same scale factor across variables produces the integer values in t
     \texttt{QUOTE\_VIRTUAL\_FLOOR}   & \texttt{2\_000\_000\_000\_000}           \\ \hline
     \texttt{BASE\_VIRTUAL\_CEILING}  & \texttt{4\_500\_000\_000\_000\_000\_000} \\ \hline
     \texttt{QUOTE\_VIRTUAL\_CEILING} & \texttt{3\_000\_000\_000\_000}           \\ \hline
-    \texttt{POOL\_FEE\_RATE\_BPS}    & \texttt{2\_500\_000\_000}                \\ \hline
+    \texttt{POOL\_FEE\_RATE\_BPS}    & \texttt{25}                              \\ \hline
   \end{tabular}
   \caption{Integer implementation values}
   \label{tab:integer-implementation-values}
@@ -524,26 +524,26 @@ Let $b_0$ and $q_0$ represent base and quote reserves before a swap, and $b_f$ a
 represent reserves after a swap. For a feeless swap buy:
 
 \begin{align}
-  b_0 \cdot q_0                & = b_f \cdot q_f \nonumber                         \\
-  b_0 \cdot q_0                & = (b_0 - b_{out}) \cdot (q_0 + q_{in}) \nonumber  \\
+  b_0 \cdot q_0                & = b_f \cdot q_f \nonumber                        \\
+  b_0 \cdot q_0                & = (b_0 - b_{out}) \cdot (q_0 + q_{in}) \nonumber \\
   b_0 \cdot q_0                & = b_0 \cdot q_0 + b_0 \cdot q_{in} - b_{out}
-  \cdot q_0 - b_{out} \cdot q_{in} \nonumber                                       \\
+  \cdot q_0 - b_{out} \cdot q_{in} \nonumber                                      \\
   b_0 \cdot q_0                & = b_0 \cdot q_0 + b_0 \cdot q_{in} -
-  b_{out} \cdot (q_0 + q_{in}) \nonumber                                           \\
-  b_{out} \cdot (q_0 + q_{in}) & = b_0 \cdot q_{in} \nonumber                      \\
+  b_{out} \cdot (q_0 + q_{in}) \nonumber                                          \\
+  b_{out} \cdot (q_0 + q_{in}) & = b_0 \cdot q_{in} \nonumber                     \\
   b_{out}                      & = \frac{b_0 \cdot q_{in}}{q_0 + q_{in}}
 \end{align}
 
 For a feeless swap sell:
 
 \begin{align}
-  b_0 \cdot q_0               & = b_f q_f \nonumber                               \\
-  b_0 \cdot q_0               & = (b_0 + b_{in}) \cdot (q_0 - q_{out}) \nonumber  \\
+  b_0 \cdot q_0               & = b_f q_f \nonumber                              \\
+  b_0 \cdot q_0               & = (b_0 + b_{in}) \cdot (q_0 - q_{out}) \nonumber \\
   b_0 \cdot q_0               & = b_0 \cdot q_0 - b_0 \cdot q_{out} +
-  b_{in} \cdot q_0 - b_{in} \cdot q_{out} \nonumber                               \\
+  b_{in} \cdot q_0 - b_{in} \cdot q_{out} \nonumber                              \\
   b_0 \cdot q_0               & = b_0 \cdot q_0 + b_{in} \cdot q_0 -
-  q_{out} \cdot(b_0 + b_{in}) \nonumber                                           \\
-  q_{out} \cdot(b_0 + b_{in}) & = b_{in} \cdot q_0 \nonumber                      \\
+  q_{out} \cdot(b_0 + b_{in}) \nonumber                                          \\
+  q_{out} \cdot(b_0 + b_{in}) & = b_{in} \cdot q_0 \nonumber                     \\
   q_{out}                     & = \frac{b_{in} \cdot q_0}{b_0 + b_{in}}
 \end{align}
 

--- a/doc/blackpaper/main.tex
+++ b/doc/blackpaper/main.tex
@@ -556,7 +556,7 @@ Define the inverse of spot price, roughly interpreted as the number of emojicoin
   A = \frac{1}{p_s}
 \end{equation}
 
-Define the ratio of bonding curve price endpoints $R$:
+Define the ratio of bonding curve price endpoints, $R$:
 
 \begin{equation} \label{eqn:alt-define-r}
   R = \frac{p_s}{p_l}
@@ -625,6 +625,32 @@ that is always met:
   1                      & < \sqrt{R} \nonumber                \\
   \sqrt{R}               & > 1 \nonumber                       \\
   R                      & > 1
+\end{align}
+
+To avoid numerical issues during calculations in a script or similar, substitute
+(\ref{eqn:alt-define-t}) and (\ref{eqn:alt-solve-p-s}) into (\ref{eqn:remainder-1}):
+
+\begin{align}
+  r_e & = \frac{q_{r, c}}{p_s} \nonumber \\
+  r_e & = \frac{T}{\frac{1}{A}} \nonumber \\
+  r_e & = A \cdot T
+\end{align}
+
+Similarly, substitute (\ref{eqn:alt-solve-c-e}), (\ref{eqn:alt-solve-p-s}), and
+(\ref{eqn:alt-solve-m-a}) into (\ref{eqn:bonding-curve-8}):
+
+\begin{align}
+  b_{v, c} & = \frac{c_e ^ 2 \cdot p_s}{2 \cdot c_e \cdot p_s - m_a} \nonumber \\
+  b_{v, c} & =
+  \frac{(A \cdot T \cdot \sqrt{R}) ^ 2 \cdot \frac{1}{A}}
+  {2 \cdot (A \cdot T \cdot \sqrt{R}) \cdot
+  \frac{1}{A} - T \cdot (1 + \sqrt{R})} \nonumber \\
+  b_{v, c} & = \frac{A^2 \cdot T^2 \cdot R \cdot \frac{1}{A}}
+  {2 \cdot T \cdot \sqrt{R} - T \cdot (1 + \sqrt{R})} \nonumber \\
+  b_{v, c} & = \frac{A \cdot T^2 \cdot R}
+  {T \cdot(2 \cdot \sqrt{R} - (1 + \sqrt{R}))} \nonumber \\
+  b_{v, c} & = \frac{A \cdot T \cdot R}{2 \cdot \sqrt{R} - (1 + \sqrt{R})} \nonumber \\
+  b_{v, c} & = \frac{A \cdot T \cdot R}{\sqrt{R} - 1}
 \end{align}
 
 \subsection{Initial \gls*{lp} tokens} \label{sec:initial-lp-tokens}

--- a/doc/blackpaper/main.tex
+++ b/doc/blackpaper/main.tex
@@ -255,24 +255,24 @@ Nominal implementation values are given in table
   \centering
   \begin{tabular}{|c|c|}
     \hline \rowcolor{blue}
-    Term             & Amount            \\ \hline
-    $A$              & 1,000,000         \\ \hline
-    $R$              & 2.25              \\ \hline
-    $T = q_{r ,c}$   & 10,000            \\ \hline
-    $m_a$            & 25,000            \\ \hline
-    $c_e = b_{r, c}$ & 15,000,000,000    \\ \hline
-    $r_e$            & 10,000,000,000    \\ \hline
-    $s_e$            & 25,000,000,000    \\ \hline
-    $d_\%$           & 60                \\ \hline
-    $p_s = p_h$      & 0.000001          \\ \hline
+    Term             & Amount              \\ \hline
+    $A$              & 100,000             \\ \hline
+    $R$              & 12.25               \\ \hline
+    $T = q_{r ,c}$   & 10,000              \\ \hline
+    $m_a$            & 45,000              \\ \hline
+    $c_e = b_{r, c}$ & 3,500,000,000       \\ \hline
+    $r_e$            & 1,000,000,000       \\ \hline
+    $s_e$            & 4,500,000,000       \\ \hline
     \rule{0pt}{10pt} % https://tex.stackexchange.com/a/387263.
-    $p_l$            & $0.000000\bar{4}$ \\ \hline
-    $L_i$            & 10,000,000        \\ \hline
-    $f_p$            & 25                \\ \hline
-    $b_{v, f}$       & 30,000,000,000    \\ \hline
-    $q_{v, f}$       & 20,000            \\ \hline
-    $b_{v, c}$       & 45,000,000,000    \\ \hline
-    $q_{v, c}$       & 30,000            \\ \hline
+    $d_\%$           & $77.\bar{7}$        \\ \hline
+    $p_s = p_h$      & 0.00001             \\ \hline
+    $p_l$            & 0.0000008163 \ldots \\ \hline
+    $L_i$            & 3,162,277.66 \ldots \\ \hline
+    $f_p$            & 25                  \\ \hline
+    $b_{v, f}$       & 1,400,000,000       \\ \hline
+    $q_{v, f}$       & 4,000               \\ \hline
+    $b_{v, c}$       & 4,900,000,000       \\ \hline
+    $q_{v, c}$       & 14,000              \\ \hline
   \end{tabular}
   \caption{Nominal implementation values}
   \label{tab:nominal-implementation-values}
@@ -311,20 +311,20 @@ Applying the same scale factor across variables produces the integer values in t
   \centering
   \begin{tabular}{|c|c|}
     \hline \rowcolor{blue}
-    Constant                         & Amount                                   \\ \hline
-    \texttt{MARKET\_CAP}             & \texttt{2\_500\_000\_000\_000}           \\ \hline
-    \texttt{EMOJICOIN\_REMAINDER}    & \texttt{1\_000\_000\_000\_000\_000\_000} \\ \hline
-    \texttt{EMOJICOIN\_SUPPLY}       & \texttt{2\_500\_000\_000\_000\_000\_000} \\ \hline
-    \texttt{LP\_TOKENS\_INITIAL}     & \texttt{1\_000\_000\_000\_000\_000}      \\ \hline
-    \texttt{BASE\_REAL\_FLOOR}       & \texttt{0}                               \\ \hline
-    \texttt{QUOTE\_REAL\_FLOOR}      & \texttt{0}                               \\ \hline
-    \texttt{BASE\_REAL\_CEILING}     & \texttt{1\_500\_000\_000\_000\_000\_000} \\ \hline
-    \texttt{QUOTE\_REAL\_CEILING}    & \texttt{1\_000\_000\_000\_000}           \\ \hline
-    \texttt{BASE\_VIRTUAL\_FLOOR}    & \texttt{3\_000\_000\_000\_000\_000\_000} \\ \hline
-    \texttt{QUOTE\_VIRTUAL\_FLOOR}   & \texttt{2\_000\_000\_000\_000}           \\ \hline
-    \texttt{BASE\_VIRTUAL\_CEILING}  & \texttt{4\_500\_000\_000\_000\_000\_000} \\ \hline
-    \texttt{QUOTE\_VIRTUAL\_CEILING} & \texttt{3\_000\_000\_000\_000}           \\ \hline
-    \texttt{POOL\_FEE\_RATE\_BPS}    & \texttt{25}                              \\ \hline
+    Constant                         & Amount                                \\ \hline
+    \texttt{MARKET\_CAP}             & \texttt{4\_500\_000\_000\_000}        \\ \hline
+    \texttt{EMOJICOIN\_REMAINDER}    & \texttt{100\_000\_000\_000\_000\_000} \\ \hline
+    \texttt{EMOJICOIN\_SUPPLY}       & \texttt{450\_000\_000\_000\_000\_000} \\ \hline
+    \texttt{LP\_TOKENS\_INITIAL}     & \texttt{316\_227\_766\_016\_837}      \\ \hline
+    \texttt{BASE\_REAL\_FLOOR}       & \texttt{0}                            \\ \hline
+    \texttt{QUOTE\_REAL\_FLOOR}      & \texttt{0}                            \\ \hline
+    \texttt{BASE\_REAL\_CEILING}     & \texttt{350\_000\_000\_000\_000\_000} \\ \hline
+    \texttt{QUOTE\_REAL\_CEILING}    & \texttt{1\_000\_000\_000\_000}        \\ \hline
+    \texttt{BASE\_VIRTUAL\_FLOOR}    & \texttt{140\_000\_000\_000\_000\_000} \\ \hline
+    \texttt{QUOTE\_VIRTUAL\_FLOOR}   & \texttt{400\_000\_000\_000}           \\ \hline
+    \texttt{BASE\_VIRTUAL\_CEILING}  & \texttt{490\_000\_000\_000\_000\_000} \\ \hline
+    \texttt{QUOTE\_VIRTUAL\_CEILING} & \texttt{1\_400\_000\_000\_000}        \\ \hline
+    \texttt{POOL\_FEE\_RATE\_BPS}    & \texttt{25}                           \\ \hline
   \end{tabular}
   \caption{Integer implementation values}
   \label{tab:integer-implementation-values}
@@ -631,7 +631,7 @@ To avoid numerical issues during calculations in a script or similar, substitute
 (\ref{eqn:alt-define-t}) and (\ref{eqn:alt-solve-p-s}) into (\ref{eqn:remainder-1}):
 
 \begin{align}
-  r_e & = \frac{q_{r, c}}{p_s} \nonumber \\
+  r_e & = \frac{q_{r, c}}{p_s} \nonumber  \\
   r_e & = \frac{T}{\frac{1}{A}} \nonumber \\
   r_e & = A \cdot T
 \end{align}
@@ -640,15 +640,15 @@ Similarly, substitute (\ref{eqn:alt-solve-c-e}), (\ref{eqn:alt-solve-p-s}), and
 (\ref{eqn:alt-solve-m-a}) into (\ref{eqn:bonding-curve-8}):
 
 \begin{align}
-  b_{v, c} & = \frac{c_e ^ 2 \cdot p_s}{2 \cdot c_e \cdot p_s - m_a} \nonumber \\
+  b_{v, c} & = \frac{c_e ^ 2 \cdot p_s}{2 \cdot c_e \cdot p_s - m_a} \nonumber       \\
   b_{v, c} & =
   \frac{(A \cdot T \cdot \sqrt{R}) ^ 2 \cdot \frac{1}{A}}
   {2 \cdot (A \cdot T \cdot \sqrt{R}) \cdot
-  \frac{1}{A} - T \cdot (1 + \sqrt{R})} \nonumber \\
+  \frac{1}{A} - T \cdot (1 + \sqrt{R})} \nonumber                                    \\
   b_{v, c} & = \frac{A^2 \cdot T^2 \cdot R \cdot \frac{1}{A}}
-  {2 \cdot T \cdot \sqrt{R} - T \cdot (1 + \sqrt{R})} \nonumber \\
+  {2 \cdot T \cdot \sqrt{R} - T \cdot (1 + \sqrt{R})} \nonumber                      \\
   b_{v, c} & = \frac{A \cdot T^2 \cdot R}
-  {T \cdot(2 \cdot \sqrt{R} - (1 + \sqrt{R}))} \nonumber \\
+  {T \cdot(2 \cdot \sqrt{R} - (1 + \sqrt{R}))} \nonumber                             \\
   b_{v, c} & = \frac{A \cdot T \cdot R}{2 \cdot \sqrt{R} - (1 + \sqrt{R})} \nonumber \\
   b_{v, c} & = \frac{A \cdot T \cdot R}{\sqrt{R} - 1}
 \end{align}

--- a/doc/blackpaper/main.tex
+++ b/doc/blackpaper/main.tex
@@ -531,7 +531,7 @@ represent reserves after a swap. For a feeless swap buy:
   b_0 \cdot q_0                & = b_0 \cdot q_0 + b_0 \cdot q_{in} -
   b_{out} \cdot (q_0 + q_{in}) \nonumber                                           \\
   b_{out} \cdot (q_0 + q_{in}) & = b_0 \cdot q_{in} \nonumber                      \\
-  b_{out}                      & = \frac{b_0 \cdot q_{in}}{q_0 + q_{in}} \nonumber \\
+  b_{out}                      & = \frac{b_0 \cdot q_{in}}{q_0 + q_{in}}
 \end{align}
 
 For a feeless swap sell:
@@ -544,7 +544,7 @@ For a feeless swap sell:
   b_0 \cdot q_0               & = b_0 \cdot q_0 + b_{in} \cdot q_0 -
   q_{out} \cdot(b_0 + b_{in}) \nonumber                                           \\
   q_{out} \cdot(b_0 + b_{in}) & = b_{in} \cdot q_0 \nonumber                      \\
-  q_{out}                     & = \frac{b_{in} \cdot q_0}{b_0 + b_{in}} \nonumber \\
+  q_{out}                     & = \frac{b_{in} \cdot q_0}{b_0 + b_{in}}
 \end{align}
 
 \subsection{Alternative economic variable selection} \label{sec:alt-vars}

--- a/src/move/.gitignore
+++ b/src/move/.gitignore
@@ -1,1 +1,4 @@
+*.mvcov
+*.trace
 build/*
+

--- a/src/move/.gitignore
+++ b/src/move/.gitignore
@@ -1,4 +1,4 @@
+# cspell:words mvcov
 *.mvcov
 *.trace
 build/*
-

--- a/src/move/sources/emojicoin_dot_fun.move
+++ b/src/move/sources/emojicoin_dot_fun.move
@@ -97,9 +97,9 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         aptos_account::create_account(@emojicoin_dot_fun);
         init_module(deployer);
         let various_emojis = vector<vector<u8>> [
-            x"f09f868e",              // Ab button blood type, 1F18E.
+            x"f09f868e",              // AB button blood type, 1F18E.
             x"f09fa6bbf09f8fbe",      // Ear with hearing aid medium dark skin tone, 1F9BB 1F3FE.
-            x"f09f87a7f09f87b9",      // Flag bhutan, 1F1E7 1F1F9.
+            x"f09f87a7f09f87b9",      // Flag Bhutan, 1F1E7 1F1F9.
             x"f09f9190f09f8fbe",      // Open hands medium dark skin tone, 1F450 1F3FE.
             x"f09fa4b0f09f8fbc",      // Pregnant woman medium light skin tone, 1F930 1F3FC.
             x"f09f9faa",              // Purple square, 1F7EA.

--- a/src/move/sources/emojicoin_dot_fun.move
+++ b/src/move/sources/emojicoin_dot_fun.move
@@ -8,12 +8,20 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     const MAX_SYMBOL_LENGTH: u8 = 10;
     const MAX_NAME_LENGTH: u8 = 32;
 
+    struct Reserves has copy, drop, store {
+        base: u64,
+        quote: u64,
+    }
+
     #[resource_group = ObjectGroup]
     struct Market has key {
         market_id: address,
         market_address: address,
         emoji_bytes: vector<u8>,
         extend_ref: ExtendRef,
+        real_reserves: Reserves,
+        virtual_reserves: Reserves,
+        lp_token_supply: u64,
     }
 
     #[resource_group = ObjectGroup]
@@ -97,4 +105,15 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         assert!(!is_supported_emoji(x"f0beefcafef0"), 0);
         assert!(!is_supported_emoji(x"f09f9982e2808de28694"), 0); // Minimally qualified "head shaking horizontally".
     }
+
+    inline fun swap_output_amount(input_amount: u64, input_is_base: bool, reserves: Reserves): u64 {
+        let (numerator_coefficient, denominator_addend) = if (input_is_base) {
+            (reserves.quote, reserves.base) else (reserves.base, reserves.quote)
+        };
+        let numerator = (input_amount as u128) * (numerator_coefficient as u128);
+        let denominator = (input_amount as u128) + (denominator_addend as u128);
+        let result = numerator / denominator;
+        // Assert fits in a u64
+    }
+
 }

--- a/src/move/sources/emojicoin_dot_fun.move
+++ b/src/move/sources/emojicoin_dot_fun.move
@@ -132,17 +132,17 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         aptos_account::create_account(@emojicoin_dot_fun);
         init_module(deployer);
         let various_emojis = vector<vector<u8>> [
-            x"f09f868e",              // AB button blood type, 1F18E.
-            x"f09fa6bbf09f8fbe",      // Ear with hearing aid medium dark skin tone, 1F9BB 1F3FE.
-            x"f09f87a7f09f87b9",      // Flag Bhutan, 1F1E7 1F1F9.
-            x"f09f9190f09f8fbe",      // Open hands medium dark skin tone, 1F450 1F3FE.
-            x"f09fa4b0f09f8fbc",      // Pregnant woman medium light skin tone, 1F930 1F3FC.
-            x"f09f9faa",              // Purple square, 1F7EA.
+            x"f09f868e",         // AB button blood type, 1F18E.
+            x"f09fa6bbf09f8fbe", // Ear with hearing aid medium dark skin tone, 1F9BB 1F3FE.
+            x"f09f87a7f09f87b9", // Flag Bhutan, 1F1E7 1F1F9.
+            x"f09f9190f09f8fbe", // Open hands medium dark skin tone, 1F450 1F3FE.
+            x"f09fa4b0f09f8fbc", // Pregnant woman medium light skin tone, 1F930 1F3FC.
+            x"f09f9faa",         // Purple square, 1F7EA.
             // Woman and man holding hands medium dark skin tone, 1F46B 1F3FE.
             x"f09f91abf09f8fbe",
-            x"f09f91a9f09f8fbe",      // Woman medium dark skin tone, 1F469 1F3FE.
-            x"f09fa795f09f8fbd",      // Woman with headscarf medium skin tone, 1F9D5 1F3FD.
-            x"f09fa490",              // Zipper mouth face, 1F910.
+            x"f09f91a9f09f8fbe", // Woman medium dark skin tone, 1F469 1F3FE.
+            x"f09fa795f09f8fbd", // Woman with headscarf medium skin tone, 1F9D5 1F3FD.
+            x"f09fa490",         // Zipper mouth face, 1F910.
         ];
         vector::for_each(various_emojis, |bytes| {
             assert!(is_supported_emoji(bytes), 0);

--- a/src/move/sources/emojicoin_dot_fun.move
+++ b/src/move/sources/emojicoin_dot_fun.move
@@ -103,7 +103,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
             x"f09f9190f09f8fbe",      // Open hands medium dark skin tone, 1F450 1F3FE.
             x"f09fa4b0f09f8fbc",      // Pregnant woman medium light skin tone, 1F930 1F3FC.
             x"f09f9faa",              // Purple square, 1F7EA.
-            x"f09f91abf09f8fbe",      // Woman and man holding hands medium dark skin tone, 1F46B 1F3FE.
+            // Woman and man holding hands medium dark skin tone, 1F46B 1F3FE.
+            x"f09f91abf09f8fbe",
             x"f09f91a9f09f8fbe",      // Woman medium dark skin tone, 1F469 1F3FE.
             x"f09fa795f09f8fbd",      // Woman with headscarf medium skin tone, 1F9D5 1F3FD.
             x"f09fa490",              // Zipper mouth face, 1F910.
@@ -118,7 +119,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         assert!(!is_supported_emoji(x"1234"), 0);
         assert!(!is_supported_emoji(x"f0fabcdefabcdeff0f"), 0);
         assert!(!is_supported_emoji(x"f0beefcafef0"), 0);
-        assert!(!is_supported_emoji(x"f09f9982e2808de28694"), 0); // Minimally qualified "head shaking horizontally".
+        // Minimally qualified "head shaking horizontally".
+        assert!(!is_supported_emoji(x"f09f9982e2808de28694"), 0);
     }
 
     inline fun swap_output_amount(input_amount: u64, input_is_base: bool, reserves: Reserves): u64 {

--- a/src/move/sources/emojicoin_dot_fun.move
+++ b/src/move/sources/emojicoin_dot_fun.move
@@ -35,6 +35,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     const E_SWAP_DIVIDE_BY_ZERO: u64 = 0;
     // No input amount provided for swap.
     const E_SWAP_INPUT_ZERO: u64 = 1;
+    // No market exists at the given address.
+    const E_NO_MARKET: u64 = 2;
 
     struct Reserves has copy, drop, store {
         base: u64,
@@ -87,6 +89,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         integrator_fee_rate_bps: u8,
         market_address: address,
     ) acquires Market {
+        assert!(exists<Market>(market_address), E_NO_MARKET);
         let market_ref_mut = borrow_global_mut<Market>(market_address);
         let market_signer = object::generate_signer_for_extending(&market_ref_mut.extend_ref);
         let swapper_address = signer::address_of(swapper);
@@ -175,6 +178,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         market_address: address,
     ): Swap
     acquires Market {
+        assert!(exists<Market>(market_address), E_NO_MARKET);
         simulate_swap_inner(
             input_amount,
             input_is_base,

--- a/src/move/sources/emojicoin_dot_fun.move
+++ b/src/move/sources/emojicoin_dot_fun.move
@@ -1,3 +1,4 @@
+// cspell:words blackpaper
 module emojicoin_dot_fun::emojicoin_dot_fun {
 
     use aptos_std::smart_table::{Self, SmartTable};
@@ -6,7 +7,21 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     use emojicoin_dot_fun::hex_codes;
 
     const MAX_SYMBOL_LENGTH: u8 = 10;
-    const MAX_NAME_LENGTH: u8 = 32;
+
+    // Generated automatically by blackpaper calculations script.
+    const MARKET_CAP: u64 = 2_500_000_000_000;
+    const EMOJICOIN_REMAINDER: u64 = 1_000_000_000_000_000_000;
+    const EMOJICOIN_SUPPLY: u64 = 2_500_000_000_000_000_000;
+    const LP_TOKENS_INITIAL: u64 = 1_000_000_000_000_000;
+    const BASE_REAL_FLOOR: u64 = 0;
+    const QUOTE_REAL_FLOOR: u64 = 0;
+    const BASE_REAL_CEILING: u64 = 1_500_000_000_000_000_000;
+    const QUOTE_REAL_CEILING: u64 = 1_000_000_000_000;
+    const BASE_VIRTUAL_FLOOR: u64 = 3_000_000_000_000_000_000;
+    const QUOTE_VIRTUAL_FLOOR: u64 = 2_000_000_000_000;
+    const BASE_VIRTUAL_CEILING: u64 = 4_500_000_000_000_000_000;
+    const QUOTE_VIRTUAL_CEILING: u64 = 3_000_000_000_000;
+    const POOL_FEE_RATE_BPS: u64 = 25;
 
     struct Reserves has copy, drop, store {
         base: u64,

--- a/src/move/sources/emojicoin_dot_fun.move
+++ b/src/move/sources/emojicoin_dot_fun.move
@@ -14,18 +14,18 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     const BASIS_POINTS_PER_UNIT: u128 = 10_000;
 
     // Generated automatically by blackpaper calculations script.
-    const MARKET_CAP: u64 = 2_500_000_000_000;
-    const EMOJICOIN_REMAINDER: u64 = 1_000_000_000_000_000_000;
-    const EMOJICOIN_SUPPLY: u64 = 2_500_000_000_000_000_000;
-    const LP_TOKENS_INITIAL: u64 = 1_000_000_000_000_000;
+    const MARKET_CAP: u64 = 4_500_000_000_000;
+    const EMOJICOIN_REMAINDER: u64 = 100_000_000_000_000_000;
+    const EMOJICOIN_SUPPLY: u64 = 450_000_000_000_000_000;
+    const LP_TOKENS_INITIAL: u64 = 316_227_766_016_837;
     const BASE_REAL_FLOOR: u64 = 0;
     const QUOTE_REAL_FLOOR: u64 = 0;
-    const BASE_REAL_CEILING: u64 = 1_500_000_000_000_000_000;
+    const BASE_REAL_CEILING: u64 = 350_000_000_000_000_000;
     const QUOTE_REAL_CEILING: u64 = 1_000_000_000_000;
-    const BASE_VIRTUAL_FLOOR: u64 = 3_000_000_000_000_000_000;
-    const QUOTE_VIRTUAL_FLOOR: u64 = 2_000_000_000_000;
-    const BASE_VIRTUAL_CEILING: u64 = 4_500_000_000_000_000_000;
-    const QUOTE_VIRTUAL_CEILING: u64 = 3_000_000_000_000;
+    const BASE_VIRTUAL_FLOOR: u64 = 140_000_000_000_000_000;
+    const QUOTE_VIRTUAL_FLOOR: u64 = 400_000_000_000;
+    const BASE_VIRTUAL_CEILING: u64 = 490_000_000_000_000_000;
+    const QUOTE_VIRTUAL_CEILING: u64 = 1_400_000_000_000;
     const POOL_FEE_RATE_BPS: u64 = 25;
 
     // Swap results in attempted divide by zero.

--- a/src/python/move_emojis/scripts/generate_code.py
+++ b/src/python/move_emojis/scripts/generate_code.py
@@ -115,13 +115,13 @@ def generate_move_code(viable_emojis: dict[str, EmojiData]) -> str:
     longest_arg = max(len(a) for a, _ in args_and_comments)
     full_args: list[str] = []
     for arg, comment in args_and_comments:
-        full_args.append(f"{arg:<{longest_arg}}{comment}")
+        full_args.append(f"{arg:<{longest_arg}}{comment}")  # noqa E231
     return_close = f"{TAB*2}]"
 
     # Generate the zeroed hex string. This results in a vector of vectors,
     # all containing a single value `0`.
     zeroes = ", ".join(["0"] * len(args_and_comments))
-    zeroed_hex_str = f"{TAB*2}vector<u8> [ {zeroes} ]"
+    zeroed_hex_str = f"{TAB*2}vector<u8> [ {zeroes} ]"  # noqa E201,E202
 
     return "\n".join(
         [


### PR DESCRIPTION
# Description

Generally, this PR adds swap simulation and commitment functionality for updating economic variables. Move code changes are awaiting integration with coin types. Some integrations, for example minting LP coins, are pending #10, and are captured in ECO-1567

Blackpaper changes:
1. Update precision support, derivations, for revised economic variables per 3347bd9
1. Fix assorted typos
1. Extend calculations script to autogen Move code

Move stylistic changes:
1. Remove unused max coin name length constant that is unlikely to be used elsewhere
1. Line break Move code at 100 chars per contributions guideline per Move book
1. Consolidate test-only `use` statements at top of module for ease of linked module analysis
1. Lookup markets by address rather than by `Object<Market>` to avoid extra internal function calls

Misc:
1. Escape flake errors erroneously generated by strings

# Testing

The constant-product swap helper functions are tested, but the swap simulation functions will need to be more comprehensively tested once there is asset mocking, etc. available

```
git ls-files | entr -c aptos move test --dev --package-dir src/move --coverage
```

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue? (note: only some tested, bulk awaiting integrations)
- [x] ~Did you update the changelog?~
- [x] Did you check off all checkboxes from the linked Linear task?
