### PR TITLE
[ECO-1629] Test module/market init to 100% coverage

### DIFF
--- a/doc/architecture-specification.md
+++ b/doc/architecture-specification.md
@@ -36,9 +36,6 @@ These keywords `SHALL` be in `monospace` for ease of identification.
 
 ## Indexing
 
-1. The user interface `SHALL` rely solely on the Aptos GraphQL endpoint for
-   indexing purposes, enabling for example a leaderboard based on market
-   capitalization of each emojicoin market.
 1. A `State` event `SHALL` be emitted for every operation, to enable fetching
    market state as of the most recent event.
 1. Each market `SHALL` track a vector of internal `PeriodicStateTracker`

--- a/doc/architecture-specification.md
+++ b/doc/architecture-specification.md
@@ -37,7 +37,8 @@ These keywords `SHALL` be in `monospace` for ease of identification.
 ## Indexing
 
 1. A `State` event `SHALL` be emitted for every operation, to enable fetching
-   market state as of the most recent event.
+   market state as of the most recent event, with the market's last bump time
+   tracking the most recent emission.
 1. Each market `SHALL` track a vector of internal `PeriodicStateTracker`
    accumulators, to enable volume and price versus times charts, with an
    internal variable for the period start time and the period length including
@@ -45,7 +46,8 @@ These keywords `SHALL` be in `monospace` for ease of identification.
    `SHALL` be used to check that a new period has started, and when an operation
    results in a new period, a `PeriodicState` event `SHALL` be emitted for each
    granularity that has lapsed.
-1. A `GlobalState` event for the entire protocol `SHALL` be emitted each day.
+1. A `GlobalState` event for the entire protocol `SHALL` be emitted each day,
+   with the registry's last bump time tracking the most recent emission.
 1. A view function shall enable enable lookup of global total value locked,
    number of emojicoin markets, and cumulative volume, via aggregators when
    necessary.
@@ -65,7 +67,8 @@ These keywords `SHALL` be in `monospace` for ease of identification.
 1. Liquidity provider APR `SHALL` be tracked by comparing the ratio of total
    value locked to issued liquidity provider tokens over time. `PeriodicState`
    events `SHALL` express the growth in the TVL/LP coin ratio in `Q64` notation.
-1. The registry and each market `SHALL` implement a 1-indexed nonce.
+1. The registry and each market `SHALL` implement a 1-indexed nonce, updated
+   whenever state is mutated.
 
 ## Frontend
 

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2257,18 +2257,6 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
 
     #[test_only] public fun init_module_test_only(account: &signer) { init_module(account) }
 
-    #[test_only] public fun pack_market_metadata(
-        market_id: u64,
-        market_address: address,
-        emoji_bytes: vector<u8>,
-    ): MarketMetadata {
-        MarketMetadata {
-            market_id,
-            market_address,
-            emoji_bytes,
-        }
-    }
-
     #[test_only] public fun pack_reserves(base: u64, quote: u64): Reserves {
         Reserves { base, quote }
     }

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2251,6 +2251,9 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     #[test_only] public fun get_PERIOD_1H(): u64 { PERIOD_1H }
     #[test_only] public fun get_PERIOD_4H(): u64 { PERIOD_4H }
     #[test_only] public fun get_PERIOD_1D(): u64 { PERIOD_1D }
+    #[test_only] public fun get_REGISTRY_NAME(): vector<u8> { REGISTRY_NAME }
+    #[test_only] public fun get_TRIGGER_MARKET_REGISTRATION(): u8 { TRIGGER_MARKET_REGISTRATION }
+    #[test_only] public fun get_TRIGGER_PACKAGE_PUBLICATION(): u8 { TRIGGER_PACKAGE_PUBLICATION }
     #[test_only] public fun get_QUOTE_REAL_CEILING(): u64 { QUOTE_REAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_CEILING(): u64 { QUOTE_VIRTUAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_FLOOR(): u64 { QUOTE_VIRTUAL_FLOOR }
@@ -2300,6 +2303,49 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
             user_emojicoin_balance,
             circulating_supply,
             balance_as_fraction_of_circulating_supply_q64,
+        )
+    }
+
+    #[test_only] public fun unpack_global_state(
+        global_state: GlobalState,
+    ): (
+        u64,
+        u64,
+        u8,
+        AggregatorSnapshot<u128>,
+        AggregatorSnapshot<u128>,
+        AggregatorSnapshot<u128>,
+        AggregatorSnapshot<u128>,
+        AggregatorSnapshot<u128>,
+        AggregatorSnapshot<u128>,
+        AggregatorSnapshot<u64>,
+        AggregatorSnapshot<u64>,
+    ) {
+        let GlobalState {
+            emit_time,
+            registry_nonce,
+            trigger,
+            cumulative_quote_volume,
+            total_quote_locked,
+            total_value_locked,
+            market_cap,
+            fully_diluted_value,
+            cumulative_integrator_fees,
+            cumulative_swaps,
+            cumulative_chat_messages,
+        } = global_state;
+        (
+            emit_time,
+            registry_nonce,
+            trigger,
+            cumulative_quote_volume,
+            total_quote_locked,
+            total_value_locked,
+            market_cap,
+            fully_diluted_value,
+            cumulative_integrator_fees,
+            cumulative_swaps,
+            cumulative_chat_messages,
         )
     }
 

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2005,7 +2005,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
             net_proceeds,
             base_volume,
             quote_volume,
-            // Ideally this would be an inline function, but that strangely breaks the compiler.
+            // Ideally this would be inline, but that strangely breaks the compiler.
             avg_execution_price_q64: ((quote_volume as u128) << SHIFT_Q64) / (base_volume as u128),
             integrator_fee,
             pool_fee,

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -525,7 +525,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         let fdv_ref_mut = &mut registry_ref_mut.global_stats.fully_diluted_value;
         aggregator_v2::try_add(fdv_ref_mut, fdv);
 
-        // Update registry nonce, but not last bump time since state only bumps out once per day.
+        // Update registry nonce, but not last bump time since global state only bumps once per day.
         let registry_nonce_ref_mut = &mut registry_ref_mut.sequence_info.nonce;
         let registry_nonce = *registry_nonce_ref_mut + 1;
         *registry_nonce_ref_mut = registry_nonce;

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2257,6 +2257,18 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
 
     #[test_only] public fun init_module_test_only(account: &signer) { init_module(account) }
 
+    #[test_only] public fun pack_market_metadata(
+        market_id: u64,
+        market_address: address,
+        emoji_bytes: vector<u8>,
+    ): MarketMetadata {
+        MarketMetadata {
+            market_id,
+            market_address,
+            emoji_bytes,
+        }
+    }
+
     #[test_only] public fun pack_reserves(base: u64, quote: u64): Reserves {
         Reserves { base, quote }
     }

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -555,7 +555,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         );
     }
 
-    inline fun instantaneous_stats(market_ref: &Market): InstantaneousStats {
+    /*inline*/ fun instantaneous_stats(market_ref: &Market): InstantaneousStats {
         let lp_coin_supply = market_ref.lp_coin_supply;
         let in_bonding_curve = lp_coin_supply == 0;
         let total_quote_locked = total_quote_locked(market_ref, in_bonding_curve);
@@ -571,7 +571,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         }
     }
 
-    inline fun create_market(
+    /*inline*/ fun create_market(
         registry_ref_mut: &mut Registry,
         emoji_bytes: vector<u8>,
     ): (address, signer) {
@@ -658,7 +658,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         (market_address, market_signer)
     }
 
-    inline fun valid_coin_types<Emojicoin, EmojicoinLP>(market_address: address): bool {
+    /*inline*/ fun valid_coin_types<Emojicoin, EmojicoinLP>(market_address: address): bool {
         let emoji_type = &type_info::type_of<Emojicoin>();
         let lp_type = &type_info::type_of<EmojicoinLP>();
 
@@ -670,7 +670,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         type_info::struct_name(lp_type) == EMOJICOIN_LP_STRUCT_NAME
     }
 
-    inline fun get_verified_symbol_emoji_bytes(
+    /*inline*/ fun get_verified_symbol_emoji_bytes(
         registry_ref: &Registry,
         emojis: vector<vector<u8>>,
     ): vector<u8> {
@@ -689,7 +689,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         verified_bytes
     }
 
-    inline fun mul_div(
+    /*inline*/ fun mul_div(
         a: u64,
         b: u64,
         c: u64,
@@ -697,14 +697,14 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         (a as u128) * (b as u128) / (c as u128)
     }
 
-    inline fun assert_valid_coin_types<Emojicoin, EmojicoinLP>(market_address: address) {
+    /*inline*/ fun assert_valid_coin_types<Emojicoin, EmojicoinLP>(market_address: address) {
         assert!(
             exists<LPCoinCapabilities<Emojicoin, EmojicoinLP>>(market_address),
             E_INVALID_COIN_TYPES
         );
     }
 
-    inline fun fdv_market_cap_start_end(
+    /*inline*/ fun fdv_market_cap_start_end(
         reserves_start: Reserves,
         reserves_end: Reserves,
         supply_minuend: u64,
@@ -719,13 +719,13 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         (fdv_start, market_cap_start, fdv_end, market_cap_end)
     }
 
-    inline fun fdv(
+    /*inline*/ fun fdv(
         reserves: Reserves,
     ): u128 {
         mul_div(reserves.quote, EMOJICOIN_SUPPLY, reserves.base)
     }
 
-    inline fun fdv_market_cap(
+    /*inline*/ fun fdv_market_cap(
         reserves: Reserves,
         supply_minuend: u64,
     ): (
@@ -774,7 +774,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         }
     }
 
-    inline fun ensure_coins_initialized<Emojicoin, EmojicoinLP>(
+    /*inline*/ fun ensure_coins_initialized<Emojicoin, EmojicoinLP>(
         market_ref: &Market,
         market_signer: &signer,
         market_address: address,
@@ -819,7 +819,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         };
     }
 
-    inline fun get_concatenation(base: String, additional: String): String {
+    /*inline*/ fun get_concatenation(base: String, additional: String): String {
         string::append(&mut base, additional);
         base
     }
@@ -1753,7 +1753,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         )
     }
 
-    inline fun burn_lp_coins<Emojicoin, EmojicoinLP>(
+    /*inline*/ fun burn_lp_coins<Emojicoin, EmojicoinLP>(
         market_address: address,
         coin: Coin<EmojicoinLP>,
     ) acquires LPCoinCapabilities {
@@ -1844,7 +1844,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         };
     }
 
-    inline fun bump_market_state(
+    /*inline*/ fun bump_market_state(
         market_ref: &Market,
         trigger: u8,
         instantaneous_stats: InstantaneousStats,
@@ -1866,7 +1866,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         });
     }
 
-    inline fun emit_periodic_state(
+    /*inline*/ fun emit_periodic_state(
         market_metadata_ref: &MarketMetadata,
         nonce: u64,
         time: u64,
@@ -1902,14 +1902,14 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         });
     }
 
-    inline fun last_period_boundary(
+    /*inline*/ fun last_period_boundary(
         time: u64,
         period: u64,
     ): u64 {
         (time / period) * period
     }
 
-    inline fun mint_lp_coins<Emojicoin, EmojicoinLP>(
+    /*inline*/ fun mint_lp_coins<Emojicoin, EmojicoinLP>(
         market_address: address,
         amount: u64,
     ): Coin<EmojicoinLP> acquires LPCoinCapabilities {
@@ -2014,7 +2014,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         }
     }
 
-    inline fun simulate_provide_liquidity_inner(
+    /*inline*/ fun simulate_provide_liquidity_inner(
         provider: address,
         quote_amount: u64,
         market_ref: &Market,
@@ -2049,7 +2049,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         }
     }
 
-    inline fun simulate_remove_liquidity_inner<Emojicoin>(
+    /*inline*/ fun simulate_remove_liquidity_inner<Emojicoin>(
         provider: address,
         lp_coin_amount: u64,
         market_ref: &Market,
@@ -2095,14 +2095,14 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         }
     }
 
-    inline fun get_bps_fee(
+    /*inline*/ fun get_bps_fee(
         principal: u64,
         fee_rate_bps: u8,
     ): u64 {
         ((((principal as u128) * (fee_rate_bps as u128)) / BASIS_POINTS_PER_UNIT) as u64)
     }
 
-    inline fun cpamm_simple_swap_output_amount(
+    /*inline*/ fun cpamm_simple_swap_output_amount(
         input_amount: u64,
         is_sell: bool,
         reserves: Reserves
@@ -2116,7 +2116,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         (result as u64)
     }
 
-    inline fun total_quote_locked(
+    /*inline*/ fun total_quote_locked(
         market_ref: &Market,
         in_bonding_curve: bool,
     ): u64 {
@@ -2127,7 +2127,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         }
     }
 
-    inline fun tvl(
+    /*inline*/ fun tvl(
         market_ref: &Market,
         in_bonding_curve: bool,
     ): u128 {
@@ -2138,7 +2138,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         }
     }
 
-    inline fun tvl_clamm(
+    /*inline*/ fun tvl_clamm(
         virtual_reserves: Reserves,
     ): u128 {
         let quote_virtual = virtual_reserves.quote;
@@ -2155,7 +2155,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         }
     }
 
-    inline fun tvl_cpamm(
+    /*inline*/ fun tvl_cpamm(
         real_quote_reserves: u64,
     ): u128 {
         // Base reserves priced in quote are equal to the value of quote reserves.
@@ -2175,7 +2175,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     ///
     /// While all terms can technically be `u128`, in practice they will all be `u64`, and even if
     /// a few terms require a few extra bits, there should not be any overflow.
-    inline fun tvl_per_lp_coin_growth_q64_inline(
+    /*inline*/ fun tvl_per_lp_coin_growth_q64_inline(
         start: TVLtoLPCoinRatio,
         end: TVLtoLPCoinRatio,
     ): u128 {
@@ -2192,7 +2192,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         }
     }
 
-    inline fun liquidity_provision_operation_epilogue(
+    /*inline*/ fun liquidity_provision_operation_epilogue(
         tvl: u128,
         lp_coin_supply: u128,
         total_quote_locked: u64,

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -38,10 +38,11 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
 
     const TRIGGER_PACKAGE_PUBLICATION: u8 = 0;
     const TRIGGER_MARKET_REGISTRATION: u8 = 1;
-    const TRIGGER_SWAP: u8 = 2;
-    const TRIGGER_PROVIDE_LIQUIDITY: u8 = 3;
-    const TRIGGER_REMOVE_LIQUIDITY: u8 = 4;
-    const TRIGGER_CHAT: u8 = 5;
+    const TRIGGER_SWAP_BUY: u8 = 2;
+    const TRIGGER_SWAP_SELL: u8 = 3;
+    const TRIGGER_PROVIDE_LIQUIDITY: u8 = 4;
+    const TRIGGER_REMOVE_LIQUIDITY: u8 = 5;
+    const TRIGGER_CHAT: u8 = 6;
 
     const PERIOD_1M: u64 = 60_000_000;
     const PERIOD_5M: u64 = 300_000_000;
@@ -852,7 +853,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         let tvl_start = tvl(market_ref_mut, starts_in_bonding_curve);
         let registry_ref_mut = borrow_registry_ref_mut();
         let time = event.time;
-        let trigger = TRIGGER_SWAP;
+        let trigger = if (is_sell) TRIGGER_SWAP_SELL else TRIGGER_SWAP_BUY;
         trigger_periodic_state(market_ref_mut, registry_ref_mut, time, trigger, tvl_start);
 
         // Prepare local variables.

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -408,7 +408,7 @@
         assert!(lp_coin_supply == test_market_view.lp_coin_supply, 0);
         assert!(in_bonding_curve == test_market_view.in_bonding_curve, 0);
         assert_cumulative_stats(test_market_view.cumulative_stats, cumulative_stats);
-        assert_instaneous_stats(test_market_view.instantaneous_stats, instantaneous_stats);
+        assert_instantaneous_stats(test_market_view.instantaneous_stats, instantaneous_stats);
         assert_last_swap(test_market_view.last_swap, last_swap);
         assert!(vector::length(&periodic_state_trackers) ==
             vector::length(&test_market_view.periodic_state_trackers), 0);
@@ -649,20 +649,20 @@
         assert!(n_chat_messages == test_cumulative_stats.n_chat_messages, 0);
     }
 
-    public fun assert_instaneous_stats(
-        test_instaneous_stats: TestInstantaneousStats,
-        instaneous_stats: InstantaneousStats,
+    public fun assert_instantaneous_stats(
+        test_instantaneous_stats: TestInstantaneousStats,
+        instantaneous_stats: InstantaneousStats,
     ) {
         let (
             total_quote_locked,
             total_value_locked,
             market_cap,
             fully_diluted_value,
-        ) = unpack_instantaneous_stats(instaneous_stats);
-        assert!(total_quote_locked == test_instaneous_stats.total_quote_locked, 0);
-        assert!(total_value_locked == test_instaneous_stats.total_value_locked, 0);
-        assert!(market_cap == test_instaneous_stats.market_cap, 0);
-        assert!(fully_diluted_value == test_instaneous_stats.fully_diluted_value, 0);
+        ) = unpack_instantaneous_stats(instantaneous_stats);
+        assert!(total_quote_locked == test_instantaneous_stats.total_quote_locked, 0);
+        assert!(total_value_locked == test_instantaneous_stats.total_value_locked, 0);
+        assert!(market_cap == test_instantaneous_stats.market_cap, 0);
+        assert!(fully_diluted_value == test_instantaneous_stats.fully_diluted_value, 0);
     }
 
     public fun assert_last_swap(
@@ -705,7 +705,7 @@
         assert_reserves(test_state.cpamm_real_reserves, cpamm_real_reserves);
         assert!(lp_coin_supply == test_state.lp_coin_supply, 0);
         assert_cumulative_stats(test_state.cumulative_stats, cumulative_stats);
-        assert_instaneous_stats(test_state.instantaneous_stats, instantaneous_stats);
+        assert_instantaneous_stats(test_state.instantaneous_stats, instantaneous_stats);
         assert_last_swap(test_state.last_swap, last_swap);
     }
 

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -1282,6 +1282,15 @@
         assert!(get_PERIOD_1D() == 24 * 60 * 60 * ms_per_s, 0);
     }
 
+    #[test, expected_failure(
+        abort_code = emojicoin_dot_fun::emojicoin_dot_fun::E_ALREADY_REGISTERED,
+        location = emojicoin_dot_fun
+    )] fun register_market_already_registered() {
+        init_package();
+        register_market(&get_signer(USER), vector[BLACK_CAT], INTEGRATOR);
+        register_market(&get_signer(USER), vector[BLACK_CAT], INTEGRATOR);
+    }
+
     #[test] fun register_market_comprehensive_state_assertion() {
 
         // Initialize module with nonzero time that truncates for some periods.
@@ -1432,6 +1441,15 @@
         assert_state(state_1, *vector::borrow(&state_events, 0));
         assert_state(state_2, *vector::borrow(&state_events, 1));
 
+    }
+
+    #[test, expected_failure(
+        abort_code = emojicoin_dot_fun::emojicoin_dot_fun::E_UNABLE_TO_PAY_MARKET_REGISTRATION_FEE,
+        location = emojicoin_dot_fun
+    )] fun register_market_unable_to_pay_market_registration_fee() {
+        init_package();
+        register_market(&get_signer(USER), vector[BLACK_CAT], INTEGRATOR);
+        register_market_without_publish(&get_signer(USER), vector[BLACK_HEART], INTEGRATOR);
     }
 
     #[test] fun register_market_with_compound_emoji_sequence() {

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -21,11 +21,22 @@
         EmojicoinLP as CoinFactoryEmojicoinLP,
     };
     use emojicoin_dot_fun::emojicoin_dot_fun::{
-        Chat,
         Self,
+        Chat,
+        CumulativeStats,
         GlobalState,
+        InstantaneousStats,
+        LastSwap,
         MarketMetadata,
+        MarketRegistration,
+        MarketView,
+        PeriodicState,
+        PeriodicStateMetadata,
+        PeriodicStateTracker,
         RegistryView,
+        TVLtoLPCoinRatio,
+        Reserves,
+        SequenceInfo,
         assert_valid_coin_types_test_only as assert_valid_coin_types,
         chat,
         cpamm_simple_swap_output_amount_test_only as cpamm_simple_swap_output_amount,
@@ -39,6 +50,7 @@
         get_EMOJICOIN_LP_STRUCT_NAME,
         get_EMOJICOIN_LP_SYMBOL_PREFIX,
         get_EMOJICOIN_NAME_SUFFIX,
+        get_EMOJICOIN_SUPPLY,
         get_MAX_CHAT_MESSAGE_LENGTH,
         get_MAX_SYMBOL_LENGTH,
         get_MARKET_REGISTRATION_FEE,
@@ -57,21 +69,33 @@
         get_TRIGGER_MARKET_REGISTRATION,
         get_TRIGGER_PACKAGE_PUBLICATION,
         get_concatenation_test_only as get_concatenation,
-        verified_symbol_emoji_bytes,
         init_module_test_only as init_module,
         is_a_supported_chat_emoji,
         is_a_supported_symbol_emoji,
+        market_view,
         market_metadata_by_emoji_bytes,
         pack_reserves,
         register_market,
         register_market_without_publish,
         registry_view,
         swap,
-        unpack_market_metadata,
         unpack_chat,
+        unpack_cumulative_stats,
         unpack_global_state,
+        unpack_instantaneous_stats,
+        unpack_last_swap,
+        unpack_market_metadata,
+        unpack_market_registration,
+        unpack_market_view,
+        unpack_periodic_state,
+        unpack_periodic_state_metadata,
+        unpack_periodic_state_tracker,
         unpack_registry_view,
+        unpack_reserves,
+        unpack_sequence_info,
+        unpack_tvl_to_lp_coin_ratio,
         valid_coin_types_test_only as valid_coin_types,
+        verified_symbol_emoji_bytes,
     };
     use emojicoin_dot_fun::hex_codes::{
         get_metadata_bytes_test_only as get_metadata_bytes,
@@ -93,6 +117,16 @@
     use std::type_info;
     use std::vector;
 
+    struct PeriodicStateTrackerStartTimes has copy, drop, store {
+        period_1M: u64,
+        period_5M: u64,
+        period_15M: u64,
+        period_30M: u64,
+        period_1H: u64,
+        period_4H: u64,
+        period_1D: u64,
+    }
+
     struct TestChat has copy, drop, store {
         market_metadata: TestMarketMetadata,
         emit_time: u64,
@@ -102,6 +136,16 @@
         user_emojicoin_balance: u64,
         circulating_supply: u64,
         balance_as_fraction_of_circulating_supply_q64: u128,
+    }
+
+    struct TestCumulativeStats has copy, drop, store {
+        base_volume: u128,
+        quote_volume: u128,
+        integrator_fees: u128,
+        pool_fees_base: u128,
+        pool_fees_quote: u128,
+        n_swaps: u64,
+        n_chat_messages: u64,
     }
 
     struct TestGlobalState has copy, drop, store {
@@ -118,13 +162,100 @@
         cumulative_chat_messages: u64,
     }
 
+    struct TestInstantaneousStats has copy, drop, store {
+        total_quote_locked: u64,
+        total_value_locked: u128,
+        market_cap: u128,
+        fully_diluted_value: u128,
+    }
+
+    struct TestLastSwap has copy, drop, store {
+        is_sell: bool,
+        avg_execution_price_q64: u128,
+        base_volume: u64,
+        quote_volume: u64,
+        nonce: u64,
+        time: u64,
+    }
+
     struct TestMarketMetadata has copy, drop, store {
         market_id: u64,
         market_address: address,
         emoji_bytes: vector<u8>,
     }
 
-    struct TestRegistryView  has copy, drop, store {
+    struct TestMarketRegistration has copy, drop, store {
+        market_metadata: TestMarketMetadata,
+        time: u64,
+        registrant: address,
+        integrator: address,
+        integrator_fee: u64,
+    }
+
+    struct TestMarketView has copy, drop, store {
+        metadata: TestMarketMetadata,
+        sequence_info: TestSequenceInfo,
+        clamm_virtual_reserves: TestReserves,
+        cpamm_real_reserves: TestReserves,
+        lp_coin_supply: u128,
+        in_bonding_curve: bool,
+        cumulative_stats: TestCumulativeStats,
+        instantaneous_stats: TestInstantaneousStats,
+        last_swap: TestLastSwap,
+        periodic_state_trackers: vector<TestPeriodicStateTracker>,
+        aptos_coin_balance: u64,
+        emojicoin_balance: u64,
+        emojicoin_lp_balance: u64,
+    }
+
+    struct TestPeriodicState has copy, drop, store {
+        market_metadata: TestMarketMetadata,
+        periodic_state_metadata: TestPeriodicStateMetadata,
+        open_price_q64: u128,
+        high_price_q64: u128,
+        low_price_q64: u128,
+        close_price_q64: u128,
+        volume_base: u128,
+        volume_quote: u128,
+        integrator_fees: u128,
+        pool_fees_base: u128,
+        pool_fees_quote: u128,
+        n_swaps: u64,
+        n_chat_messages: u64,
+        starts_in_bonding_curve: bool,
+        ends_in_bonding_curve: bool,
+        tvl_per_lp_coin_growth_q64: u128,
+    }
+
+    struct TestPeriodicStateTracker has copy, drop, store {
+        start_time: u64,
+        period: u64,
+        open_price_q64: u128,
+        high_price_q64: u128,
+        low_price_q64: u128,
+        close_price_q64: u128,
+        volume_base: u128,
+        volume_quote: u128,
+        integrator_fees: u128,
+        pool_fees_base: u128,
+        pool_fees_quote: u128,
+        n_swaps: u64,
+        n_chat_messages: u64,
+        starts_in_bonding_curve: bool,
+        ends_in_bonding_curve: bool,
+        tvl_to_lp_coin_ratio_start: TestTVLtoLPCoinRatio,
+        tvl_to_lp_coin_ratio_end: TestTVLtoLPCoinRatio,
+    }
+
+    struct TestPeriodicStateMetadata has copy, drop, store {
+        start_time: u64,
+        period: u64,
+        emit_time: u64,
+        emit_market_nonce: u64,
+        trigger: u8,
+    }
+
+    struct TestRegistryView has copy, drop, store {
         registry_address: address,
         nonce: u64,
         last_bump_time: u64,
@@ -137,6 +268,21 @@
         cumulative_integrator_fees: u128,
         cumulative_swaps: u64,
         cumulative_chat_messages: u64,
+    }
+
+    struct TestTVLtoLPCoinRatio has copy, drop, store {
+        tvl: u128,
+        lp_coins: u128,
+    }
+
+    struct TestReserves has copy, drop, store {
+        base: u64,
+        quote: u64,
+    }
+
+    struct TestSequenceInfo has copy, drop, store {
+        nonce: u64,
+        last_bump_time: u64,
     }
 
     // Test market emoji bytes.
@@ -197,6 +343,47 @@
         assert!(emoji_bytes == test_metadata.emoji_bytes, 0);
     }
 
+    public fun assert_market_view(
+        test_market_view: TestMarketView,
+        market_view: MarketView,
+    ) {
+        let (
+            metadata,
+            sequence_info,
+            clamm_virtual_reserves,
+            cpamm_real_reserves,
+            lp_coin_supply,
+            in_bonding_curve,
+            cumulative_stats,
+            instantaneous_stats,
+            last_swap,
+            periodic_state_trackers,
+            aptos_coin_balance,
+            emojicoin_balance,
+            emojicoin_lp_balance,
+        ) = unpack_market_view(market_view);
+        assert_market_metadata(test_market_view.metadata, metadata);
+        assert_sequence_info(test_market_view.sequence_info, sequence_info);
+        assert_reserves(test_market_view.clamm_virtual_reserves, clamm_virtual_reserves);
+        assert_reserves(test_market_view.cpamm_real_reserves, cpamm_real_reserves);
+        assert!(lp_coin_supply == test_market_view.lp_coin_supply, 0);
+        assert!(in_bonding_curve == test_market_view.in_bonding_curve, 0);
+        assert_cumulative_stats(test_market_view.cumulative_stats, cumulative_stats);
+        assert_instaneous_stats(test_market_view.instantaneous_stats, instantaneous_stats);
+        assert_last_swap(test_market_view.last_swap, last_swap);
+        assert!(vector::length(&periodic_state_trackers) ==
+            vector::length(&test_market_view.periodic_state_trackers), 0);
+        for (i in 0..vector::length(&periodic_state_trackers)) {
+            assert_periodic_state_tracker(
+                *vector::borrow(&test_market_view.periodic_state_trackers, i),
+                *vector::borrow(&periodic_state_trackers, i),
+            );
+        };
+        assert!(aptos_coin_balance == test_market_view.aptos_coin_balance, 0);
+        assert!(emojicoin_balance == test_market_view.emojicoin_balance, 0);
+        assert!(emojicoin_lp_balance == test_market_view.emojicoin_lp_balance, 0);
+    }
+
     public fun assert_registry_view(
         test_registry_view: TestRegistryView,
         registry_view: RegistryView,
@@ -232,6 +419,24 @@
             == test_registry_view.cumulative_chat_messages, 0);
     }
 
+    public fun assert_market_registration(
+        test_market_registration: TestMarketRegistration,
+        market_registration: MarketRegistration,
+    ) {
+        let (
+            market_metadata,
+            time,
+            registrant,
+            integrator,
+            integrator_fee,
+        ) = unpack_market_registration(market_registration);
+        assert_market_metadata(test_market_registration.market_metadata, market_metadata);
+        assert!(time == test_market_registration.time, 0);
+        assert!(registrant == test_market_registration.registrant, 0);
+        assert!(integrator == test_market_registration.integrator, 0);
+        assert!(integrator_fee == test_market_registration.integrator_fee, 0);
+    }
+
     public fun assert_global_state(
         test_global_state: TestGlobalState,
         global_state: GlobalState
@@ -263,6 +468,200 @@
         assert!(read_snapshot(&cumulative_swaps) == test_global_state.cumulative_swaps, 0);
         assert!(read_snapshot(&cumulative_chat_messages)
             == test_global_state.cumulative_chat_messages, 0);
+    }
+
+    public fun assert_periodic_state(
+        test_periodic_state: TestPeriodicState,
+        periodic_state: PeriodicState,
+    ) {
+        let (
+            market_metadata,
+            periodic_state_metadata,
+            open_price_q64,
+            high_price_q64,
+            low_price_q64,
+            close_price_q64,
+            volume_base,
+            volume_quote,
+            integrator_fees,
+            pool_fees_base,
+            pool_fees_quote,
+            n_swaps,
+            n_chat_messages,
+            starts_in_bonding_curve,
+            ends_in_bonding_curve,
+            tvl_per_lp_coin_growth_q64,
+        ) = unpack_periodic_state(periodic_state);
+        assert_market_metadata(test_periodic_state.market_metadata, market_metadata);
+        assert_periodic_state_metadata(
+            test_periodic_state.periodic_state_metadata,
+            periodic_state_metadata,
+        );
+        assert!(open_price_q64 == test_periodic_state.open_price_q64, 0);
+        assert!(high_price_q64 == test_periodic_state.high_price_q64, 0);
+        assert!(low_price_q64 == test_periodic_state.low_price_q64, 0);
+        assert!(close_price_q64 == test_periodic_state.close_price_q64, 0);
+        assert!(volume_base == test_periodic_state.volume_base, 0);
+        assert!(volume_quote == test_periodic_state.volume_quote, 0);
+        assert!(integrator_fees == test_periodic_state.integrator_fees, 0);
+        assert!(pool_fees_base == test_periodic_state.pool_fees_base, 0);
+        assert!(pool_fees_quote == test_periodic_state.pool_fees_quote, 0);
+        assert!(n_swaps == test_periodic_state.n_swaps, 0);
+        assert!(n_chat_messages == test_periodic_state.n_chat_messages, 0);
+        assert!(starts_in_bonding_curve == test_periodic_state.starts_in_bonding_curve, 0);
+        assert!(ends_in_bonding_curve == test_periodic_state.ends_in_bonding_curve, 0);
+        assert!(tvl_per_lp_coin_growth_q64 == test_periodic_state.tvl_per_lp_coin_growth_q64, 0);
+    }
+
+    public fun assert_periodic_state_metadata(
+        test_periodic_state_metadata: TestPeriodicStateMetadata,
+        periodic_state_metadata: PeriodicStateMetadata,
+    ) {
+        let (
+            start_time,
+            period,
+            emit_time,
+            emit_market_nonce,
+            trigger,
+        ) = unpack_periodic_state_metadata(periodic_state_metadata);
+        assert!(start_time == test_periodic_state_metadata.start_time, 0);
+        assert!(period == test_periodic_state_metadata.period, 0);
+        assert!(emit_time == test_periodic_state_metadata.emit_time, 0);
+        assert!(emit_market_nonce == test_periodic_state_metadata.emit_market_nonce, 0);
+        assert!(trigger == test_periodic_state_metadata.trigger, 0);
+    }
+
+    public fun assert_periodic_state_tracker(
+        test_periodic_state_tracker: TestPeriodicStateTracker,
+        periodic_state_tracker: PeriodicStateTracker,
+    ) {
+        let (
+            start_time,
+            period,
+            open_price_q64,
+            high_price_q64,
+            low_price_q64,
+            close_price_q64,
+            volume_base,
+            volume_quote,
+            integrator_fees,
+            pool_fees_base,
+            pool_fees_quote,
+            n_swaps,
+            n_chat_messages,
+            starts_in_bonding_curve,
+            ends_in_bonding_curve,
+            tvl_to_lp_coin_ratio_start,
+            tvl_to_lp_coin_ratio_end,
+        ) = unpack_periodic_state_tracker(periodic_state_tracker);
+        assert!(start_time == test_periodic_state_tracker.start_time, 0);
+        assert!(period == test_periodic_state_tracker.period, 0);
+        assert!(open_price_q64 == test_periodic_state_tracker.open_price_q64, 0);
+        assert!(high_price_q64 == test_periodic_state_tracker.high_price_q64, 0);
+        assert!(low_price_q64 == test_periodic_state_tracker.low_price_q64, 0);
+        assert!(close_price_q64 == test_periodic_state_tracker.close_price_q64, 0);
+        assert!(volume_base == test_periodic_state_tracker.volume_base, 0);
+        assert!(volume_quote == test_periodic_state_tracker.volume_quote, 0);
+        assert!(integrator_fees == test_periodic_state_tracker.integrator_fees, 0);
+        assert!(pool_fees_base == test_periodic_state_tracker.pool_fees_base, 0);
+        assert!(pool_fees_quote == test_periodic_state_tracker.pool_fees_quote, 0);
+        assert!(n_swaps == test_periodic_state_tracker.n_swaps, 0);
+        assert!(n_chat_messages == test_periodic_state_tracker.n_chat_messages, 0);
+        assert!(starts_in_bonding_curve == test_periodic_state_tracker.starts_in_bonding_curve, 0);
+        assert!(ends_in_bonding_curve == test_periodic_state_tracker.ends_in_bonding_curve, 0);
+        assert_tvl_to_lp_coin_ratio(
+            test_periodic_state_tracker.tvl_to_lp_coin_ratio_start,
+            tvl_to_lp_coin_ratio_start,
+        );
+        assert_tvl_to_lp_coin_ratio(
+            test_periodic_state_tracker.tvl_to_lp_coin_ratio_end,
+            tvl_to_lp_coin_ratio_end,
+        );
+    }
+
+    public fun assert_reserves(
+        test_reserves: TestReserves,
+        reserves: Reserves,
+    ) {
+        let (base, quote) = unpack_reserves(reserves);
+        assert!(base == test_reserves.base, 0);
+        assert!(quote == test_reserves.quote, 0);
+    }
+
+    public fun assert_sequence_info(
+        test_sequence_info: TestSequenceInfo,
+        sequence_info: SequenceInfo,
+    ) {
+        let (nonce, last_bump_time) = unpack_sequence_info(sequence_info);
+        assert!(nonce == test_sequence_info.nonce, 0);
+        assert!(last_bump_time == test_sequence_info.last_bump_time, 0);
+    }
+
+    public fun assert_tvl_to_lp_coin_ratio(
+        test_tvl_to_lp_coin_ratio: TestTVLtoLPCoinRatio,
+        tvl_to_lp_coin_ratio: TVLtoLPCoinRatio,
+    ) {
+        let (tvl, lp_coins) = unpack_tvl_to_lp_coin_ratio(tvl_to_lp_coin_ratio);
+        assert!(tvl == test_tvl_to_lp_coin_ratio.tvl, 0);
+        assert!(lp_coins == test_tvl_to_lp_coin_ratio.lp_coins, 0);
+    }
+
+    public fun assert_cumulative_stats(
+        test_cumulative_stats: TestCumulativeStats,
+        cumulative_stats: CumulativeStats,
+    ) {
+        let (
+            base_volume,
+            quote_volume,
+            integrator_fees,
+            pool_fees_base,
+            pool_fees_quote,
+            n_swaps,
+            n_chat_messages,
+        ) = unpack_cumulative_stats(cumulative_stats);
+        assert!(base_volume == test_cumulative_stats.base_volume, 0);
+        assert!(quote_volume == test_cumulative_stats.quote_volume, 0);
+        assert!(integrator_fees == test_cumulative_stats.integrator_fees, 0);
+        assert!(pool_fees_base == test_cumulative_stats.pool_fees_base, 0);
+        assert!(pool_fees_quote == test_cumulative_stats.pool_fees_quote, 0);
+        assert!(n_swaps == test_cumulative_stats.n_swaps, 0);
+        assert!(n_chat_messages == test_cumulative_stats.n_chat_messages, 0);
+    }
+
+    public fun assert_instaneous_stats(
+        test_instaneous_stats: TestInstantaneousStats,
+        instaneous_stats: InstantaneousStats,
+    ) {
+        let (
+            total_quote_locked,
+            total_value_locked,
+            market_cap,
+            fully_diluted_value,
+        ) = unpack_instantaneous_stats(instaneous_stats);
+        assert!(total_quote_locked == test_instaneous_stats.total_quote_locked, 0);
+        assert!(total_value_locked == test_instaneous_stats.total_value_locked, 0);
+        assert!(market_cap == test_instaneous_stats.market_cap, 0);
+        assert!(fully_diluted_value == test_instaneous_stats.fully_diluted_value, 0);
+    }
+
+    public fun assert_last_swap(
+        test_last_swap: TestLastSwap,
+        last_swap: LastSwap,
+    ) {
+        let (
+            is_sell,
+            avg_execution_price_q64,
+            base_volume,
+            quote_volume,
+            nonce,
+            time,
+        ) = unpack_last_swap(last_swap);
+        assert!(is_sell == test_last_swap.is_sell, 0);
+        assert!(avg_execution_price_q64 == test_last_swap.avg_execution_price_q64, 0);
+        assert!(base_volume == test_last_swap.base_volume, 0);
+        assert!(quote_volume == test_last_swap.quote_volume, 0);
+        assert!(nonce == test_last_swap.nonce, 0);
+        assert!(time == test_last_swap.time, 0);
     }
 
     public fun assert_test_market_address(
@@ -304,8 +703,109 @@
         assert!(coin::name<EmojicoinLP>() == lp_name, 0);
     }
 
+    public fun apply_periodic_state_tracker_start_times(
+        periodic_state_trackers_ref_mut: &mut vector<TestPeriodicStateTracker>,
+        start_times: PeriodicStateTrackerStartTimes,
+    ) {
+        vector::borrow_mut(periodic_state_trackers_ref_mut, 0).start_time = start_times.period_1M;
+        vector::borrow_mut(periodic_state_trackers_ref_mut, 1).start_time = start_times.period_5M;
+        vector::borrow_mut(periodic_state_trackers_ref_mut, 2).start_time = start_times.period_15M;
+        vector::borrow_mut(periodic_state_trackers_ref_mut, 3).start_time = start_times.period_30M;
+        vector::borrow_mut(periodic_state_trackers_ref_mut, 4).start_time = start_times.period_1H;
+        vector::borrow_mut(periodic_state_trackers_ref_mut, 5).start_time = start_times.period_4H;
+        vector::borrow_mut(periodic_state_trackers_ref_mut, 6).start_time = start_times.period_1D;
+    }
+
+    public fun base_market_view(): TestMarketView {
+        TestMarketView {
+            metadata: TestMarketMetadata {
+                market_id: 1,
+                market_address: @0x0,
+                emoji_bytes: vector[],
+            },
+            sequence_info: TestSequenceInfo {
+                nonce: 1,
+                last_bump_time: 0,
+            },
+            clamm_virtual_reserves: TestReserves {
+                base: get_BASE_VIRTUAL_CEILING(),
+                quote: get_QUOTE_VIRTUAL_FLOOR(),
+            },
+            cpamm_real_reserves: TestReserves {
+                base: 0,
+                quote: 0,
+            },
+            lp_coin_supply: 0,
+            in_bonding_curve: true,
+            cumulative_stats: TestCumulativeStats {
+                base_volume: 0,
+                quote_volume: 0,
+                integrator_fees: 0,
+                pool_fees_base: 0,
+                pool_fees_quote: 0,
+                n_swaps: 0,
+                n_chat_messages: 0,
+            },
+            instantaneous_stats: TestInstantaneousStats {
+                total_quote_locked: 0,
+                total_value_locked: 0,
+                market_cap: 0,
+                fully_diluted_value: fdv_for_newly_registered_market(),
+            },
+            last_swap: TestLastSwap {
+                is_sell: false,
+                avg_execution_price_q64: 0,
+                base_volume: 0,
+                quote_volume: 0,
+                nonce: 0,
+                time: 0,
+            },
+            periodic_state_trackers:
+                vectorize_periodic_state_tracker_base(base_periodic_state_tracker()),
+            aptos_coin_balance: 0,
+            emojicoin_balance: get_EMOJICOIN_SUPPLY(),
+            emojicoin_lp_balance: 0,
+        }
+    }
+
+    public fun base_periodic_state_tracker(): TestPeriodicStateTracker {
+        TestPeriodicStateTracker {
+            start_time: 0,
+            period: 0,
+            open_price_q64: 0,
+            high_price_q64: 0,
+            low_price_q64: 0,
+            close_price_q64: 0,
+            volume_base: 0,
+            volume_quote: 0,
+            integrator_fees: 0,
+            pool_fees_base: 0,
+            pool_fees_quote: 0,
+            n_swaps: 0,
+            n_chat_messages: 0,
+            starts_in_bonding_curve: true,
+            ends_in_bonding_curve: true,
+            tvl_to_lp_coin_ratio_start: TestTVLtoLPCoinRatio {
+                tvl: 0,
+                lp_coins: 0,
+            },
+            tvl_to_lp_coin_ratio_end: TestTVLtoLPCoinRatio {
+                tvl: 0,
+                lp_coins: 0,
+            },
+        }
+    }
+
+    public fun fdv_for_newly_registered_market(): u128 {
+        (
+            (
+                (get_QUOTE_VIRTUAL_FLOOR() as u256) * (get_EMOJICOIN_SUPPLY() as u256) /
+                (get_BASE_VIRTUAL_CEILING() as u256)
+            ) as u128
+        )
+    }
+
     public fun init_package() {
-        aptos_account::create_account(@emojicoin_dot_fun);
         timestamp::set_time_has_started_for_testing(&get_signer(@aptos_framework));
         init_module(&get_signer(@emojicoin_dot_fun));
     }
@@ -348,6 +848,24 @@
          option::destroy_some(
             market_metadata_by_emoji_bytes(verified_symbol_emoji_bytes(emoji_bytes))
         )
+    }
+
+    public fun vectorize_periodic_state_tracker_base(
+        base: TestPeriodicStateTracker
+    ): vector<TestPeriodicStateTracker> {
+        vector::map(vector[
+            get_PERIOD_1M(),
+            get_PERIOD_5M(),
+            get_PERIOD_15M(),
+            get_PERIOD_30M(),
+            get_PERIOD_1H(),
+            get_PERIOD_4H(),
+            get_PERIOD_1D(),
+        ], |period| {
+            let periodic_state_tracker = copy base;
+            periodic_state_tracker.period = period;
+            periodic_state_tracker
+        })
     }
 
     #[test] fun all_supported_emojis_under_10_bytes() {
@@ -633,11 +1151,82 @@
         assert!(get_PERIOD_1D() == 24 * 60 * 60 * ms_per_s, 0);
     }
 
+    #[test] fun register_market_complex_state_assertion() {
+        init_package();
+
+        // Register simple market, assert market state.
+        let time = get_PERIOD_1H();
+        timestamp::update_global_time_for_test(time);
+        register_market(&get_signer(USER), vector[BLACK_CAT], INTEGRATOR);
+        let market_view = base_market_view();
+        market_view.metadata.market_address = @black_cat_market;
+        market_view.metadata.emoji_bytes = BLACK_CAT;
+        market_view.sequence_info.last_bump_time = time;
+        apply_periodic_state_tracker_start_times(
+            &mut market_view.periodic_state_trackers,
+            PeriodicStateTrackerStartTimes {
+                period_1D: 0,
+                period_4H: 0,
+                period_1H: get_PERIOD_1H(),
+                period_30M: get_PERIOD_1H(),
+                period_15M: get_PERIOD_1H(),
+                period_5M: get_PERIOD_1H(),
+                period_1M: get_PERIOD_1H(),
+            }
+        );
+        assert_market_view(
+            market_view,
+            market_view<BlackCatEmojicoin, BlackCatEmojicoinLP>(@black_cat_market),
+        );
+
+        // Set next market registration time such that all periodic state trackers will truncate
+        // to last period boundary.
+        time = get_PERIOD_1D() + get_PERIOD_4H() + get_PERIOD_1H() + get_PERIOD_30M() +
+            get_PERIOD_15M() + get_PERIOD_5M() + get_PERIOD_1M() + 1;
+        let periodic_state_tracker_start_times = PeriodicStateTrackerStartTimes {
+            period_1D: get_PERIOD_1D(),
+            period_4H: get_PERIOD_1D() + get_PERIOD_4H(),
+            period_1H: get_PERIOD_1D() + get_PERIOD_4H() + get_PERIOD_1H(),
+            period_30M: get_PERIOD_1D() + get_PERIOD_4H() + get_PERIOD_1H() + get_PERIOD_30M(),
+            period_15M: get_PERIOD_1D() + get_PERIOD_4H() + get_PERIOD_1H() + get_PERIOD_30M() +
+                get_PERIOD_15M(),
+            period_5M: get_PERIOD_1D() + get_PERIOD_4H() + get_PERIOD_1H() + get_PERIOD_30M() +
+                get_PERIOD_15M() + get_PERIOD_5M(),
+            period_1M: get_PERIOD_1D() + get_PERIOD_4H() + get_PERIOD_1H() + get_PERIOD_30M() +
+                get_PERIOD_15M() + get_PERIOD_5M() + get_PERIOD_1M(),
+        };
+        timestamp::update_global_time_for_test(time);
+
+        // Register new market, assert state.
+        mint_aptos_coin_to(USER, get_MARKET_REGISTRATION_FEE());
+        register_market_without_publish(&get_signer(USER), vector[BLACK_HEART], INTEGRATOR);
+        market_view.metadata = TestMarketMetadata {
+            market_id: 2,
+            market_address: @black_heart_market,
+            emoji_bytes: BLACK_HEART,
+        };
+        market_view.sequence_info.last_bump_time = time;
+        market_view.cumulative_stats.integrator_fees = (get_MARKET_REGISTRATION_FEE() as u128);
+        apply_periodic_state_tracker_start_times(
+            &mut market_view.periodic_state_trackers,
+            periodic_state_tracker_start_times,
+        );
+        vector::for_each_mut(&mut market_view.periodic_state_trackers, |e| {
+            let periodic_state_tracker_ref_mut: &mut TestPeriodicStateTracker = e;
+            periodic_state_tracker_ref_mut.integrator_fees =
+                (get_MARKET_REGISTRATION_FEE() as u128);
+        });
+        assert_market_view(
+            market_view,
+            market_view<BlackHeartEmojicoin, BlackHeartEmojicoinLP>(@black_heart_market),
+        );
+    }
+
     #[test] fun register_market_with_compound_emoji_sequence() {
         init_package();
         let emojis = vector[
-            x"e29aa1",           // High voltage.
-            x"f09f96a5efb88f",   // Desktop computer.
+            x"e29aa1",         // High voltage.
+            x"f09f96a5efb88f", // Desktop computer.
         ];
         let concatenated_bytes = verified_symbol_emoji_bytes(emojis);
 

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -1421,11 +1421,12 @@
 
         // Assert state events.
         let state_1 = base_state();
-        let state_1.market_metadata = market_metadata_1;
-        let state_1.state_metadata.bump_time = market_1_registration_time;
+        state_1.market_metadata = market_metadata_1;
+        state_1.state_metadata.bump_time = market_1_registration_time;
         let state_2 = base_state();
-        let state_2.market_metadata = market_metadata_2;
-        let state_2.state_metadata.bump_time = market_2_registration_time;
+        state_2.market_metadata = market_metadata_2;
+        state_2.state_metadata.bump_time = market_2_registration_time;
+        state_2.cumulative_stats.integrator_fees = (get_MARKET_REGISTRATION_FEE() as u128);
         let state_events = emitted_events<State>();
         assert!(vector::length(&market_registration_events) == 2, 0);
         assert_state(state_1, *vector::borrow(&state_events, 0));

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -55,7 +55,6 @@
         is_a_supported_chat_emoji,
         is_a_supported_symbol_emoji,
         market_metadata_by_emoji_bytes,
-        pack_market_metadata,
         pack_reserves,
         register_market,
         register_market_without_publish,
@@ -85,7 +84,7 @@
     use std::vector;
 
     struct TestChat has copy, drop, store {
-        market_metadata: MarketMetadata,
+        market_metadata: TestMarketMetadata,
         emit_time: u64,
         emit_market_nonce: u64,
         user: address,
@@ -135,7 +134,7 @@
             circulating_supply,
             balance_as_fraction_of_circulating_supply_q64,
         ) = unpack_chat(chat);
-        assert!(market_metadata == test_chat.market_metadata, 0);
+        assert_market_metadata(test_chat.market_metadata, market_metadata);
         assert!(emit_time == test_chat.emit_time, 0);
         assert!(emit_market_nonce == test_chat.emit_market_nonce, 0);
         assert!(user == test_chat.user, 0);
@@ -196,16 +195,6 @@
         let lp_name = get_concatenation(symbol, utf8(get_EMOJICOIN_LP_NAME_SUFFIX()));
         assert!(coin::symbol<EmojicoinLP>() == lp_symbol, 0);
         assert!(coin::name<EmojicoinLP>() == lp_name, 0);
-    }
-
-    public fun get_market_metadata(
-        test_metadata: TestMarketMetadata,
-    ): MarketMetadata {
-        pack_market_metadata(
-            test_metadata.market_id,
-            test_metadata.market_address,
-            test_metadata.emoji_bytes,
-        )
     }
 
     public fun init_package() {
@@ -321,11 +310,11 @@
 
         // Assert the emitted chat events.
         let events_emitted = event::emitted_events<Chat>();
-        let market_metadata = get_market_metadata(TestMarketMetadata {
+        let market_metadata = TestMarketMetadata {
             market_id: 1,
             market_address: @black_cat_market,
             emoji_bytes: BLACK_CAT,
-        });
+        };
         assert_chat(
             TestChat {
                 market_metadata,


### PR DESCRIPTION
# Description

## Production code

1. Since the [coverage tool is broken for inline functions][coverage tool], take
   out all inline annotations except where:
    1. The function returns a borrowed reference.
    1. The function would require an `acquires` statement if not inline.
1. Add swap/buy trigger differentiation on swaps.
1. Track market-wise Aptos Coin balance in a `MarketView`.
1. Update initial market stats/state triggers.
1. Update tracking for market registration fees.
1. Add inline FDV helper function.
1. Fix start time/period return mismatch in periodic state tracker decoder.

## Test code

1. Add assorted decoders for test-only state to main module.
1. Add struct mocking with base values, and struct-wise assertion.
1. Add tests to assert all state (global storage, emitted events) modifications
   during package publication and market registration.
1. Ensure 100%

## Miscellaneous

1. Clarify nonce vs bump time in architecture specification.

# Testing

From in `src/move/emojicoin_dot_fun`

```sh
git ls-files | entr -c aptos move test --coverage --dev
```

Compare coverage against bytecode:

```sh
aptos move coverage bytecode --module emojicoin_dot_fun --dev
```

[coverage tool]: https://github.com/aptos-labs/aptos-core/issues/9154

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] ~Did you update the changelog?~
- [x] Did you check off all checkboxes from the linked Linear task?