### PR TITLE
[ECO-1640] Add swap test setup harnessing for simple buy/exact transition cases

### DIFF
--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -48,6 +48,7 @@ rica
 rustup
 sint
 struct
+structs
 subdir
 supervillain
 tanabata

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -530,11 +530,6 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         let fdv_ref_mut = &mut registry_ref_mut.global_stats.fully_diluted_value;
         aggregator_v2::try_add(fdv_ref_mut, fdv);
 
-        // Update registry nonce, but not last bump time since global state only bumps once per day.
-        let registry_nonce_ref_mut = &mut registry_ref_mut.sequence_info.nonce;
-        let registry_nonce = *registry_nonce_ref_mut + 1;
-        *registry_nonce_ref_mut = registry_nonce;
-
         // Bump state.
         event::emit(MarketRegistration {
             market_metadata: market_ref_mut.metadata,
@@ -1868,13 +1863,16 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
             };
         });
 
-        // Check global state tracker period lapse.
+        // Increment registry nonce.
         let registry_sequence_info_ref_mut = &mut registry_ref_mut.sequence_info;
+        let registry_nonce_ref_mut = &mut registry_sequence_info_ref_mut.nonce;
+        let registry_nonce = *registry_nonce_ref_mut + 1;
+        *registry_nonce_ref_mut = registry_nonce;
+
+        // Check global state tracker period lapse.
         let last_registry_bump_time = registry_sequence_info_ref_mut.last_bump_time;
         if (time - last_registry_bump_time >= PERIOD_1D) {
             registry_sequence_info_ref_mut.last_bump_time = time;
-            let registry_nonce = registry_sequence_info_ref_mut.nonce + 1;
-            registry_sequence_info_ref_mut.nonce = registry_nonce;
             let global_stats_ref = &registry_ref_mut.global_stats;
             event::emit(GlobalState {
                 emit_time: time,

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2328,7 +2328,9 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         EMOJICOIN_LP_NAME_SUFFIX
     }
     #[test_only] public fun get_EMOJICOIN_NAME_SUFFIX(): vector<u8> { EMOJICOIN_NAME_SUFFIX }
+    #[test_only] public fun get_EMOJICOIN_REMAINDER(): u64 { EMOJICOIN_REMAINDER }
     #[test_only] public fun get_EMOJICOIN_SUPPLY(): u64 { EMOJICOIN_SUPPLY }
+    #[test_only] public fun get_LP_TOKENS_INITIAL(): u64 { LP_TOKENS_INITIAL }
     #[test_only] public fun get_MAX_CHAT_MESSAGE_LENGTH(): u64 { MAX_CHAT_MESSAGE_LENGTH }
     #[test_only] public fun get_MAX_SYMBOL_LENGTH(): u8 { MAX_SYMBOL_LENGTH }
     #[test_only] public fun get_MARKET_REGISTRATION_FEE(): u64 { MARKET_REGISTRATION_FEE }

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -890,7 +890,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         let pool_fees_quote_as_u128 = 0;
         let (quote, fdv_start, market_cap_start, fdv_end, market_cap_end);
         let results_in_state_transition = event.results_in_state_transition;
-        let ends_in_bonding_curve = !starts_in_bonding_curve || results_in_state_transition;
+        let ends_in_bonding_curve = starts_in_bonding_curve && !results_in_state_transition;
 
         // Create for swapper an account with AptosCoin store if it doesn't exist.
         if (!account::exists_at(swapper_address)) {

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2343,6 +2343,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     #[test_only] public fun get_REGISTRY_NAME(): vector<u8> { REGISTRY_NAME }
     #[test_only] public fun get_TRIGGER_MARKET_REGISTRATION(): u8 { TRIGGER_MARKET_REGISTRATION }
     #[test_only] public fun get_TRIGGER_PACKAGE_PUBLICATION(): u8 { TRIGGER_PACKAGE_PUBLICATION }
+    #[test_only] public fun get_TRIGGER_SWAP_BUY(): u8 { TRIGGER_SWAP_BUY }
     #[test_only] public fun get_QUOTE_REAL_CEILING(): u64 { QUOTE_REAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_CEILING(): u64 { QUOTE_VIRTUAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_FLOOR(): u64 { QUOTE_VIRTUAL_FLOOR }

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -1729,6 +1729,62 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         (base, quote)
     }
 
+    public fun unpack_swap(swap: Swap): (
+        u64,
+        u64,
+        u64,
+        address,
+        u64,
+        bool,
+        address,
+        u8,
+        u64,
+        u64,
+        u64,
+        u128,
+        u64,
+        u64,
+        bool,
+        bool,
+    ) {
+        let Swap {
+            market_id,
+            time,
+            market_nonce,
+            swapper,
+            input_amount,
+            is_sell,
+            integrator,
+            integrator_fee_rate_bps,
+            net_proceeds,
+            base_volume,
+            quote_volume,
+            avg_execution_price_q64,
+            integrator_fee,
+            pool_fee,
+            starts_in_bonding_curve,
+            results_in_state_transition,
+        } = swap;
+        (
+            market_id,
+            time,
+            market_nonce,
+            swapper,
+            input_amount,
+            is_sell,
+            integrator,
+            integrator_fee_rate_bps,
+            net_proceeds,
+            base_volume,
+            quote_volume,
+            avg_execution_price_q64,
+            integrator_fee,
+            pool_fee,
+            starts_in_bonding_curve,
+            results_in_state_transition,
+        )
+    }
+
     public fun unpack_sequence_info(sequence_info: SequenceInfo): (u64, u64) {
         let SequenceInfo { nonce, last_bump_time } = sequence_info;
         (nonce, last_bump_time)
@@ -2245,6 +2301,13 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         exists<LPCoinCapabilities<Emojicoin, EmojicoinLP>>(market_address)
     }
 
+    #[test_only] public fun get_bps_fee_test_only(
+        principal: u64,
+        fee_rate_bps: u8,
+    ): u64 {
+        get_bps_fee(principal, fee_rate_bps)
+    }
+
     #[test_only] public fun get_concatenation_test_only(
         base: String,
         additional: String,
@@ -2255,6 +2318,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     #[test_only] public fun get_BASE_REAL_CEILING(): u64 { BASE_REAL_CEILING }
     #[test_only] public fun get_BASE_VIRTUAL_CEILING(): u64 { BASE_VIRTUAL_CEILING }
     #[test_only] public fun get_BASE_VIRTUAL_FLOOR(): u64 { BASE_VIRTUAL_FLOOR }
+    #[test_only] public fun get_BASIS_POINTS_PER_UNIT(): u128 { BASIS_POINTS_PER_UNIT }
     #[test_only] public fun get_COIN_FACTORY_AS_BYTES(): vector<u8> { COIN_FACTORY_AS_BYTES }
     #[test_only] public fun get_EMOJICOIN_STRUCT_NAME(): vector<u8> { EMOJICOIN_STRUCT_NAME }
     #[test_only] public fun get_EMOJICOIN_LP_NAME_SUFFIX(): vector<u8> { EMOJICOIN_LP_NAME_SUFFIX }

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -994,7 +994,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
                 let reserves_end = reserves_start;
                 reserves_end.base = reserves_end.base - event.base_volume;
                 reserves_end.quote = reserves_end.quote + event.quote_volume;
-                let reserves_end = *reserves_ref_mut;
+                *reserves_ref_mut = reserves_end;
 
                 // Get FDV, market cap at start and end.
                 (fdv_start, market_cap_start, fdv_end, market_cap_end) =

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -131,8 +131,8 @@
         period_1D: u64,
     }
 
-    struct TestChat has copy, drop, store {
-        market_metadata: TestMarketMetadata,
+    struct MockChat has copy, drop, store {
+        market_metadata: MockMarketMetadata,
         emit_time: u64,
         emit_market_nonce: u64,
         user: address,
@@ -142,7 +142,7 @@
         balance_as_fraction_of_circulating_supply_q64: u128,
     }
 
-    struct TestCumulativeStats has copy, drop, store {
+    struct MockCumulativeStats has copy, drop, store {
         base_volume: u128,
         quote_volume: u128,
         integrator_fees: u128,
@@ -152,7 +152,7 @@
         n_chat_messages: u64,
     }
 
-    struct TestGlobalState has copy, drop, store {
+    struct MockGlobalState has copy, drop, store {
         emit_time: u64,
         registry_nonce: u64,
         trigger: u8,
@@ -166,14 +166,14 @@
         cumulative_chat_messages: u64,
     }
 
-    struct TestInstantaneousStats has copy, drop, store {
+    struct MockInstantaneousStats has copy, drop, store {
         total_quote_locked: u64,
         total_value_locked: u128,
         market_cap: u128,
         fully_diluted_value: u128,
     }
 
-    struct TestLastSwap has copy, drop, store {
+    struct MockLastSwap has copy, drop, store {
         is_sell: bool,
         avg_execution_price_q64: u128,
         base_volume: u64,
@@ -182,39 +182,39 @@
         time: u64,
     }
 
-    struct TestMarketMetadata has copy, drop, store {
+    struct MockMarketMetadata has copy, drop, store {
         market_id: u64,
         market_address: address,
         emoji_bytes: vector<u8>,
     }
 
-    struct TestMarketRegistration has copy, drop, store {
-        market_metadata: TestMarketMetadata,
+    struct MockMarketRegistration has copy, drop, store {
+        market_metadata: MockMarketMetadata,
         time: u64,
         registrant: address,
         integrator: address,
         integrator_fee: u64,
     }
 
-    struct TestMarketView has copy, drop, store {
-        metadata: TestMarketMetadata,
-        sequence_info: TestSequenceInfo,
-        clamm_virtual_reserves: TestReserves,
-        cpamm_real_reserves: TestReserves,
+    struct MockMarketView has copy, drop, store {
+        metadata: MockMarketMetadata,
+        sequence_info: MockSequenceInfo,
+        clamm_virtual_reserves: MockReserves,
+        cpamm_real_reserves: MockReserves,
         lp_coin_supply: u128,
         in_bonding_curve: bool,
-        cumulative_stats: TestCumulativeStats,
-        instantaneous_stats: TestInstantaneousStats,
-        last_swap: TestLastSwap,
-        periodic_state_trackers: vector<TestPeriodicStateTracker>,
+        cumulative_stats: MockCumulativeStats,
+        instantaneous_stats: MockInstantaneousStats,
+        last_swap: MockLastSwap,
+        periodic_state_trackers: vector<MockPeriodicStateTracker>,
         aptos_coin_balance: u64,
         emojicoin_balance: u64,
         emojicoin_lp_balance: u64,
     }
 
-    struct TestPeriodicState has copy, drop, store {
-        market_metadata: TestMarketMetadata,
-        periodic_state_metadata: TestPeriodicStateMetadata,
+    struct MockPeriodicState has copy, drop, store {
+        market_metadata: MockMarketMetadata,
+        periodic_state_metadata: MockPeriodicStateMetadata,
         open_price_q64: u128,
         high_price_q64: u128,
         low_price_q64: u128,
@@ -231,7 +231,7 @@
         tvl_per_lp_coin_growth_q64: u128,
     }
 
-    struct TestPeriodicStateTracker has copy, drop, store {
+    struct MockPeriodicStateTracker has copy, drop, store {
         start_time: u64,
         period: u64,
         open_price_q64: u128,
@@ -247,11 +247,11 @@
         n_chat_messages: u64,
         starts_in_bonding_curve: bool,
         ends_in_bonding_curve: bool,
-        tvl_to_lp_coin_ratio_start: TestTVLtoLPCoinRatio,
-        tvl_to_lp_coin_ratio_end: TestTVLtoLPCoinRatio,
+        tvl_to_lp_coin_ratio_start: MockTVLtoLPCoinRatio,
+        tvl_to_lp_coin_ratio_end: MockTVLtoLPCoinRatio,
     }
 
-    struct TestPeriodicStateMetadata has copy, drop, store {
+    struct MockPeriodicStateMetadata has copy, drop, store {
         start_time: u64,
         period: u64,
         emit_time: u64,
@@ -259,7 +259,7 @@
         trigger: u8,
     }
 
-    struct TestRegistryView has copy, drop, store {
+    struct MockRegistryView has copy, drop, store {
         registry_address: address,
         nonce: u64,
         last_bump_time: u64,
@@ -274,33 +274,33 @@
         cumulative_chat_messages: u64,
     }
 
-    struct TestTVLtoLPCoinRatio has copy, drop, store {
+    struct MockTVLtoLPCoinRatio has copy, drop, store {
         tvl: u128,
         lp_coins: u128,
     }
 
-    struct TestReserves has copy, drop, store {
+    struct MockReserves has copy, drop, store {
         base: u64,
         quote: u64,
     }
 
-    struct TestSequenceInfo has copy, drop, store {
+    struct MockSequenceInfo has copy, drop, store {
         nonce: u64,
         last_bump_time: u64,
     }
 
-    struct TestState has copy, drop, store {
-        market_metadata: TestMarketMetadata,
-        state_metadata: TestStateMetadata,
-        clamm_virtual_reserves: TestReserves,
-        cpamm_real_reserves: TestReserves,
+    struct MockState has copy, drop, store {
+        market_metadata: MockMarketMetadata,
+        state_metadata: MockStateMetadata,
+        clamm_virtual_reserves: MockReserves,
+        cpamm_real_reserves: MockReserves,
         lp_coin_supply: u128,
-        cumulative_stats: TestCumulativeStats,
-        instantaneous_stats: TestInstantaneousStats,
-        last_swap: TestLastSwap,
+        cumulative_stats: MockCumulativeStats,
+        instantaneous_stats: MockInstantaneousStats,
+        last_swap: MockLastSwap,
     }
 
-    struct TestStateMetadata has copy, drop, store {
+    struct MockStateMetadata has copy, drop, store {
         market_nonce: u64,
         bump_time: u64,
         trigger: u8,
@@ -331,7 +331,7 @@
     }
 
     public fun assert_chat(
-        test_chat: TestChat,
+        mock_chat: MockChat,
         chat: Chat,
     ) {
         let (
@@ -344,32 +344,32 @@
             circulating_supply,
             balance_as_fraction_of_circulating_supply_q64,
         ) = unpack_chat(chat);
-        assert_market_metadata(test_chat.market_metadata, market_metadata);
-        assert!(emit_time == test_chat.emit_time, 0);
-        assert!(emit_market_nonce == test_chat.emit_market_nonce, 0);
-        assert!(user == test_chat.user, 0);
-        assert!(message == test_chat.message, 0);
-        assert!(user_emojicoin_balance == test_chat.user_emojicoin_balance, 0);
-        assert!(circulating_supply == test_chat.circulating_supply, 0);
+        assert_market_metadata(mock_chat.market_metadata, market_metadata);
+        assert!(emit_time == mock_chat.emit_time, 0);
+        assert!(emit_market_nonce == mock_chat.emit_market_nonce, 0);
+        assert!(user == mock_chat.user, 0);
+        assert!(message == mock_chat.message, 0);
+        assert!(user_emojicoin_balance == mock_chat.user_emojicoin_balance, 0);
+        assert!(circulating_supply == mock_chat.circulating_supply, 0);
         assert!(
             balance_as_fraction_of_circulating_supply_q64 ==
-                test_chat.balance_as_fraction_of_circulating_supply_q64,
+                mock_chat.balance_as_fraction_of_circulating_supply_q64,
             0
         );
     }
 
     public fun assert_market_metadata(
-        test_metadata: TestMarketMetadata,
+        mock_metadata: MockMarketMetadata,
         metadata: MarketMetadata,
     ) {
         let (market_id, market_address, emoji_bytes) = unpack_market_metadata(metadata);
-        assert!(market_id == test_metadata.market_id, 0);
-        assert!(market_address == test_metadata.market_address, 0);
-        assert!(emoji_bytes == test_metadata.emoji_bytes, 0);
+        assert!(market_id == mock_metadata.market_id, 0);
+        assert!(market_address == mock_metadata.market_address, 0);
+        assert!(emoji_bytes == mock_metadata.emoji_bytes, 0);
     }
 
     public fun assert_market_registration(
-        test_market_registration: TestMarketRegistration,
+        mock_market_registration: MockMarketRegistration,
         market_registration: MarketRegistration,
     ) {
         let (
@@ -379,15 +379,15 @@
             integrator,
             integrator_fee,
         ) = unpack_market_registration(market_registration);
-        assert_market_metadata(test_market_registration.market_metadata, market_metadata);
-        assert!(time == test_market_registration.time, 0);
-        assert!(registrant == test_market_registration.registrant, 0);
-        assert!(integrator == test_market_registration.integrator, 0);
-        assert!(integrator_fee == test_market_registration.integrator_fee, 0);
+        assert_market_metadata(mock_market_registration.market_metadata, market_metadata);
+        assert!(time == mock_market_registration.time, 0);
+        assert!(registrant == mock_market_registration.registrant, 0);
+        assert!(integrator == mock_market_registration.integrator, 0);
+        assert!(integrator_fee == mock_market_registration.integrator_fee, 0);
     }
 
     public fun assert_market_view(
-        test_market_view: TestMarketView,
+        mock_market_view: MockMarketView,
         market_view: MarketView,
     ) {
         let (
@@ -405,30 +405,30 @@
             emojicoin_balance,
             emojicoin_lp_balance,
         ) = unpack_market_view(market_view);
-        assert_market_metadata(test_market_view.metadata, metadata);
-        assert_sequence_info(test_market_view.sequence_info, sequence_info);
-        assert_reserves(test_market_view.clamm_virtual_reserves, clamm_virtual_reserves);
-        assert_reserves(test_market_view.cpamm_real_reserves, cpamm_real_reserves);
-        assert!(lp_coin_supply == test_market_view.lp_coin_supply, 0);
-        assert!(in_bonding_curve == test_market_view.in_bonding_curve, 0);
-        assert_cumulative_stats(test_market_view.cumulative_stats, cumulative_stats);
-        assert_instantaneous_stats(test_market_view.instantaneous_stats, instantaneous_stats);
-        assert_last_swap(test_market_view.last_swap, last_swap);
+        assert_market_metadata(mock_market_view.metadata, metadata);
+        assert_sequence_info(mock_market_view.sequence_info, sequence_info);
+        assert_reserves(mock_market_view.clamm_virtual_reserves, clamm_virtual_reserves);
+        assert_reserves(mock_market_view.cpamm_real_reserves, cpamm_real_reserves);
+        assert!(lp_coin_supply == mock_market_view.lp_coin_supply, 0);
+        assert!(in_bonding_curve == mock_market_view.in_bonding_curve, 0);
+        assert_cumulative_stats(mock_market_view.cumulative_stats, cumulative_stats);
+        assert_instantaneous_stats(mock_market_view.instantaneous_stats, instantaneous_stats);
+        assert_last_swap(mock_market_view.last_swap, last_swap);
         assert!(vector::length(&periodic_state_trackers) ==
-            vector::length(&test_market_view.periodic_state_trackers), 0);
+            vector::length(&mock_market_view.periodic_state_trackers), 0);
         for (i in 0..vector::length(&periodic_state_trackers)) {
             assert_periodic_state_tracker(
-                *vector::borrow(&test_market_view.periodic_state_trackers, i),
+                *vector::borrow(&mock_market_view.periodic_state_trackers, i),
                 *vector::borrow(&periodic_state_trackers, i),
             );
         };
-        assert!(aptos_coin_balance == test_market_view.aptos_coin_balance, 0);
-        assert!(emojicoin_balance == test_market_view.emojicoin_balance, 0);
-        assert!(emojicoin_lp_balance == test_market_view.emojicoin_lp_balance, 0);
+        assert!(aptos_coin_balance == mock_market_view.aptos_coin_balance, 0);
+        assert!(emojicoin_balance == mock_market_view.emojicoin_balance, 0);
+        assert!(emojicoin_lp_balance == mock_market_view.emojicoin_lp_balance, 0);
     }
 
     public fun assert_registry_view(
-        test_registry_view: TestRegistryView,
+        mock_registry_view: MockRegistryView,
         registry_view: RegistryView,
     ) {
         let (
@@ -445,25 +445,25 @@
             cumulative_swaps,
             cumulative_chat_messages,
         ) = unpack_registry_view(registry_view);
-        assert!(registry_address == test_registry_view.registry_address, 0);
-        assert!(nonce == test_registry_view.nonce, 0);
-        assert!(last_bump_time == test_registry_view.last_bump_time, 0);
-        assert!(n_markets == test_registry_view.n_markets, 0);
+        assert!(registry_address == mock_registry_view.registry_address, 0);
+        assert!(nonce == mock_registry_view.nonce, 0);
+        assert!(last_bump_time == mock_registry_view.last_bump_time, 0);
+        assert!(n_markets == mock_registry_view.n_markets, 0);
         assert!(read_snapshot(&cumulative_quote_volume)
-            == test_registry_view.cumulative_quote_volume, 0);
-        assert!(read_snapshot(&total_quote_locked) == test_registry_view.total_quote_locked, 0);
-        assert!(read_snapshot(&total_value_locked) == test_registry_view.total_value_locked, 0);
-        assert!(read_snapshot(&market_cap) == test_registry_view.market_cap, 0);
-        assert!(read_snapshot(&fully_diluted_value) == test_registry_view.fully_diluted_value, 0);
+            == mock_registry_view.cumulative_quote_volume, 0);
+        assert!(read_snapshot(&total_quote_locked) == mock_registry_view.total_quote_locked, 0);
+        assert!(read_snapshot(&total_value_locked) == mock_registry_view.total_value_locked, 0);
+        assert!(read_snapshot(&market_cap) == mock_registry_view.market_cap, 0);
+        assert!(read_snapshot(&fully_diluted_value) == mock_registry_view.fully_diluted_value, 0);
         assert!(read_snapshot(&cumulative_integrator_fees)
-            == test_registry_view.cumulative_integrator_fees, 0);
-        assert!(read_snapshot(&cumulative_swaps) == test_registry_view.cumulative_swaps, 0);
+            == mock_registry_view.cumulative_integrator_fees, 0);
+        assert!(read_snapshot(&cumulative_swaps) == mock_registry_view.cumulative_swaps, 0);
         assert!(read_snapshot(&cumulative_chat_messages)
-            == test_registry_view.cumulative_chat_messages, 0);
+            == mock_registry_view.cumulative_chat_messages, 0);
     }
 
     public fun assert_global_state(
-        test_global_state: TestGlobalState,
+        mock_global_state: MockGlobalState,
         global_state: GlobalState
     ) {
         let (
@@ -479,24 +479,24 @@
             cumulative_swaps,
             cumulative_chat_messages,
         ) = unpack_global_state(global_state);
-        assert!(emit_time == test_global_state.emit_time, 0);
-        assert!(registry_nonce == test_global_state.registry_nonce, 0);
-        assert!(trigger == test_global_state.trigger, 0);
+        assert!(emit_time == mock_global_state.emit_time, 0);
+        assert!(registry_nonce == mock_global_state.registry_nonce, 0);
+        assert!(trigger == mock_global_state.trigger, 0);
         assert!(read_snapshot(&cumulative_quote_volume)
-            == test_global_state.cumulative_quote_volume, 0);
-        assert!(read_snapshot(&total_quote_locked) == test_global_state.total_quote_locked, 0);
-        assert!(read_snapshot(&total_value_locked) == test_global_state.total_value_locked, 0);
-        assert!(read_snapshot(&market_cap) == test_global_state.market_cap, 0);
-        assert!(read_snapshot(&fully_diluted_value) == test_global_state.fully_diluted_value, 0);
+            == mock_global_state.cumulative_quote_volume, 0);
+        assert!(read_snapshot(&total_quote_locked) == mock_global_state.total_quote_locked, 0);
+        assert!(read_snapshot(&total_value_locked) == mock_global_state.total_value_locked, 0);
+        assert!(read_snapshot(&market_cap) == mock_global_state.market_cap, 0);
+        assert!(read_snapshot(&fully_diluted_value) == mock_global_state.fully_diluted_value, 0);
         assert!(read_snapshot(&cumulative_integrator_fees)
-            == test_global_state.cumulative_integrator_fees, 0);
-        assert!(read_snapshot(&cumulative_swaps) == test_global_state.cumulative_swaps, 0);
+            == mock_global_state.cumulative_integrator_fees, 0);
+        assert!(read_snapshot(&cumulative_swaps) == mock_global_state.cumulative_swaps, 0);
         assert!(read_snapshot(&cumulative_chat_messages)
-            == test_global_state.cumulative_chat_messages, 0);
+            == mock_global_state.cumulative_chat_messages, 0);
     }
 
     public fun assert_periodic_state(
-        test_periodic_state: TestPeriodicState,
+        mock_periodic_state: MockPeriodicState,
         periodic_state: PeriodicState,
     ) {
         let (
@@ -517,29 +517,29 @@
             ends_in_bonding_curve,
             tvl_per_lp_coin_growth_q64,
         ) = unpack_periodic_state(periodic_state);
-        assert_market_metadata(test_periodic_state.market_metadata, market_metadata);
+        assert_market_metadata(mock_periodic_state.market_metadata, market_metadata);
         assert_periodic_state_metadata(
-            test_periodic_state.periodic_state_metadata,
+            mock_periodic_state.periodic_state_metadata,
             periodic_state_metadata,
         );
-        assert!(open_price_q64 == test_periodic_state.open_price_q64, 0);
-        assert!(high_price_q64 == test_periodic_state.high_price_q64, 0);
-        assert!(low_price_q64 == test_periodic_state.low_price_q64, 0);
-        assert!(close_price_q64 == test_periodic_state.close_price_q64, 0);
-        assert!(volume_base == test_periodic_state.volume_base, 0);
-        assert!(volume_quote == test_periodic_state.volume_quote, 0);
-        assert!(integrator_fees == test_periodic_state.integrator_fees, 0);
-        assert!(pool_fees_base == test_periodic_state.pool_fees_base, 0);
-        assert!(pool_fees_quote == test_periodic_state.pool_fees_quote, 0);
-        assert!(n_swaps == test_periodic_state.n_swaps, 0);
-        assert!(n_chat_messages == test_periodic_state.n_chat_messages, 0);
-        assert!(starts_in_bonding_curve == test_periodic_state.starts_in_bonding_curve, 0);
-        assert!(ends_in_bonding_curve == test_periodic_state.ends_in_bonding_curve, 0);
-        assert!(tvl_per_lp_coin_growth_q64 == test_periodic_state.tvl_per_lp_coin_growth_q64, 0);
+        assert!(open_price_q64 == mock_periodic_state.open_price_q64, 0);
+        assert!(high_price_q64 == mock_periodic_state.high_price_q64, 0);
+        assert!(low_price_q64 == mock_periodic_state.low_price_q64, 0);
+        assert!(close_price_q64 == mock_periodic_state.close_price_q64, 0);
+        assert!(volume_base == mock_periodic_state.volume_base, 0);
+        assert!(volume_quote == mock_periodic_state.volume_quote, 0);
+        assert!(integrator_fees == mock_periodic_state.integrator_fees, 0);
+        assert!(pool_fees_base == mock_periodic_state.pool_fees_base, 0);
+        assert!(pool_fees_quote == mock_periodic_state.pool_fees_quote, 0);
+        assert!(n_swaps == mock_periodic_state.n_swaps, 0);
+        assert!(n_chat_messages == mock_periodic_state.n_chat_messages, 0);
+        assert!(starts_in_bonding_curve == mock_periodic_state.starts_in_bonding_curve, 0);
+        assert!(ends_in_bonding_curve == mock_periodic_state.ends_in_bonding_curve, 0);
+        assert!(tvl_per_lp_coin_growth_q64 == mock_periodic_state.tvl_per_lp_coin_growth_q64, 0);
     }
 
     public fun assert_periodic_state_metadata(
-        test_periodic_state_metadata: TestPeriodicStateMetadata,
+        mock_periodic_state_metadata: MockPeriodicStateMetadata,
         periodic_state_metadata: PeriodicStateMetadata,
     ) {
         let (
@@ -549,15 +549,15 @@
             emit_market_nonce,
             trigger,
         ) = unpack_periodic_state_metadata(periodic_state_metadata);
-        assert!(start_time == test_periodic_state_metadata.start_time, 0);
-        assert!(period == test_periodic_state_metadata.period, 0);
-        assert!(emit_time == test_periodic_state_metadata.emit_time, 0);
-        assert!(emit_market_nonce == test_periodic_state_metadata.emit_market_nonce, 0);
-        assert!(trigger == test_periodic_state_metadata.trigger, 0);
+        assert!(start_time == mock_periodic_state_metadata.start_time, 0);
+        assert!(period == mock_periodic_state_metadata.period, 0);
+        assert!(emit_time == mock_periodic_state_metadata.emit_time, 0);
+        assert!(emit_market_nonce == mock_periodic_state_metadata.emit_market_nonce, 0);
+        assert!(trigger == mock_periodic_state_metadata.trigger, 0);
     }
 
     public fun assert_periodic_state_tracker(
-        test_periodic_state_tracker: TestPeriodicStateTracker,
+        mock_periodic_state_tracker: MockPeriodicStateTracker,
         periodic_state_tracker: PeriodicStateTracker,
     ) {
         let (
@@ -579,60 +579,60 @@
             tvl_to_lp_coin_ratio_start,
             tvl_to_lp_coin_ratio_end,
         ) = unpack_periodic_state_tracker(periodic_state_tracker);
-        assert!(start_time == test_periodic_state_tracker.start_time, 0);
-        assert!(period == test_periodic_state_tracker.period, 0);
-        assert!(open_price_q64 == test_periodic_state_tracker.open_price_q64, 0);
-        assert!(high_price_q64 == test_periodic_state_tracker.high_price_q64, 0);
-        assert!(low_price_q64 == test_periodic_state_tracker.low_price_q64, 0);
-        assert!(close_price_q64 == test_periodic_state_tracker.close_price_q64, 0);
-        assert!(volume_base == test_periodic_state_tracker.volume_base, 0);
-        assert!(volume_quote == test_periodic_state_tracker.volume_quote, 0);
-        assert!(integrator_fees == test_periodic_state_tracker.integrator_fees, 0);
-        assert!(pool_fees_base == test_periodic_state_tracker.pool_fees_base, 0);
-        assert!(pool_fees_quote == test_periodic_state_tracker.pool_fees_quote, 0);
-        assert!(n_swaps == test_periodic_state_tracker.n_swaps, 0);
-        assert!(n_chat_messages == test_periodic_state_tracker.n_chat_messages, 0);
-        assert!(starts_in_bonding_curve == test_periodic_state_tracker.starts_in_bonding_curve, 0);
-        assert!(ends_in_bonding_curve == test_periodic_state_tracker.ends_in_bonding_curve, 0);
+        assert!(start_time == mock_periodic_state_tracker.start_time, 0);
+        assert!(period == mock_periodic_state_tracker.period, 0);
+        assert!(open_price_q64 == mock_periodic_state_tracker.open_price_q64, 0);
+        assert!(high_price_q64 == mock_periodic_state_tracker.high_price_q64, 0);
+        assert!(low_price_q64 == mock_periodic_state_tracker.low_price_q64, 0);
+        assert!(close_price_q64 == mock_periodic_state_tracker.close_price_q64, 0);
+        assert!(volume_base == mock_periodic_state_tracker.volume_base, 0);
+        assert!(volume_quote == mock_periodic_state_tracker.volume_quote, 0);
+        assert!(integrator_fees == mock_periodic_state_tracker.integrator_fees, 0);
+        assert!(pool_fees_base == mock_periodic_state_tracker.pool_fees_base, 0);
+        assert!(pool_fees_quote == mock_periodic_state_tracker.pool_fees_quote, 0);
+        assert!(n_swaps == mock_periodic_state_tracker.n_swaps, 0);
+        assert!(n_chat_messages == mock_periodic_state_tracker.n_chat_messages, 0);
+        assert!(starts_in_bonding_curve == mock_periodic_state_tracker.starts_in_bonding_curve, 0);
+        assert!(ends_in_bonding_curve == mock_periodic_state_tracker.ends_in_bonding_curve, 0);
         assert_tvl_to_lp_coin_ratio(
-            test_periodic_state_tracker.tvl_to_lp_coin_ratio_start,
+            mock_periodic_state_tracker.tvl_to_lp_coin_ratio_start,
             tvl_to_lp_coin_ratio_start,
         );
         assert_tvl_to_lp_coin_ratio(
-            test_periodic_state_tracker.tvl_to_lp_coin_ratio_end,
+            mock_periodic_state_tracker.tvl_to_lp_coin_ratio_end,
             tvl_to_lp_coin_ratio_end,
         );
     }
 
     public fun assert_reserves(
-        test_reserves: TestReserves,
+        mock_reserves: MockReserves,
         reserves: Reserves,
     ) {
         let (base, quote) = unpack_reserves(reserves);
-        assert!(base == test_reserves.base, 0);
-        assert!(quote == test_reserves.quote, 0);
+        assert!(base == mock_reserves.base, 0);
+        assert!(quote == mock_reserves.quote, 0);
     }
 
     public fun assert_sequence_info(
-        test_sequence_info: TestSequenceInfo,
+        mock_sequence_info: MockSequenceInfo,
         sequence_info: SequenceInfo,
     ) {
         let (nonce, last_bump_time) = unpack_sequence_info(sequence_info);
-        assert!(nonce == test_sequence_info.nonce, 0);
-        assert!(last_bump_time == test_sequence_info.last_bump_time, 0);
+        assert!(nonce == mock_sequence_info.nonce, 0);
+        assert!(last_bump_time == mock_sequence_info.last_bump_time, 0);
     }
 
     public fun assert_tvl_to_lp_coin_ratio(
-        test_tvl_to_lp_coin_ratio: TestTVLtoLPCoinRatio,
+        mock_tvl_to_lp_coin_ratio: MockTVLtoLPCoinRatio,
         tvl_to_lp_coin_ratio: TVLtoLPCoinRatio,
     ) {
         let (tvl, lp_coins) = unpack_tvl_to_lp_coin_ratio(tvl_to_lp_coin_ratio);
-        assert!(tvl == test_tvl_to_lp_coin_ratio.tvl, 0);
-        assert!(lp_coins == test_tvl_to_lp_coin_ratio.lp_coins, 0);
+        assert!(tvl == mock_tvl_to_lp_coin_ratio.tvl, 0);
+        assert!(lp_coins == mock_tvl_to_lp_coin_ratio.lp_coins, 0);
     }
 
     public fun assert_cumulative_stats(
-        test_cumulative_stats: TestCumulativeStats,
+        mock_cumulative_stats: MockCumulativeStats,
         cumulative_stats: CumulativeStats,
     ) {
         let (
@@ -644,17 +644,17 @@
             n_swaps,
             n_chat_messages,
         ) = unpack_cumulative_stats(cumulative_stats);
-        assert!(base_volume == test_cumulative_stats.base_volume, 0);
-        assert!(quote_volume == test_cumulative_stats.quote_volume, 0);
-        assert!(integrator_fees == test_cumulative_stats.integrator_fees, 0);
-        assert!(pool_fees_base == test_cumulative_stats.pool_fees_base, 0);
-        assert!(pool_fees_quote == test_cumulative_stats.pool_fees_quote, 0);
-        assert!(n_swaps == test_cumulative_stats.n_swaps, 0);
-        assert!(n_chat_messages == test_cumulative_stats.n_chat_messages, 0);
+        assert!(base_volume == mock_cumulative_stats.base_volume, 0);
+        assert!(quote_volume == mock_cumulative_stats.quote_volume, 0);
+        assert!(integrator_fees == mock_cumulative_stats.integrator_fees, 0);
+        assert!(pool_fees_base == mock_cumulative_stats.pool_fees_base, 0);
+        assert!(pool_fees_quote == mock_cumulative_stats.pool_fees_quote, 0);
+        assert!(n_swaps == mock_cumulative_stats.n_swaps, 0);
+        assert!(n_chat_messages == mock_cumulative_stats.n_chat_messages, 0);
     }
 
     public fun assert_instantaneous_stats(
-        test_instantaneous_stats: TestInstantaneousStats,
+        mock_instantaneous_stats: MockInstantaneousStats,
         instantaneous_stats: InstantaneousStats,
     ) {
         let (
@@ -663,14 +663,14 @@
             market_cap,
             fully_diluted_value,
         ) = unpack_instantaneous_stats(instantaneous_stats);
-        assert!(total_quote_locked == test_instantaneous_stats.total_quote_locked, 0);
-        assert!(total_value_locked == test_instantaneous_stats.total_value_locked, 0);
-        assert!(market_cap == test_instantaneous_stats.market_cap, 0);
-        assert!(fully_diluted_value == test_instantaneous_stats.fully_diluted_value, 0);
+        assert!(total_quote_locked == mock_instantaneous_stats.total_quote_locked, 0);
+        assert!(total_value_locked == mock_instantaneous_stats.total_value_locked, 0);
+        assert!(market_cap == mock_instantaneous_stats.market_cap, 0);
+        assert!(fully_diluted_value == mock_instantaneous_stats.fully_diluted_value, 0);
     }
 
     public fun assert_last_swap(
-        test_last_swap: TestLastSwap,
+        mock_last_swap: MockLastSwap,
         last_swap: LastSwap,
     ) {
         let (
@@ -681,16 +681,16 @@
             nonce,
             time,
         ) = unpack_last_swap(last_swap);
-        assert!(is_sell == test_last_swap.is_sell, 0);
-        assert!(avg_execution_price_q64 == test_last_swap.avg_execution_price_q64, 0);
-        assert!(base_volume == test_last_swap.base_volume, 0);
-        assert!(quote_volume == test_last_swap.quote_volume, 0);
-        assert!(nonce == test_last_swap.nonce, 0);
-        assert!(time == test_last_swap.time, 0);
+        assert!(is_sell == mock_last_swap.is_sell, 0);
+        assert!(avg_execution_price_q64 == mock_last_swap.avg_execution_price_q64, 0);
+        assert!(base_volume == mock_last_swap.base_volume, 0);
+        assert!(quote_volume == mock_last_swap.quote_volume, 0);
+        assert!(nonce == mock_last_swap.nonce, 0);
+        assert!(time == mock_last_swap.time, 0);
     }
 
     public fun assert_state(
-        test_state: TestState,
+        mock_state: MockState,
         state: State,
     ) {
         let (
@@ -703,24 +703,24 @@
             instantaneous_stats,
             last_swap,
         ) = unpack_state(state);
-        assert_market_metadata(test_state.market_metadata, market_metadata);
-        assert_state_metadata(test_state.state_metadata, state_metadata);
-        assert_reserves(test_state.clamm_virtual_reserves, clamm_virtual_reserves);
-        assert_reserves(test_state.cpamm_real_reserves, cpamm_real_reserves);
-        assert!(lp_coin_supply == test_state.lp_coin_supply, 0);
-        assert_cumulative_stats(test_state.cumulative_stats, cumulative_stats);
-        assert_instantaneous_stats(test_state.instantaneous_stats, instantaneous_stats);
-        assert_last_swap(test_state.last_swap, last_swap);
+        assert_market_metadata(mock_state.market_metadata, market_metadata);
+        assert_state_metadata(mock_state.state_metadata, state_metadata);
+        assert_reserves(mock_state.clamm_virtual_reserves, clamm_virtual_reserves);
+        assert_reserves(mock_state.cpamm_real_reserves, cpamm_real_reserves);
+        assert!(lp_coin_supply == mock_state.lp_coin_supply, 0);
+        assert_cumulative_stats(mock_state.cumulative_stats, cumulative_stats);
+        assert_instantaneous_stats(mock_state.instantaneous_stats, instantaneous_stats);
+        assert_last_swap(mock_state.last_swap, last_swap);
     }
 
     public fun assert_state_metadata(
-        test_state_metadata: TestStateMetadata,
+        mock_state_metadata: MockStateMetadata,
         state_metadata: StateMetadata,
     ) {
         let (market_nonce, bump_time, trigger) = unpack_state_metadata(state_metadata);
-        assert!(market_nonce == test_state_metadata.market_nonce, 0);
-        assert!(bump_time == test_state_metadata.bump_time, 0);
-        assert!(trigger == test_state_metadata.trigger, 0);
+        assert!(market_nonce == mock_state_metadata.market_nonce, 0);
+        assert!(bump_time == mock_state_metadata.bump_time, 0);
+        assert!(trigger == mock_state_metadata.trigger, 0);
     }
 
     public fun assert_test_market_address(
@@ -763,7 +763,7 @@
     }
 
     public fun apply_periodic_state_tracker_start_times(
-        periodic_state_trackers_ref_mut: &mut vector<TestPeriodicStateTracker>,
+        periodic_state_trackers_ref_mut: &mut vector<MockPeriodicStateTracker>,
         start_times: PeriodicStateTrackerStartTimes,
     ) {
         vector::borrow_mut(periodic_state_trackers_ref_mut, 0).start_time = start_times.period_1M;
@@ -775,22 +775,22 @@
         vector::borrow_mut(periodic_state_trackers_ref_mut, 6).start_time = start_times.period_1D;
     }
 
-    public fun base_clamm_virtual_reserves(): TestReserves {
-        TestReserves {
+    public fun base_clamm_virtual_reserves(): MockReserves {
+        MockReserves {
             base: get_BASE_VIRTUAL_CEILING(),
             quote: get_QUOTE_VIRTUAL_FLOOR(),
         }
     }
 
-    public fun base_cpamm_real_reserves(): TestReserves {
-        TestReserves {
+    public fun base_cpamm_real_reserves(): MockReserves {
+        MockReserves {
             base: 0,
             quote: 0,
         }
     }
 
-    public fun base_cumulative_stats(): TestCumulativeStats {
-        TestCumulativeStats {
+    public fun base_cumulative_stats(): MockCumulativeStats {
+        MockCumulativeStats {
             base_volume: 0,
             quote_volume: 0,
             integrator_fees: 0,
@@ -801,8 +801,8 @@
         }
     }
 
-    public fun base_instantaneous_stats(): TestInstantaneousStats {
-        TestInstantaneousStats {
+    public fun base_instantaneous_stats(): MockInstantaneousStats {
+        MockInstantaneousStats {
             total_quote_locked: 0,
             total_value_locked: 0,
             market_cap: 0,
@@ -810,8 +810,8 @@
         }
     }
 
-    public fun base_global_state(): TestGlobalState {
-        TestGlobalState {
+    public fun base_global_state(): MockGlobalState {
+        MockGlobalState {
             emit_time: 0,
             registry_nonce: 1,
             trigger: get_TRIGGER_PACKAGE_PUBLICATION(),
@@ -826,8 +826,8 @@
         }
     }
 
-    public fun base_last_swap(): TestLastSwap {
-        TestLastSwap {
+    public fun base_last_swap(): MockLastSwap {
+        MockLastSwap {
             is_sell: false,
             avg_execution_price_q64: 0,
             base_volume: 0,
@@ -837,16 +837,16 @@
         }
     }
 
-    public fun base_market_metadata(): TestMarketMetadata {
-        TestMarketMetadata {
+    public fun base_market_metadata(): MockMarketMetadata {
+        MockMarketMetadata {
             market_id: 1,
             market_address: @0x0,
             emoji_bytes: vector[],
         }
     }
 
-    public fun base_market_registration(): TestMarketRegistration {
-        TestMarketRegistration {
+    public fun base_market_registration(): MockMarketRegistration {
+        MockMarketRegistration {
             market_metadata: base_market_metadata(),
             time: 0,
             registrant: USER,
@@ -855,10 +855,10 @@
         }
     }
 
-    public fun base_market_view(): TestMarketView {
-        TestMarketView {
+    public fun base_market_view(): MockMarketView {
+        MockMarketView {
             metadata: base_market_metadata(),
-            sequence_info: TestSequenceInfo {
+            sequence_info: MockSequenceInfo {
                 nonce: 1,
                 last_bump_time: 0,
             },
@@ -877,8 +877,8 @@
         }
     }
 
-    public fun base_periodic_state_tracker(): TestPeriodicStateTracker {
-        TestPeriodicStateTracker {
+    public fun base_periodic_state_tracker(): MockPeriodicStateTracker {
+        MockPeriodicStateTracker {
             start_time: 0,
             period: 0,
             open_price_q64: 0,
@@ -899,8 +899,8 @@
         }
     }
 
-    public fun base_registry_view(): TestRegistryView {
-        TestRegistryView {
+    public fun base_registry_view(): MockRegistryView {
+        MockRegistryView {
             registry_address: registry_address(),
             nonce: 1,
             last_bump_time: 0,
@@ -916,8 +916,8 @@
         }
     }
 
-    public fun base_state(): TestState {
-        TestState {
+    public fun base_state(): MockState {
+        MockState {
             market_metadata: base_market_metadata(),
             state_metadata: base_state_metadata(),
             clamm_virtual_reserves: base_clamm_virtual_reserves(),
@@ -929,16 +929,16 @@
         }
     }
 
-    public fun base_state_metadata(): TestStateMetadata {
-        TestStateMetadata {
+    public fun base_state_metadata(): MockStateMetadata {
+        MockStateMetadata {
             market_nonce: 1,
             bump_time: 0,
             trigger: get_TRIGGER_MARKET_REGISTRATION(),
         }
     }
 
-    public fun base_tvl_to_lp_coin_ratio(): TestTVLtoLPCoinRatio {
-        TestTVLtoLPCoinRatio {
+    public fun base_tvl_to_lp_coin_ratio(): MockTVLtoLPCoinRatio {
+        MockTVLtoLPCoinRatio {
             tvl: 0,
             lp_coins: 0,
         }
@@ -999,8 +999,8 @@
     }
 
     public fun vectorize_periodic_state_tracker_base(
-        base: TestPeriodicStateTracker
-    ): vector<TestPeriodicStateTracker> {
+        base: MockPeriodicStateTracker
+    ): vector<MockPeriodicStateTracker> {
         vector::map(vector[
             get_PERIOD_1M(),
             get_PERIOD_5M(),
@@ -1083,13 +1083,13 @@
 
         // Assert the emitted chat events.
         let events_emitted = emitted_events<Chat>();
-        let market_metadata = TestMarketMetadata {
+        let market_metadata = MockMarketMetadata {
             market_id: 1,
             market_address: @black_cat_market,
             emoji_bytes: BLACK_CAT,
         };
         assert_chat(
-            TestChat {
+            MockChat {
                 market_metadata,
                 emit_time: 0,
                 emit_market_nonce: 2,
@@ -1102,7 +1102,7 @@
             *vector::borrow(&events_emitted, 0),
         );
         assert_chat(
-            TestChat {
+            MockChat {
                 market_metadata,
                 emit_time: 0,
                 emit_market_nonce: 3,
@@ -1320,7 +1320,7 @@
         timestamp::update_global_time_for_test(time);
         register_market(&get_signer(USER), vector[BLACK_CAT], INTEGRATOR);
         let market_view = base_market_view();
-        let market_metadata_1 = TestMarketMetadata {
+        let market_metadata_1 = MockMarketMetadata {
             market_id: 1,
             market_address: @black_cat_market,
             emoji_bytes: BLACK_CAT,
@@ -1375,7 +1375,7 @@
         // Register new market, assert state.
         mint_aptos_coin_to(USER, get_MARKET_REGISTRATION_FEE());
         register_market_without_publish(&get_signer(USER), vector[BLACK_HEART], INTEGRATOR);
-        let market_metadata_2 = TestMarketMetadata {
+        let market_metadata_2 = MockMarketMetadata {
             market_id: 2,
             market_address: @black_heart_market,
             emoji_bytes: BLACK_HEART,
@@ -1388,7 +1388,7 @@
             periodic_state_tracker_start_times,
         );
         vector::for_each_mut(&mut market_view.periodic_state_trackers, |e| {
-            let periodic_state_tracker_ref_mut: &mut TestPeriodicStateTracker = e;
+            let periodic_state_tracker_ref_mut: &mut MockPeriodicStateTracker = e;
             periodic_state_tracker_ref_mut.integrator_fees =
                 (get_MARKET_REGISTRATION_FEE() as u128);
         });

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -1,3 +1,12 @@
+// This module contains assorted mock structs used to canonicalize variable naming during state
+// assertions, since the mocked structs themselves cannot be packed in this module (structs can
+// only be packed inside the module that defines them). Mock struct names begin with `Mock`.
+//
+// Mock structs contain an associated test function for asserting that their fields match those of
+// the corresponding struct defined in the main file. These test functions begin with `assert_`.
+//
+// Base struct values are defined via functions starting with `base_`, corresponding to default
+// values that require the minimum number of field modifications for testing.
 #[test_only] module emojicoin_dot_fun::tests {
 
     use aptos_framework::account::{create_signer_for_test as get_signer};

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -6,8 +6,10 @@
 // the corresponding struct defined in the main file. These test functions begin with `assert_`.
 //
 // Base struct values are defined via functions starting with `base_`, corresponding to default
-// values that require the minimum number of field modifications for testing. For some testing cases
-// that are reused across multiple tests, there are additional base struct functions.
+// values that require the minimum number of field modifications for testing.
+//
+// For some testing cases that are reused across multiple tests, there are additional base struct
+// functions: see constants starting with `SIMPLE_BUY_` and `EXACT_TRANSITION_` for more.
 #[test_only] module emojicoin_dot_fun::tests {
 
     use aptos_framework::account::{create_signer_for_test as get_signer};

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -357,7 +357,7 @@
     const USER: address = @0xaaaaa;
     const INTEGRATOR: address = @0xbbbbb;
 
-    // Constants for a simple buy against a new market (does not result in state transtiion), used
+    // Constants for a simple buy against a new market (does not result in state transition), used
     // for assorted test setup.
     const SIMPLE_BUY_INPUT_AMOUNT: u64 = 111_111_111_111;
     const SIMPLE_BUY_INTEGRATOR: address = @0xddddd;


### PR DESCRIPTION
# Description

## Production code

1. Update registry nonce to increment at the beginning of the periodic state
   trigger function.
1. Fix boolean check for if a swap ends in bonding curve.
1. Fix reserve amounts assignment statement.
1. Add decoder for unpacking a `Swap` struct, since the event is returned via
   the swap simulator view function.
1. Add assorted minimal test-only functions such that testing can be contained
   in testing file.

## Test code layout

1. Clarify mock structure/testing function layout.
1. Change `TestStruct` pattern to `MockStruct` for clarity.
1. Add simple buy/exact state transition harnessing for swap function.

## New tests

1. `bps_fee_assorted`
1. `simple_buy_amounts`
1. `swap_simple_buy`
1. `swap_exact_transition`

# Testing

From in `src/move/emojicoin_dot_fun`

```sh
git ls-files | entr -c aptos move test --coverage --dev
```

Compare coverage against bytecode:

```sh
aptos move coverage bytecode --module emojicoin_dot_fun --dev
```

Also published on testnet

https://explorer.aptoslabs.com/account/0xaaf84cab338c0cde5b4d25677aede1f5f877954ac354236da5ef67d99d764ebb/modules/code/emojicoin_dot_fun?network=testnet

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] ~Did you update the changelog?~
- [x] Did you check off all checkboxes from the linked Linear task?