### PR TITLE
[ECO-1593] Add TVL, fee aggregation locally and globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-.env
-.env.local
-.env.development
-.tmp

--- a/doc/architecture-specification.md
+++ b/doc/architecture-specification.md
@@ -84,13 +84,13 @@ These keywords `SHALL` be in `monospace` for ease of identification.
 
 1. New coins `SHALL` use the same number of decimals as `APT` for ease of
    constant product calculations.
-1. Each `emojicoin` `symbol` field `SHALL` use hex-encoded UTF8.
-1. Each `emojicoin` `name` field `SHALL` use the format `<symbol> emojicoin`
-   where `<symbol>` is identical to the bytes from its `symbol` field.
-1. Each `emojicoin` `SHALL` have a unique liquidity provider coin (LP coin)
+1. Each emojicoin `symbol` field `SHALL` use hex-encoded UTF8.
+1. Each emojicoin `name` field `SHALL` use the format `<symbol> emojicoin` where
+   `<symbol>` is identical to the bytes from its `symbol` field.
+1. Each emojicoin `SHALL` have a unique liquidity provider coin (LP coin)
    associated with it.
-1. Each LP coin's `symbol` field `SHALL` use the format `LP-<market ID>`
-   where `<market ID>` is the corresponding market's `market_id`.
+1. Each LP coin's `symbol` field `SHALL` use the format `LP-<market ID>` where
+   `<market ID>` is the corresponding market's `market_id`.
 1. Each LP coin's `name` field `SHALL` use the format `<symbol> emojicoin LP`
    where `<symbol>` is identical to the bytes from the corresponding emojicoin's
    `symbol` field.

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -18,34 +18,35 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     use std::vector;
 
     #[test_only] use aptos_std::aptos_coin;
-    #[test_only] use yellow_heart_market::coin_factory::{
-        Emojicoin as YellowHeartEmojicoin,
-        EmojicoinLP as YellowHeartEmojicoinLP,
-        BadType,
+    #[test_only] use black_cat_market::coin_factory::{
+        Emojicoin as BlackCatEmojicoin,
+        EmojicoinLP as BlackCatEmojicoinLP,
     };
     #[test_only] use black_heart_market::coin_factory::{
         Emojicoin as BlackHeartEmojicoin,
         EmojicoinLP as BlackHeartEmojicoinLP,
     };
-    #[test_only] use black_cat_market::coin_factory::{
-        Emojicoin as BlackCatEmojicoin,
-        EmojicoinLP as BlackCatEmojicoinLP,
+
+    #[test_only] use yellow_heart_market::coin_factory::{
+        Emojicoin as YellowHeartEmojicoin,
+        EmojicoinLP as YellowHeartEmojicoinLP,
+        BadType,
     };
-
-    #[test_only] const YELLOW_HEART: vector<u8> = x"f09f929b";
-    #[test_only] const BLACK_HEART: vector<u8> = x"f09f96a4";
     #[test_only] const BLACK_CAT: vector<u8> = x"f09f9088e2808de2ac9b";
+    #[test_only] const BLACK_HEART: vector<u8> = x"f09f96a4";
+    #[test_only] const YELLOW_HEART: vector<u8> = x"f09f929b";
 
-    const MAX_SYMBOL_LENGTH: u8 = 10;
     const DECIMALS: u8 = 8;
+    const MAX_SYMBOL_LENGTH: u8 = 10;
     const MONITOR_SUPPLY: bool = true;
+
     const COIN_FACTORY_AS_BYTES: vector<u8> = b"coin_factory";
-    const EMOJICOIN_STRUCT_NAME: vector<u8> = b"Emojicoin";
-    const EMOJICOIN_LP_STRUCT_NAME: vector<u8> = b"EmojicoinLP";
     const EMOJICOIN_NAME_SUFFIX: vector<u8> = b" emojicoin";
-    const REGISTRY_NAME: vector<u8> = b"Registry";
+    const EMOJICOIN_STRUCT_NAME: vector<u8> = b"Emojicoin";
     const EMOJICOIN_LP_NAME_SUFFIX: vector<u8> = b" emojicoin LP";
+    const EMOJICOIN_LP_STRUCT_NAME: vector<u8> = b"EmojicoinLP";
     const EMOJICOIN_LP_SYMBOL_PREFIX: vector<u8> = b"LP-";
+    const REGISTRY_NAME: vector<u8> = b"Registry";
 
     const U64_MAX_AS_u128: u128 = 0xffffffffffffffff;
     const BASIS_POINTS_PER_UNIT: u128 = 10_000;

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -1076,7 +1076,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         assert!(!is_a_supported_emoji(x"fe0f"), 0);
         assert!(!is_a_supported_emoji(x"1234"), 0);
         assert!(!is_a_supported_emoji(x"f0fabcdefabcdeff0f"), 0);
-        assert!(!is_a_supported_emoji(x"f0beefcafef0"), 0);
+        assert!(!is_a_supported_emoji(x"f0f00dcafef0"), 0);
         // Minimally qualified "head shaking horizontally".
         assert!(!is_a_supported_emoji(x"f09f9982e2808de28694"), 0);
 

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -117,8 +117,10 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     struct GlobalStats has store {
         cumulative_quote_volume: Aggregator<u128>,
         total_quote_locked: Aggregator<u128>,
+        total_value_locked: Aggregator<u128>,
         market_cap: Aggregator<u128>,
         fully_diluted_value: Aggregator<u128>,
+        cumulative_integrator_fees: Aggregator<u128>,
     }
 
     #[resource_group = ObjectGroup]
@@ -629,8 +631,10 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
             global_stats: GlobalStats {
                 cumulative_quote_volume: aggregator_v2::create_unbounded_aggregator<u128>(),
                 total_quote_locked: aggregator_v2::create_unbounded_aggregator<u128>(),
+                total_value_locked: aggregator_v2::create_unbounded_aggregator<u128>(),
                 market_cap: aggregator_v2::create_unbounded_aggregator<u128>(),
                 fully_diluted_value: aggregator_v2::create_unbounded_aggregator<u128>(),
+                cumulative_integrator_fees: aggregator_v2::create_unbounded_aggregator<u128>(),
             }
         };
 

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -470,7 +470,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
             aggregator_v2::try_sub(market_cap_ref_mut, market_cap_start - market_cap_end);
             aggregator_v2::try_sub(fdv_ref_mut, fdv_start - fdv_end);
 
-            // Update cumuative pool fees.
+            // Update cumulative pool fees.
             let local_cumulative_pool_fees_quote_ref_mut =
                 &mut market_ref_mut.cumulative_pool_fees_quote;
             *local_cumulative_pool_fees_quote_ref_mut =


### PR DESCRIPTION
# Description

1. Track local fees for integrator, pool base, pool quote
1. Track global integrator fees
1. Add helpers for calculating TVL in CLAMM and CPAMM
1. Aggregate TVL globally, via changes in swap and liquidity functions

Housekeeping

1. Take out emojicoin monospace on architecture specification where not
   applicable
1. Clear out gitignore at top level since not needed
1. Sort uses, constants

# Testing

```sh
git ls-files | entr -c aptos move test --dev --package-dir src/move/emojicoin_dot_fun
```

# Checklist

- [x] ~Did you update relevant documentation?~
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] ~Did you update the changelog?~
- [x] Did you check off all checkboxes from the linked Linear task?