### PR TITLE
[ECO-1613] Fix Market resource query for CI/unit test

### DIFF
--- a/src/typescript/api/src/emojicoin_dot_fun/utils.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/utils.ts
@@ -69,10 +69,20 @@ export async function getRegistryAddress(args: {
   return registryAddressResource.registry_address;
 }
 
-export type MarketResource = {
+export type MarketMetadata = {
   market_id: Uint64;
   market_address: AccountAddress;
   emoji_bytes: Hex;
+};
+
+export type SequenceInfo = {
+  nonce: Uint64;
+  last_bump_time: Uint64;
+};
+
+export type MarketResource = {
+  metadata: MarketMetadata;
+  sequence_info: SequenceInfo;
   extend_ref: ExtendRef;
   clamm_virtual_reserves: Reserves;
   cpamm_real_reserves: Reserves;
@@ -101,9 +111,15 @@ export async function getMarketResource(args: {
     resourceType: `${moduleAddress.toString()}::${EMOJICOIN_DOT_FUN_MODULE_NAME}::Market`,
   });
   return {
-    market_id: BigInt(marketResource.market_id),
-    market_address: AccountAddress.from(marketResource.market_address),
-    emoji_bytes: Hex.fromHexString(marketResource.emoji_bytes),
+    metadata: {
+      market_id: BigInt(marketResource.metadata.market_id),
+      market_address: AccountAddress.from(marketResource.metadata.market_address),
+      emoji_bytes: Hex.fromHexString(marketResource.metadata.emoji_bytes),
+    },
+    sequence_info: {
+      nonce: BigInt(marketResource.sequence_info.nonce),
+      last_bump_time: BigInt(marketResource.sequence_info.last_bump_time),
+    },
     extend_ref: {
       self: AccountAddress.from(marketResource.extend_ref.self),
     },

--- a/src/typescript/api/tests/e2e/register.test.ts
+++ b/src/typescript/api/tests/e2e/register.test.ts
@@ -69,12 +69,19 @@ describe("registers a market successfully", () => {
       objectAddress: derivedNamedObjectAddress,
     });
 
-    expect(marketObjectMarketResource.emoji_bytes.toString()).toEqual(`0x${emojis[0]}${emojis[1]}`);
-    expect(marketObjectMarketResource.extend_ref.self.toStringLong()).toEqual(
-      derivedNamedObjectAddress.toStringLong()
-    );
-    expect(marketObjectMarketResource.market_id).toEqual(1n);
-    expect(marketObjectMarketResource.lp_coin_supply).toEqual(0n);
+    const {
+      market_id: marketId,
+      market_address: marketAddress,
+      emoji_bytes: emojiBytes,
+    } = marketObjectMarketResource.metadata;
+
+    const { lp_coin_supply: lpCoinSupply, extend_ref: extendRef } = marketObjectMarketResource;
+
+    expect(marketId).toEqual(1n);
+    expect(emojiBytes.toString()).toEqual(`0x${emojis[0]}${emojis[1]}`);
+    expect(extendRef.self.toStringLong()).toEqual(derivedNamedObjectAddress.toStringLong());
+    expect(extendRef.self.toStringLong()).toEqual(marketAddress.toStringLong());
+    expect(lpCoinSupply).toEqual(0n);
 
     const marketObjectResources = await aptos.getAccountModule({
       accountAddress: derivedNamedObjectAddress,


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The new `emojicoin_dot_fun.move` has differently structured resources. We need to update the types in the typescript unit tests to reflect this accurately so the unit tests/CI will not fail.

# Testing

`pnpm run test` and the CI unit tests

# Checklist

- [x] ~Did you update relevant documentation?~
- [x] Did you add tests to cover new code or a fixed issue?
- [x] ~Did you update the changelog?~
- [x] ~Did you check off all checkboxes from the linked Linear task?~
