### PR TITLE
[ECO-1609] Add periodic/instantaneous state events, chat stubs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,24 +2,20 @@
 
 # Description
 
-Delete this line and add a description that explains what changes you have done
-and why they were necessary.
+1. Incorporate global and local backend-less indexing, to rely solely on GraphQL
+endpoint.
+1. Update architecture specification for designs.
+1. Update tests to incorporate timestamp support.
 
 # Testing
 
-Delete this line and provide a description of how to test the changes in this
-PR.
+```sh
+git ls-files | entr -c aptos move test --dev --package-dir src/move/emojicoin_dot_fun
+```
 
 # Checklist
 
-- [ ] Did you update relevant documentation?
-- [ ] Did you add tests to cover new code or a fixed issue?
-- [ ] Did you update the changelog?
-- [ ] Did you check off all checkboxes from the linked Linear task? (Ignore if
-  you are not a member of Econia Labs)
-
-> If a task does not apply to your PR, strike it through and mark it complete:
-
-```md
+- [x] Did you update relevant documentation?
+- [x] Did you add tests to cover new code or a fixed issue?
 - [x] ~Did you update the changelog?~
-```
+- [x] Did you check off all checkboxes from the linked Linear task?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,20 +2,24 @@
 
 # Description
 
-1. Incorporate global and local backend-less indexing, to rely solely on GraphQL
-endpoint.
-1. Update architecture specification for designs.
-1. Update tests to incorporate timestamp support.
+Delete this line and add a description that explains what changes you have done
+and why they were necessary.
 
 # Testing
 
-```sh
-git ls-files | entr -c aptos move test --dev --package-dir src/move/emojicoin_dot_fun
-```
+Delete this line and provide a description of how to test the changes in this
+PR.
 
 # Checklist
 
-- [x] Did you update relevant documentation?
-- [x] Did you add tests to cover new code or a fixed issue?
+- [ ] Did you update relevant documentation?
+- [ ] Did you add tests to cover new code or a fixed issue?
+- [ ] Did you update the changelog?
+- [ ] Did you check off all checkboxes from the linked Linear task? (Ignore if
+  you are not a member of Econia Labs)
+
+> If a task does not apply to your PR, strike it through and mark it complete:
+
+```md
 - [x] ~Did you update the changelog?~
-- [x] Did you check off all checkboxes from the linked Linear task?
+```

--- a/doc/architecture-specification.md
+++ b/doc/architecture-specification.md
@@ -41,14 +41,14 @@ These keywords `SHALL` be in `monospace` for ease of identification.
    capitalization of each emojicoin market.
 1. A `State` event `SHALL` be emitted for every operation, to enable fetching
    market state as of the most recent event.
-1. Each market `SHALL` track a vector of internal `PeriodicState` event
+1. Each market `SHALL` track a vector of internal `PeriodicStateTracker`
    accumulators, to enable volume and price versus times charts, with an
-   internal variable for the last time the event was emitted. Each granularity,
-   for example `1min`, `30min`, `1hr`, `6hr`, and `24hr`, `SHALL` track the last
-   time it was emitted, and use integer time truncation to check that a new
-   period has not started. When an operation results in a new period, a
-   `PeriodicState` event `SHALL` be emitted for each granularity that has
-   lapsed.
+   internal variable for the period start time and the period length including
+   `1M`, `5M`, `15M`, `30M`, `1H`, `4H`, and `1D`. Integer time truncation
+   `SHALL` be used to check that a new period has started, and when an operation
+   results in a new period, a `PeriodicState` event `SHALL` be emitted for each
+   granularity that has lapsed.
+1. A `GlobalState` event for the entire protocol `SHALL` be emitted each day.
 1. A view function shall enable enable lookup of global total value locked,
    number of emojicoin markets, and cumulative volume, via aggregators when
    necessary.
@@ -58,13 +58,17 @@ These keywords `SHALL` be in `monospace` for ease of identification.
 1. Simulation functions `SHALL` be paired with simulation commitment functions
    such that results can be applied during runtime, using the same logic as
    view function indexing functions.
-1. Events `SHALL` include timestamps for chronological indexing.
+1. Events `SHALL` include timestamps for chronological indexing, expressed in
+   UNIX microseconds.
 1. Events `SHALL` include information for fees charged, accumulated at the
    market and global level.
 1. The total number of trades `SHALL` be indexed at the market and global level.
 1. Cumulative fees `SHALL` be indexed at the market and global level.
-1. Liquidity provider APR `SHALL` be tracked by comparing the ratio of liquidity
-   to issued liquidity provider tokens over time.
+1. Prices `SHALL` be expressed in `Q64` notation.
+1. Liquidity provider APR `SHALL` be tracked by comparing the ratio of total
+   value locked to issued liquidity provider tokens over time. `PeriodicState`
+   events `SHALL` express the growth in the TVL/LP coin ratio in `Q64` notation.
+1. The registry and each market `SHALL` implement a 1-indexed nonce.
 
 ## Frontend
 

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -1499,8 +1499,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     /// `d :=` LP coins at end
     ///
     /// Growth in TVL per LP coin symbolically evaluates to:
-    /// `(a / b) / (c / d)`
-    /// `(a * d) / (b * c)`
+    /// `(c / d) / (a / b)`
+    /// `(b * c) / (a * d)`
     ///
     /// Numerator should be shifted by `SHIFT_Q64` so that the result is in Q64 format.
     ///
@@ -1514,11 +1514,11 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         let b = start.lp_coins;
         let c = end.tvl;
         let d = end.lp_coins;
-        if (b == 0 || c == 0) {
+        if (a == 0 || d == 0) {
             0
         } else {
-            let numerator = (a as u256) * (d as u256);
-            let denominator = (b as u256) * (c as u256);
+            let numerator = (b as u256) * (c as u256);
+            let denominator = (a as u256) * (d as u256);
             (((numerator << SHIFT_Q64) / denominator) as u128)
         }
     }

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -218,7 +218,6 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         trigger: u8,
     }
 
-
     #[event]
     struct State has drop, store {
         market_metadata: MarketMetadata,

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -61,7 +61,6 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     const TRIGGER_REMOVE_LIQUIDITY: u8 = 4;
     const TRIGGER_CHAT: u8 = 5;
 
-    const PERIOD_INSTANTANEOUS: u64 = 0;
     const PERIOD_1M: u64 = 60_000_000;
     const PERIOD_5M: u64 = 300_000_000;
     const PERIOD_15M: u64 = 900_000_000;

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -1500,7 +1500,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     /// `c :=` TVL at end
     /// `d :=` LP coins at end
     ///
-    /// Growth in TVL per LP coin symbolically evalutes to:
+    /// Growth in TVL per LP coin symbolically evaluates to:
     /// `(a / b) / (c / d)`
     /// `(a * d) / (b * c)`
     ///
@@ -1541,7 +1541,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
             tracker_ref_mut.tvl_to_lp_coin_ratio_end.lp_coins = lp_coin_supply;
         });
 
-        // Get instananeous stats, bump market state.
+        // Get instantaneous stats, bump market state.
         let (fdv, market_cap) = fdv_market_cap(real_reserves, EMOJICOIN_SUPPLY);
         bump_market_state(
             market_ref_mut,


### PR DESCRIPTION
# Description

1. Abstract existing data structures for stats
1. Create new state events for tracking indexed data
1. Create `init_module_for_testing()` helper
1. Incorporate global and local backend-less indexing, to rely solely on GraphQL
endpoint
1. Update architecture specification for designs
1. Update tests to incorporate timestamp support
1. Add chat API/event stubs

# Testing

```sh
git ls-files | entr -c aptos move test --dev --package-dir src/move/emojicoin_dot_fun
```

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] ~Did you update the changelog?~
- [x] Did you check off all checkboxes from the linked Linear task?
