### PR TITLE
[ECO-1615] Fix peer dependency with react-scripts with override in package.json

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -33,6 +33,11 @@
     "web-vitals": "^2.1.4",
     "yup": "^1.2.0"
   },
+  "overrides": {
+    "react-scripts": {
+      "typescript": "^5"
+    }
+  },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@storybook/preset-create-react-app": "^7.4.1",

--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -33,11 +33,6 @@
     "web-vitals": "^2.1.4",
     "yup": "^1.2.0"
   },
-  "overrides": {
-    "react-scripts": {
-      "typescript": "^5"
-    }
-  },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@storybook/preset-create-react-app": "^7.4.1",
@@ -63,6 +58,11 @@
   },
   "main": "src/index.tsx",
   "name": "econia-labs",
+  "overrides": {
+    "react-scripts": {
+      "typescript": "^5"
+    }
+  },
   "private": true,
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",


### PR DESCRIPTION
# Description

Because react-scripts thinks it must have typescript v3 or v4, it complains that we're using v5. According to this issue:

https://github.com/facebook/create-react-app/issues/13080

Typescript v5 works just fine with Create React App (CRA). Thus we can override it in package.json.

# Testing

```shell
npm install && npm run build && npm run start
```

Tested locally for now.

# Checklist

- [x] ~Did you update relevant documentation?~
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] ~Did you update the changelog?~
- [x] ~Did you check off all checkboxes from the linked Linear task?~
