### PR TITLE
[ECO-1592] Add global FDV, market cap tracking

### DIFF
--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -226,7 +226,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         registry_ref: &Registry,
         emojis: vector<vector<u8>>,
     ): vector<u8> {
-        let supported_emojis_ref: &Table<vector<u8>, u8> = &registry_ref.supported_emojis;
+        let supported_emojis_ref = &registry_ref.supported_emojis;
         let verified_bytes = vector[];
         for (i in 0..vector::length(&emojis)) {
             let emoji = *vector::borrow(&emojis, i);

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -30,6 +30,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     const EMOJICOIN_LP_STRUCT_NAME: vector<u8> = b"EmojicoinLP";
     const EMOJICOIN_NAME_SUFFIX: vector<u8> = b" emojicoin";
     const EMOJICOIN_LP_NAME_SUFFIX: vector<u8> = b" emojicoin LP";
+    const REGISTRY_NAME: vector<u8> = b"Registry";
 
     const U64_MAX_AS_u128: u128 = 0xffffffffffffffff;
     const BASIS_POINTS_PER_UNIT: u128 = 10_000;
@@ -478,7 +479,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     }
 
     fun init_module(emojicoin_dot_fun: &signer) {
-        let constructor_ref = object::create_object(@emojicoin_dot_fun);
+        let constructor_ref = object::create_named_object(emojicoin_dot_fun, REGISTRY_NAME);
         let extend_ref = object::generate_extend_ref(&constructor_ref);
         let registry_signer = object::generate_signer(&constructor_ref);
         let registry_address = object::address_from_constructor_ref(&constructor_ref);


### PR DESCRIPTION
# Description

Core logic:
1. Abstract `GlobalStats` resource
1. Add market cap and FDV to tracked global stats
1. Update swap function to globally aggregate FDV/market cap effects


Housekeeping:
1. Make registry a named object
1. Remove a redundant type annotation

# Testing

```sh
git ls-files | entr -c aptos move test --dev --package-dir src/move/emojicoin_dot_fun
```

# Checklist

- [x] ~Did you update relevant documentation?~
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] ~Did you update the changelog?~
- [x] Did you check off all checkboxes from the linked Linear task?