### PR TITLE
[ECO 1672] Add basic mock data buy script and types for queries/events

### DIFF
--- a/src/typescript/api/.eslintrc.js
+++ b/src/typescript/api/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
   rules: {
     quotes: ["error", "double"],
     "max-len": ["error", 100],
-    "import/extensions": ["error", "never"],
+    "import/extensions": "off",
     "import/no-commonjs": ["error", { allowRequire: false, allowPrimitiveModules: false }],
     "import/no-extraneous-dependencies": [
       "error",
@@ -46,7 +46,7 @@ module.exports = {
       {
         missingExports: true,
         unusedExports: true,
-        ignoreExports: ["tests/**/*", "**/index.ts", "src/emojicoin_dot_fun/types.ts"],
+        ignoreExports: ["tests/**/*", "**/index.ts"],
       },
     ],
     "@typescript-eslint/consistent-type-imports": [

--- a/src/typescript/api/src/emojicoin_dot_fun/consts.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/consts.ts
@@ -1,4 +1,9 @@
 import { AccountAddress } from "@aptos-labs/ts-sdk";
+import dotenv from "dotenv";
+import path from "path";
+import { getGitRoot } from "../../tests/utils/helpers";
+
+dotenv.config();
 
 export const ONE_APT = 1 * 10 ** 8;
 export const MAX_GAS_FOR_PUBLISH = 1500000;
@@ -9,3 +14,18 @@ export const DEFAULT_REGISTER_MARKET_GAS_OPTIONS = {
   maxGasAmount: ONE_APT / 100,
   gasUnitPrice: 100,
 };
+export const MARKET_DATA_DIR = path.join(getGitRoot(), "src/typescript/api/src/markets/data");
+
+export const MARKET_CAP = 4_500_000_000_000n;
+export const EMOJICOIN_REMAINDER = 10_000_000_000_000_000n;
+export const EMOJICOIN_SUPPLY = 45_000_000_000_000_000n;
+export const LP_TOKENS_INITIAL = 100_000_000_000_000n;
+export const BASE_REAL_FLOOR = 0n;
+export const QUOTE_REAL_FLOOR = 0n;
+export const BASE_REAL_CEILING = 35_000_000_000_000_000n;
+export const QUOTE_REAL_CEILING = 1_000_000_000_000n;
+export const BASE_VIRTUAL_FLOOR = 14_000_000_000_000_000n;
+export const QUOTE_VIRTUAL_FLOOR = 400_000_000_000n;
+export const BASE_VIRTUAL_CEILING = 49_000_000_000_000_000n;
+export const QUOTE_VIRTUAL_CEILING = 1_400_000_000_000n;
+export const POOL_FEE_RATE_BPS = 25;

--- a/src/typescript/api/src/emojicoin_dot_fun/emojicoin-dot-fun.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/emojicoin-dot-fun.ts
@@ -142,15 +142,15 @@ export class Chat extends EntryFunctionPayloadBuilder {
 }
 
 export type ProvideLiquidityPayloadMoveArguments = {
-  provider: AccountAddress;
+  marketAddress: AccountAddress;
   quoteAmount: U64;
 };
 
 /**
  *```
  *  public entry fun provide_liquidity<Emojicoin, EmojicoinLP>(
- *     market_address: &signer,
- *     provider: address,
+ *     provider: &signer,
+ *     market_address: address,
  *     quote_amount: u64,
  *  )
  *```
@@ -174,18 +174,18 @@ export class ProvideLiquidity extends EntryFunctionPayloadBuilder {
   public readonly feePayer?: AccountAddress;
 
   private constructor(args: {
-    marketAddress: AccountAddressInput; // &signer
-    provider: AccountAddressInput; // address
+    provider: AccountAddressInput; // &signer
+    marketAddress: AccountAddressInput; // address
     quoteAmount: Uint64; // u64
     typeTags: [TypeTagInput, TypeTagInput]; // [Emojicoin, EmojicoinLP]
     feePayer?: AccountAddressInput; // Optional fee payer account to pay gas fees.
   }) {
     super();
-    const { marketAddress, provider, quoteAmount, typeTags, feePayer } = args;
-    this.primarySender = AccountAddress.from(marketAddress);
+    const { provider, marketAddress, quoteAmount, typeTags, feePayer } = args;
+    this.primarySender = AccountAddress.from(provider);
 
     this.args = {
-      provider: AccountAddress.from(provider),
+      marketAddress: AccountAddress.from(marketAddress),
       quoteAmount: new U64(quoteAmount),
     };
     this.typeTags = typeTags.map((typeTag) =>
@@ -196,8 +196,8 @@ export class ProvideLiquidity extends EntryFunctionPayloadBuilder {
 
   static async builder(args: {
     aptosConfig: AptosConfig;
-    marketAddress: AccountAddressInput; // &signer
-    provider: AccountAddressInput; // address
+    provider: AccountAddressInput; // &signer
+    marketAddress: AccountAddressInput; // address
     quoteAmount: Uint64; // u64
     typeTags: [TypeTagInput, TypeTagInput]; // [Emojicoin, EmojicoinLP],
     feePayer?: AccountAddressInput;
@@ -218,20 +218,20 @@ export class ProvideLiquidity extends EntryFunctionPayloadBuilder {
 
   static async submit(args: {
     aptosConfig: AptosConfig;
-    marketAddress: Account; // &signer
-    provider: AccountAddressInput; // address
+    provider: Account; // &signer
+    marketAddress: AccountAddressInput; // address
     quoteAmount: Uint64; // u64
     typeTags: [TypeTagInput, TypeTagInput]; // [Emojicoin, EmojicoinLP]
     feePayer?: Account;
     options?: InputGenerateTransactionOptions;
     waitForTransactionOptions?: WaitForTransactionOptions;
   }): Promise<UserTransactionResponse> {
-    const { marketAddress: primarySigner, waitForTransactionOptions, feePayer } = args;
+    const { provider: primarySigner, waitForTransactionOptions, feePayer } = args;
 
     const transactionBuilder = await ProvideLiquidity.builder({
       ...args,
       feePayer: feePayer ? feePayer.accountAddress : undefined,
-      marketAddress: primarySigner.accountAddress,
+      provider: primarySigner.accountAddress,
     });
     const response = await transactionBuilder.submit({
       primarySigner,
@@ -338,15 +338,15 @@ export class RegisterMarket extends EntryFunctionPayloadBuilder {
 }
 
 export type RemoveLiquidityPayloadMoveArguments = {
-  provider: AccountAddress;
+  marketAddress: AccountAddress;
   lpCoinAmount: U64;
 };
 
 /**
  *```
  *  public entry fun remove_liquidity<Emojicoin, EmojicoinLP>(
- *     market_address: &signer,
- *     provider: address,
+ *     provider: &signer,
+ *     market_address: address,
  *     lp_coin_amount: u64,
  *  )
  *```
@@ -370,18 +370,18 @@ export class RemoveLiquidity extends EntryFunctionPayloadBuilder {
   public readonly feePayer?: AccountAddress;
 
   private constructor(args: {
-    marketAddress: AccountAddressInput; // &signer
-    provider: AccountAddressInput; // address
+    provider: AccountAddressInput; // &signer
+    marketAddress: AccountAddressInput; // address
     lpCoinAmount: Uint64; // u64
     typeTags: [TypeTagInput, TypeTagInput]; // [Emojicoin, EmojicoinLP]
     feePayer?: AccountAddressInput; // Optional fee payer account to pay gas fees.
   }) {
     super();
-    const { marketAddress, provider, lpCoinAmount, typeTags, feePayer } = args;
-    this.primarySender = AccountAddress.from(marketAddress);
+    const { provider, marketAddress, lpCoinAmount, typeTags, feePayer } = args;
+    this.primarySender = AccountAddress.from(provider);
 
     this.args = {
-      provider: AccountAddress.from(provider),
+      marketAddress: AccountAddress.from(marketAddress),
       lpCoinAmount: new U64(lpCoinAmount),
     };
     this.typeTags = typeTags.map((typeTag) =>
@@ -392,8 +392,8 @@ export class RemoveLiquidity extends EntryFunctionPayloadBuilder {
 
   static async builder(args: {
     aptosConfig: AptosConfig;
-    marketAddress: AccountAddressInput; // &signer
-    provider: AccountAddressInput; // address
+    provider: AccountAddressInput; // &signer
+    marketAddress: AccountAddressInput; // address
     lpCoinAmount: Uint64; // u64
     typeTags: [TypeTagInput, TypeTagInput]; // [Emojicoin, EmojicoinLP],
     feePayer?: AccountAddressInput;
@@ -414,20 +414,20 @@ export class RemoveLiquidity extends EntryFunctionPayloadBuilder {
 
   static async submit(args: {
     aptosConfig: AptosConfig;
-    marketAddress: Account; // &signer
-    provider: AccountAddressInput; // address
+    provider: Account; // &signer
+    marketAddress: AccountAddressInput; // address
     lpCoinAmount: Uint64; // u64
     typeTags: [TypeTagInput, TypeTagInput]; // [Emojicoin, EmojicoinLP]
     feePayer?: Account;
     options?: InputGenerateTransactionOptions;
     waitForTransactionOptions?: WaitForTransactionOptions;
   }): Promise<UserTransactionResponse> {
-    const { marketAddress: primarySigner, waitForTransactionOptions, feePayer } = args;
+    const { provider: primarySigner, waitForTransactionOptions, feePayer } = args;
 
     const transactionBuilder = await RemoveLiquidity.builder({
       ...args,
       feePayer: feePayer ? feePayer.accountAddress : undefined,
-      marketAddress: primarySigner.accountAddress,
+      provider: primarySigner.accountAddress,
     });
     const response = await transactionBuilder.submit({
       primarySigner,
@@ -439,7 +439,7 @@ export class RemoveLiquidity extends EntryFunctionPayloadBuilder {
 }
 
 export type SwapPayloadMoveArguments = {
-  swapper: AccountAddress;
+  marketAddress: AccountAddress;
   inputAmount: U64;
   isSell: Bool;
   integrator: AccountAddress;
@@ -449,8 +449,8 @@ export type SwapPayloadMoveArguments = {
 /**
  *```
  *  public entry fun swap<Emojicoin, EmojicoinLP>(
- *     market_address: &signer,
- *     swapper: address,
+ *     swapper: &signer,
+ *     market_address: address,
  *     input_amount: u64,
  *     is_sell: bool,
  *     integrator: address,
@@ -477,8 +477,8 @@ export class Swap extends EntryFunctionPayloadBuilder {
   public readonly feePayer?: AccountAddress;
 
   private constructor(args: {
-    marketAddress: AccountAddressInput; // &signer
-    swapper: AccountAddressInput; // address
+    swapper: AccountAddressInput; // &signer
+    marketAddress: AccountAddressInput; // address
     inputAmount: Uint64; // u64
     isSell: boolean; // bool
     integrator: AccountAddressInput; // address
@@ -488,8 +488,8 @@ export class Swap extends EntryFunctionPayloadBuilder {
   }) {
     super();
     const {
-      marketAddress,
       swapper,
+      marketAddress,
       inputAmount,
       isSell,
       integrator,
@@ -497,10 +497,10 @@ export class Swap extends EntryFunctionPayloadBuilder {
       typeTags,
       feePayer,
     } = args;
-    this.primarySender = AccountAddress.from(marketAddress);
+    this.primarySender = AccountAddress.from(swapper);
 
     this.args = {
-      swapper: AccountAddress.from(swapper),
+      marketAddress: AccountAddress.from(marketAddress),
       inputAmount: new U64(inputAmount),
       isSell: new Bool(isSell),
       integrator: AccountAddress.from(integrator),
@@ -514,8 +514,8 @@ export class Swap extends EntryFunctionPayloadBuilder {
 
   static async builder(args: {
     aptosConfig: AptosConfig;
-    marketAddress: AccountAddressInput; // &signer
-    swapper: AccountAddressInput; // address
+    swapper: AccountAddressInput; // &signer
+    marketAddress: AccountAddressInput; // address
     inputAmount: Uint64; // u64
     isSell: boolean; // bool
     integrator: AccountAddressInput; // address
@@ -539,8 +539,8 @@ export class Swap extends EntryFunctionPayloadBuilder {
 
   static async submit(args: {
     aptosConfig: AptosConfig;
-    marketAddress: Account; // &signer
-    swapper: AccountAddressInput; // address
+    swapper: Account; // &signer
+    marketAddress: AccountAddressInput; // address
     inputAmount: Uint64; // u64
     isSell: boolean; // bool
     integrator: AccountAddressInput; // address
@@ -550,12 +550,12 @@ export class Swap extends EntryFunctionPayloadBuilder {
     options?: InputGenerateTransactionOptions;
     waitForTransactionOptions?: WaitForTransactionOptions;
   }): Promise<UserTransactionResponse> {
-    const { marketAddress: primarySigner, waitForTransactionOptions, feePayer } = args;
+    const { swapper: primarySigner, waitForTransactionOptions, feePayer } = args;
 
     const transactionBuilder = await Swap.builder({
       ...args,
       feePayer: feePayer ? feePayer.accountAddress : undefined,
-      marketAddress: primarySigner.accountAddress,
+      swapper: primarySigner.accountAddress,
     });
     const response = await transactionBuilder.submit({
       primarySigner,

--- a/src/typescript/api/src/emojicoin_dot_fun/events.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/events.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unused-modules */
 import {
   AccountAddress,
   type AccountAddressInput,
@@ -41,13 +42,13 @@ export function toTypeTag(
   return parseTypeTag(`${address.toString()}::${moduleName}::${structName}`);
 }
 
-interface KnownEvent<T> {
+interface KnownEvent {
   MODULE_ADDRESS: AccountAddress;
   MODULE_NAME: string;
   STRUCT_NAME: string;
 }
 
-export function knownEventTypeTagString<T>(e: KnownEvent<T>): string {
+export function knownEventTypeTagString(e: KnownEvent): string {
   return toTypeTag(e.MODULE_ADDRESS, e.MODULE_NAME, e.STRUCT_NAME).toString();
 }
 
@@ -212,7 +213,7 @@ export type ChatEventFields = {
   emitMarketNonce: Uint64;
   user: AccountAddress;
   message: string;
-  userEmojicoinBbalance: Uint64;
+  userEmojicoinBalance: Uint64;
   circulatingSupply: Uint64;
   balanceAsFractionOfCirculatingSupplyQ64: Uint128;
 };
@@ -236,7 +237,7 @@ export class ChatEvent extends Event {
       emitMarketNonce: BigInt(event.data.emit_market_nonce),
       user: AccountAddress.from(event.data.user),
       message: event.data.message,
-      userEmojicoinBbalance: BigInt(event.data.user_emojicoin_balance),
+      userEmojicoinBalance: BigInt(event.data.user_emojicoin_balance),
       circulatingSupply: BigInt(event.data.circulating_supply),
       balanceAsFractionOfCirculatingSupplyQ64: BigInt(
         event.data.balance_as_fraction_of_circulating_supply_q64

--- a/src/typescript/api/src/emojicoin_dot_fun/events.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/events.ts
@@ -1,0 +1,451 @@
+import {
+  AccountAddress,
+  type AccountAddressInput,
+  type TypeTag,
+  type Uint128,
+  type Uint64,
+  type Uint8,
+  parseTypeTag,
+} from "@aptos-labs/ts-sdk";
+import {
+  type CumulativeStats,
+  type InstantaneousStats,
+  type LastSwap,
+  type MarketMetadata,
+  type PeriodicStateMetadata,
+  type Reserves,
+  type StateMetadata,
+  isMarketMetadata,
+  toAggregatorSnapshot,
+  toCumulativeStats,
+  toInstantaneousStats,
+  toLastSwap,
+  toMarketMetadata,
+  toPeriodicStateMetadata,
+  toReserves,
+  toStateMetadata,
+} from "../types/contract";
+import { type EventJSON } from "../types/core";
+
+type GUID = {
+  creationNumber: Uint64;
+  accountAddress: AccountAddress;
+};
+
+export function toTypeTag(
+  addressInput: AccountAddressInput,
+  moduleName: string,
+  structName: string
+): TypeTag {
+  const address = AccountAddress.from(addressInput);
+  return parseTypeTag(`${address.toString()}::${moduleName}::${structName}`);
+}
+
+interface KnownEvent<T> {
+  MODULE_ADDRESS: AccountAddress;
+  MODULE_NAME: string;
+  STRUCT_NAME: string;
+}
+
+export function knownEventTypeTagString<T>(e: KnownEvent<T>): string {
+  return toTypeTag(e.MODULE_ADDRESS, e.MODULE_NAME, e.STRUCT_NAME).toString();
+}
+
+export function isKnownEventType(e: Event): e is KnownEventType {
+  return (
+    e instanceof SwapEvent ||
+    e instanceof ChatEvent ||
+    e instanceof MarketRegistrationEvent ||
+    e instanceof PeriodicStateEvent ||
+    e instanceof StateEvent ||
+    e instanceof GlobalStateEvent ||
+    e instanceof LiquidityEvent
+  );
+}
+
+export type KnownEventType =
+  | SwapEvent
+  | ChatEvent
+  | MarketRegistrationEvent
+  | PeriodicStateEvent
+  | StateEvent
+  | GlobalStateEvent
+  | LiquidityEvent;
+
+export type AnyEventTpe = Event | KnownEventType;
+
+export type Events = {
+  swapEvents: SwapEvent[];
+  chatEvents: ChatEvent[];
+  marketRegistrationEvents: MarketRegistrationEvent[];
+  periodicStateEvents: PeriodicStateEvent[];
+  stateEvents: StateEvent[];
+  globalStateEvents: GlobalStateEvent[];
+  liquidityEvents: LiquidityEvent[];
+  events: Event[];
+};
+
+export class Event {
+  public readonly guid: GUID;
+
+  public readonly sequenceNumber: Uint64;
+
+  public readonly type: TypeTag;
+
+  public readonly fields: any;
+
+  constructor(event: EventJSON) {
+    this.guid = {
+      creationNumber: BigInt(event.guid.creation_number),
+      accountAddress: AccountAddress.from(event.guid.account_address),
+    };
+    this.sequenceNumber = BigInt(event.sequence_number);
+    this.type = parseTypeTag(event.type);
+    this.fields = event.data;
+  }
+
+  static fromJSON(event: EventJSON): Event | KnownEventType {
+    const eventType = parseTypeTag(event.type);
+    switch (eventType.toString()) {
+      case SwapEvent.STRUCT_STRING:
+        return new SwapEvent(event);
+      case ChatEvent.STRUCT_STRING:
+        return new ChatEvent(event);
+      case MarketRegistrationEvent.STRUCT_STRING:
+        return new MarketRegistrationEvent(event);
+      case PeriodicStateEvent.STRUCT_STRING:
+        return new PeriodicStateEvent(event);
+      case StateEvent.STRUCT_STRING:
+        return new StateEvent(event);
+      case GlobalStateEvent.STRUCT_STRING:
+        return new GlobalStateEvent(event);
+      case LiquidityEvent.STRUCT_STRING:
+        return new LiquidityEvent(event);
+      default:
+        return new Event(event);
+    }
+  }
+
+  toJSON(): any {
+    const d: Record<string, any> = {};
+    Object.keys(this.fields).forEach((field) => {
+      const val = this.fields[field as keyof typeof this.fields];
+      if (typeof val === "bigint") {
+        d[field] = val < Number.MAX_SAFE_INTEGER ? Number(val) : val.toString();
+      } else if (val instanceof AccountAddress) {
+        d[field] = val.toString();
+      } else if (val instanceof Uint8Array) {
+        d[field] = Array.from(val);
+      } else if (isMarketMetadata(val)) {
+        d[field] = {
+          marketId: val.marketId.toString(),
+          emojiBytes: val.emojiBytes.toString(),
+          marketAddress: val.marketAddress.toString(),
+        };
+      } else {
+        d[field] = val;
+      }
+    });
+    return d;
+  }
+}
+
+const EMOJICOIN_DOT_FUN_MODULE_ADDRESS = AccountAddress.from(process.env.MODULE_ADDRESS!);
+const EMOJICOIN_DOT_FUN_MODULE_NAME = process.env.EMOJICOIN_DOT_FUN_MODULE_NAME!;
+
+export type SwapEventFields = {
+  marketId: Uint64;
+  time: Uint64;
+  marketNonce: Uint64;
+  swapper: AccountAddress;
+  inputAmount: Uint64;
+  isSell: boolean;
+  integrator: AccountAddress;
+  integratorFeeRateBps: Uint8;
+  netProceeds: Uint64;
+  baseVolume: Uint64;
+  quoteVolume: Uint64;
+  avgExecutionPriceQ64: Uint128;
+  integratorFee: Uint64;
+  poolFee: Uint64;
+  startsInBondingCurve: boolean;
+  resultsInStateTransition: boolean;
+};
+
+export class SwapEvent extends Event {
+  public static readonly MODULE_ADDRESS = EMOJICOIN_DOT_FUN_MODULE_ADDRESS;
+
+  public static readonly MODULE_NAME = EMOJICOIN_DOT_FUN_MODULE_NAME;
+
+  public static readonly STRUCT_NAME = "Swap";
+
+  public static readonly STRUCT_STRING = knownEventTypeTagString(SwapEvent);
+
+  public readonly fields: SwapEventFields;
+
+  public constructor(event: EventJSON) {
+    super(event);
+    this.fields = {
+      marketId: BigInt(event.data.market_id),
+      time: BigInt(event.data.time),
+      marketNonce: BigInt(event.data.market_nonce),
+      swapper: AccountAddress.from(event.data.swapper),
+      inputAmount: BigInt(event.data.input_amount),
+      isSell: event.data.is_sell,
+      integrator: AccountAddress.from(event.data.integrator),
+      integratorFeeRateBps: Number(event.data.integrator_fee_rate_bps),
+      netProceeds: BigInt(event.data.net_proceeds),
+      baseVolume: BigInt(event.data.base_volume),
+      quoteVolume: BigInt(event.data.quote_volume),
+      avgExecutionPriceQ64: BigInt(event.data.avg_execution_price_q64),
+      integratorFee: BigInt(event.data.integrator_fee),
+      poolFee: BigInt(event.data.pool_fee),
+      startsInBondingCurve: event.data.starts_in_bonding_curve,
+      resultsInStateTransition: event.data.results_in_state_transition,
+    };
+  }
+}
+
+export type ChatEventFields = {
+  marketMetadata: MarketMetadata;
+  emitTime: Uint64;
+  emitMarketNonce: Uint64;
+  user: AccountAddress;
+  message: string;
+  userEmojicoinBbalance: Uint64;
+  circulatingSupply: Uint64;
+  balanceAsFractionOfCirculatingSupplyQ64: Uint128;
+};
+
+export class ChatEvent extends Event {
+  public static readonly MODULE_ADDRESS = EMOJICOIN_DOT_FUN_MODULE_ADDRESS;
+
+  public static readonly MODULE_NAME = EMOJICOIN_DOT_FUN_MODULE_NAME;
+
+  public static readonly STRUCT_NAME = "Chat";
+
+  public static readonly STRUCT_STRING = knownEventTypeTagString(ChatEvent);
+
+  public readonly fields: ChatEventFields;
+
+  public constructor(event: EventJSON) {
+    super(event);
+    this.fields = {
+      marketMetadata: toMarketMetadata(event.data.market_metadata),
+      emitTime: BigInt(event.data.emit_time),
+      emitMarketNonce: BigInt(event.data.emit_market_nonce),
+      user: AccountAddress.from(event.data.user),
+      message: event.data.message,
+      userEmojicoinBbalance: BigInt(event.data.user_emojicoin_balance),
+      circulatingSupply: BigInt(event.data.circulating_supply),
+      balanceAsFractionOfCirculatingSupplyQ64: BigInt(
+        event.data.balance_as_fraction_of_circulating_supply_q64
+      ),
+    };
+  }
+}
+
+export type MarketRegistrationEventFields = {
+  marketMetadata: MarketMetadata;
+  time: Uint64;
+  registrant: AccountAddress;
+  integrator: AccountAddress;
+  integratorFee: Uint64;
+};
+
+export class MarketRegistrationEvent extends Event {
+  public static readonly MODULE_ADDRESS = EMOJICOIN_DOT_FUN_MODULE_ADDRESS;
+
+  public static readonly MODULE_NAME = EMOJICOIN_DOT_FUN_MODULE_NAME;
+
+  public static readonly STRUCT_NAME = "MarketRegistration";
+
+  public static readonly STRUCT_STRING = knownEventTypeTagString(MarketRegistrationEvent);
+
+  public readonly fields: MarketRegistrationEventFields;
+
+  public constructor(event: EventJSON) {
+    super(event);
+    this.fields = {
+      marketMetadata: toMarketMetadata(event.data.market_metadata),
+      time: BigInt(event.data.time),
+      registrant: AccountAddress.from(event.data.registrant),
+      integrator: AccountAddress.from(event.data.integrator),
+      integratorFee: BigInt(event.data.integrator_fee),
+    };
+  }
+}
+
+export type PeriodicStateEventFields = {
+  marketMetadata: MarketMetadata;
+  periodicStateMetadata: PeriodicStateMetadata;
+  openPriceQ64: Uint128;
+  highPriceQ64: Uint128;
+  lowPriceQ64: Uint128;
+  closePriceQ64: Uint128;
+  volumeBase: Uint128;
+  volumeQuote: Uint128;
+  integratorFees: Uint128;
+  poolFeesBase: Uint128;
+  poolFeesQuote: Uint128;
+  nSwaps: Uint64;
+  nChatMessages: Uint64;
+  startsInBondingCurve: boolean;
+  endsInBondingCurve: boolean;
+  tvlPerLpCoinGrowthQ64: Uint128;
+};
+
+export class PeriodicStateEvent extends Event {
+  public static readonly MODULE_ADDRESS = EMOJICOIN_DOT_FUN_MODULE_ADDRESS;
+
+  public static readonly MODULE_NAME = EMOJICOIN_DOT_FUN_MODULE_NAME;
+
+  public static readonly STRUCT_NAME = "PeriodicState";
+
+  public static readonly STRUCT_STRING = knownEventTypeTagString(PeriodicStateEvent);
+
+  public readonly fields: PeriodicStateEventFields;
+
+  public constructor(event: EventJSON) {
+    super(event);
+    this.fields = {
+      marketMetadata: toMarketMetadata(event.data.market_metadata),
+      periodicStateMetadata: toPeriodicStateMetadata(event.data.periodic_state_metadata),
+      openPriceQ64: BigInt(event.data.open_price_q64),
+      highPriceQ64: BigInt(event.data.high_price_q64),
+      lowPriceQ64: BigInt(event.data.low_price_q64),
+      closePriceQ64: BigInt(event.data.close_price_q64),
+      volumeBase: BigInt(event.data.volume_base),
+      volumeQuote: BigInt(event.data.volume_quote),
+      integratorFees: BigInt(event.data.integrator_fees),
+      poolFeesBase: BigInt(event.data.pool_fees_base),
+      poolFeesQuote: BigInt(event.data.pool_fees_quote),
+      nSwaps: BigInt(event.data.n_swaps),
+      nChatMessages: BigInt(event.data.n_chat_messages),
+      startsInBondingCurve: event.data.starts_in_bonding_curve,
+      endsInBondingCurve: event.data.ends_in_bonding_curve,
+      tvlPerLpCoinGrowthQ64: BigInt(event.data.tvl_per_lp_coin_growth_q64),
+    };
+  }
+}
+
+export type StateEventFields = {
+  marketMetadata: MarketMetadata;
+  stateMetadata: StateMetadata;
+  clammVirtualReserves: Reserves;
+  cpammRealReserves: Reserves;
+  lpCoinSupply: Uint128;
+  cumulativeStats: CumulativeStats;
+  instantaneousStats: InstantaneousStats;
+  lastSwap: LastSwap;
+};
+
+export class StateEvent extends Event {
+  public static readonly MODULE_ADDRESS = EMOJICOIN_DOT_FUN_MODULE_ADDRESS;
+
+  public static readonly MODULE_NAME = EMOJICOIN_DOT_FUN_MODULE_NAME;
+
+  public static readonly STRUCT_NAME = "State";
+
+  public static readonly STRUCT_STRING = knownEventTypeTagString(StateEvent);
+
+  public readonly fields: StateEventFields;
+
+  public constructor(event: EventJSON) {
+    super(event);
+    this.fields = {
+      marketMetadata: toMarketMetadata(event.data.market_metadata),
+      stateMetadata: toStateMetadata(event.data.state_metadata),
+      clammVirtualReserves: toReserves(event.data.clamm_virtual_reserves),
+      cpammRealReserves: toReserves(event.data.cpamm_real_reserves),
+      lpCoinSupply: event.data.lp_coin_supply,
+      cumulativeStats: toCumulativeStats(event.data.cumulative_stats),
+      instantaneousStats: toInstantaneousStats(event.data.instantaneous_stats),
+      lastSwap: toLastSwap(event.data.last_swap),
+    };
+  }
+}
+
+export type GlobalStateEventFields = {
+  emitTime: Uint64;
+  registryNonce: Uint64;
+  trigger: Uint8;
+  cumulativeQuoteVolume: Uint128; // AggregatorSnapshot<Uint128>
+  totalQuoteLocked: Uint128; // AggregatorSnapshot<Uint128>
+  totalValueLocked: Uint128; // AggregatorSnapshot<Uint128>
+  marketCap: Uint128; // AggregatorSnapshot<Uint128>
+  fullyDilutedValue: Uint128; // AggregatorSnapshot<Uint128>
+  cumulativeIntegratorFees: Uint128; // AggregatorSnapshot<Uint128>
+  cumulativeSwaps: Uint64; // AggregatorSnapshot<Uint64>
+  cumulativeChatMessages: Uint64; // AggregatorSnapshot<Uint64>
+};
+
+export class GlobalStateEvent extends Event {
+  public static readonly MODULE_ADDRESS = EMOJICOIN_DOT_FUN_MODULE_ADDRESS;
+
+  public static readonly MODULE_NAME = EMOJICOIN_DOT_FUN_MODULE_NAME;
+
+  public static readonly STRUCT_NAME = "GlobalState";
+
+  public static readonly STRUCT_STRING = knownEventTypeTagString(GlobalStateEvent);
+
+  public readonly fields: GlobalStateEventFields;
+
+  public constructor(event: EventJSON) {
+    super(event);
+    this.fields = {
+      emitTime: BigInt(event.data.emit_time),
+      registryNonce: BigInt(event.data.registry_nonce),
+      trigger: Number(event.data.trigger),
+      cumulativeQuoteVolume: toAggregatorSnapshot(event.data.cumulative_quote_volume),
+      totalQuoteLocked: toAggregatorSnapshot(event.data.total_quote_locked),
+      totalValueLocked: toAggregatorSnapshot(event.data.total_value_locked),
+      marketCap: toAggregatorSnapshot(event.data.market_cap),
+      fullyDilutedValue: toAggregatorSnapshot(event.data.fully_diluted_value),
+      cumulativeIntegratorFees: toAggregatorSnapshot(event.data.cumulative_integrator_fees),
+      cumulativeSwaps: toAggregatorSnapshot(event.data.cumulative_swaps),
+      cumulativeChatMessages: toAggregatorSnapshot(event.data.cumulative_chat_messages),
+    };
+  }
+}
+
+export type LiquidityEventFields = {
+  marketId: Uint64;
+  time: Uint64;
+  marketNonce: Uint64;
+  provider: AccountAddress;
+  baseAmount: Uint64;
+  quoteAmount: Uint64;
+  lpCoinAmount: Uint64;
+  liquidityProvided: boolean;
+  proRataBaseDonationClaimAmount: Uint64;
+  proRataQuoteDonationClaimAmount: Uint64;
+};
+
+export class LiquidityEvent extends Event {
+  public static readonly MODULE_ADDRESS = EMOJICOIN_DOT_FUN_MODULE_ADDRESS;
+
+  public static readonly MODULE_NAME = EMOJICOIN_DOT_FUN_MODULE_NAME;
+
+  public static readonly STRUCT_NAME = "Liquidity";
+
+  public static readonly STRUCT_STRING = knownEventTypeTagString(LiquidityEvent);
+
+  public readonly fields: LiquidityEventFields;
+
+  public constructor(event: EventJSON) {
+    super(event);
+    this.fields = {
+      marketId: BigInt(event.data.market_id),
+      time: BigInt(event.data.time),
+      marketNonce: BigInt(event.data.market_nonce),
+      provider: AccountAddress.from(event.data.provider),
+      baseAmount: BigInt(event.data.base_amount),
+      quoteAmount: BigInt(event.data.quote_amount),
+      lpCoinAmount: BigInt(event.data.lp_coin_amount),
+      liquidityProvided: event.data.liquidity_provided,
+      proRataBaseDonationClaimAmount: BigInt(event.data.pro_rata_base_donation_claim_amount),
+      proRataQuoteDonationClaimAmount: BigInt(event.data.pro_rata_quote_donation_claim_amount),
+    };
+  }
+}

--- a/src/typescript/api/src/emojicoin_dot_fun/payload-builders.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/payload-builders.ts
@@ -232,7 +232,7 @@ export abstract class ViewFunctionPayloadBuilder<T extends Array<MoveValue>> {
       payload: entryFunction,
       options,
     });
-    return viewRequest;
+    return viewRequest as T;
   }
 
   argsToArray(): Array<EntryFunctionArgumentTypes> {

--- a/src/typescript/api/src/emojicoin_dot_fun/payload-builders.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/payload-builders.ts
@@ -112,12 +112,12 @@ export class EntryFunctionTransactionBuilder {
       additionalSignersAuthenticators: secondarySendersAuthenticators ?? [],
     });
 
-    const userTransactionResponse = await this.aptos.waitForTransaction({
+    const userTransactionResponse = (await this.aptos.waitForTransaction({
       transactionHash: pendingTransaction.hash,
       options,
-    });
+    })) as UserTransactionResponse;
 
-    return userTransactionResponse as UserTransactionResponse;
+    return userTransactionResponse;
   }
 
   /**

--- a/src/typescript/api/src/emojicoin_dot_fun/types.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/types.ts
@@ -8,7 +8,9 @@ import {
   type TypeTag,
 } from "@aptos-labs/ts-sdk";
 
-export type Option<T> = [T] | [];
+export type Option<T> = {
+  vec: [T] | [];
+};
 
 // Because the @aptos-labs/ts-sdk does not let you use a `number` for `Uint64`,
 // we coalesce the types here.

--- a/src/typescript/api/src/emojicoin_dot_fun/types.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/types.ts
@@ -1,6 +1,4 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
-
+/* eslint-disable import/no-unused-modules */
 import {
   type AccountAddress,
   type AccountAddressInput,

--- a/src/typescript/api/src/emojicoin_dot_fun/utils.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/utils.ts
@@ -8,7 +8,7 @@ import {
   type AptosConfig,
 } from "@aptos-labs/ts-sdk";
 import { sha3_256 } from "@noble/hashes/sha3";
-import { COIN_FACTORY_MODULE_NAME, EMOJICOIN_DOT_FUN_MODULE_NAME, MODULE_ADDRESS } from "./consts";
+import { EMOJICOIN_DOT_FUN_MODULE_NAME } from "./consts";
 
 /**
  * Sleep the current thread for the given amount of time

--- a/src/typescript/api/src/emojicoin_dot_fun/utils.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/utils.ts
@@ -8,7 +8,7 @@ import {
   type AptosConfig,
 } from "@aptos-labs/ts-sdk";
 import { sha3_256 } from "@noble/hashes/sha3";
-import { EMOJICOIN_DOT_FUN_MODULE_NAME } from "./consts";
+import { COIN_FACTORY_MODULE_NAME, EMOJICOIN_DOT_FUN_MODULE_NAME, MODULE_ADDRESS } from "./consts";
 
 /**
  * Sleep the current thread for the given amount of time

--- a/src/typescript/api/src/emojicoin_dot_fun/utils.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/utils.ts
@@ -6,9 +6,21 @@ import {
   type HexInput,
   DeriveScheme,
   type AptosConfig,
+  type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import { sha3_256 } from "@noble/hashes/sha3";
 import { EMOJICOIN_DOT_FUN_MODULE_NAME } from "./consts";
+import {
+  ChatEvent,
+  Event,
+  type Events,
+  GlobalStateEvent,
+  LiquidityEvent,
+  MarketRegistrationEvent,
+  PeriodicStateEvent,
+  StateEvent,
+  SwapEvent,
+} from "./events";
 
 /**
  * Sleep the current thread for the given amount of time
@@ -74,4 +86,48 @@ export async function getRegistryAddress(args: {
     resourceType: `${moduleAddress.toString()}::${EMOJICOIN_DOT_FUN_MODULE_NAME}::RegistryAddress`,
   });
   return registryAddressResource.registry_address;
+}
+
+export function getEvents(response: UserTransactionResponse): Events {
+  const events: Events = {
+    swapEvents: [],
+    chatEvents: [],
+    marketRegistrationEvents: [],
+    periodicStateEvents: [],
+    stateEvents: [],
+    globalStateEvents: [],
+    liquidityEvents: [],
+    events: [],
+  };
+
+  response.events.forEach((eventData) => {
+    const event = Event.fromJSON(eventData);
+    switch (event.type.toString()) {
+      case SwapEvent.STRUCT_STRING:
+        events.swapEvents.push(event as SwapEvent);
+        break;
+      case ChatEvent.STRUCT_STRING:
+        events.chatEvents.push(event as ChatEvent);
+        break;
+      case MarketRegistrationEvent.STRUCT_STRING:
+        events.marketRegistrationEvents.push(event as MarketRegistrationEvent);
+        break;
+      case PeriodicStateEvent.STRUCT_STRING:
+        events.periodicStateEvents.push(event as PeriodicStateEvent);
+        break;
+      case StateEvent.STRUCT_STRING:
+        events.stateEvents.push(event as StateEvent);
+        break;
+      case GlobalStateEvent.STRUCT_STRING:
+        events.globalStateEvents.push(event as GlobalStateEvent);
+        break;
+      case LiquidityEvent.STRUCT_STRING:
+        events.liquidityEvents.push(event as LiquidityEvent);
+        break;
+      default:
+        events.events.push(event as Event);
+        break;
+    }
+  });
+  return events;
 }

--- a/src/typescript/api/src/markets/coin-transfers.ts
+++ b/src/typescript/api/src/markets/coin-transfers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unused-modules */
 import {
   MoveVector,
   AccountAddress,

--- a/src/typescript/api/src/markets/coin-transfers.ts
+++ b/src/typescript/api/src/markets/coin-transfers.ts
@@ -1,0 +1,365 @@
+import {
+  MoveVector,
+  AccountAddress,
+  U64,
+  type AccountAddressInput,
+  type Uint64,
+  type AptosConfig,
+  type InputGenerateTransactionOptions,
+  buildTransaction,
+  Aptos,
+  type Account,
+  type WaitForTransactionOptions,
+  type UserTransactionResponse,
+  type TypeTag,
+  parseTypeTag,
+  type LedgerVersionArg,
+} from "@aptos-labs/ts-sdk";
+import {
+  EntryFunctionPayloadBuilder,
+  EntryFunctionTransactionBuilder,
+  ViewFunctionPayloadBuilder,
+} from "../emojicoin_dot_fun/payload-builders";
+import { type TypeTagInput } from "../emojicoin_dot_fun";
+
+export type MintPayloadMoveArguments = {
+  dstAddr: AccountAddress;
+  amount: U64;
+};
+
+/**
+ *```
+ *  public entry fun mint(
+ *     account: &signer,
+ *     dst_addr: address,
+ *     amount: u64,
+ *  )
+ *```
+ * */
+
+export class Mint extends EntryFunctionPayloadBuilder {
+  public readonly moduleAddress = AccountAddress.ONE;
+
+  public readonly moduleName = "aptos_coin";
+
+  public readonly functionName = "mint";
+
+  public readonly args: MintPayloadMoveArguments;
+
+  public readonly typeTags: [] = [];
+
+  public readonly primarySender: AccountAddress;
+
+  public readonly secondarySenders: [] = [];
+
+  public readonly feePayer?: AccountAddress;
+
+  private constructor(args: {
+    account: AccountAddressInput; // &signer
+    dstAddr: AccountAddressInput; // address
+    amount: Uint64; // u64
+    feePayer?: AccountAddressInput; // Optional fee payer account to pay gas fees.
+  }) {
+    super();
+    const { account, dstAddr, amount, feePayer } = args;
+    this.primarySender = AccountAddress.from(account);
+
+    this.args = {
+      dstAddr: AccountAddress.from(dstAddr),
+      amount: new U64(amount),
+    };
+    this.feePayer = feePayer !== undefined ? AccountAddress.from(feePayer) : undefined;
+  }
+
+  static async builder(args: {
+    aptosConfig: AptosConfig;
+    account: AccountAddressInput; // &signer
+    dstAddr: AccountAddressInput; // address
+    amount: Uint64; // u64
+    feePayer?: AccountAddressInput;
+    options?: InputGenerateTransactionOptions;
+  }): Promise<EntryFunctionTransactionBuilder> {
+    const { aptosConfig, options, feePayer } = args;
+    const payloadBuilder = new this(args);
+    const rawTransactionInput = await buildTransaction({
+      aptosConfig,
+      sender: payloadBuilder.primarySender,
+      payload: payloadBuilder.createPayload(),
+      options,
+      feePayerAddress: feePayer,
+    });
+    const aptos = new Aptos(aptosConfig);
+    return new EntryFunctionTransactionBuilder(payloadBuilder, aptos, rawTransactionInput);
+  }
+
+  static async submit(args: {
+    aptosConfig: AptosConfig;
+    account: Account; // &signer
+    dstAddr: AccountAddressInput; // address
+    amount: Uint64; // u64
+    feePayer?: Account;
+    options?: InputGenerateTransactionOptions;
+    waitForTransactionOptions?: WaitForTransactionOptions;
+  }): Promise<UserTransactionResponse> {
+    const { account: primarySigner, waitForTransactionOptions, feePayer } = args;
+
+    const transactionBuilder = await Mint.builder({
+      ...args,
+      feePayer: feePayer ? feePayer.accountAddress : undefined,
+      account: primarySigner.accountAddress,
+    });
+    const response = await transactionBuilder.submit({
+      primarySigner,
+      feePayer,
+      options: waitForTransactionOptions,
+    });
+    return response;
+  }
+}
+
+export type BatchTransferCoinsPayloadMoveArguments = {
+  recipients: MoveVector<AccountAddress>;
+  amounts: MoveVector<U64>;
+};
+
+/**
+ *```
+ *  public entry fun batch_transfer_coins<CoinType>(
+ *     from: &signer,
+ *     recipients: vector<address>,
+ *     amounts: vector<u64>,
+ *  )
+ *```
+ * */
+
+export class BatchTransferCoins extends EntryFunctionPayloadBuilder {
+  public readonly moduleAddress = AccountAddress.ONE;
+
+  public readonly moduleName = "aptos_account";
+
+  public readonly functionName = "batch_transfer_coins";
+
+  public readonly args: BatchTransferCoinsPayloadMoveArguments;
+
+  public readonly typeTags: [TypeTag]; // [CoinType]
+
+  public readonly primarySender: AccountAddress;
+
+  public readonly secondarySenders: [] = [];
+
+  public readonly feePayer?: AccountAddress;
+
+  private constructor(args: {
+    from: AccountAddressInput; // &signer
+    recipients: Array<AccountAddressInput>; // vector<address>
+    amounts: Array<Uint64>; // vector<u64>
+    typeTags: [TypeTagInput]; // [CoinType]
+    feePayer?: AccountAddressInput; // Optional fee payer account to pay gas fees.
+  }) {
+    super();
+    const { from, recipients, amounts, typeTags, feePayer } = args;
+    this.primarySender = AccountAddress.from(from);
+
+    this.args = {
+      recipients: new MoveVector(recipients.map((argA) => AccountAddress.from(argA))),
+      amounts: new MoveVector(amounts.map((argA) => new U64(argA))),
+    };
+    this.typeTags = typeTags.map((typeTag) =>
+      typeof typeTag === "string" ? parseTypeTag(typeTag) : typeTag
+    ) as [TypeTag];
+    this.feePayer = feePayer !== undefined ? AccountAddress.from(feePayer) : undefined;
+  }
+
+  static async builder(args: {
+    aptosConfig: AptosConfig;
+    from: AccountAddressInput; // &signer
+    recipients: Array<AccountAddressInput>; // vector<address>
+    amounts: Array<Uint64>; // vector<u64>
+    typeTags: [TypeTagInput]; // [CoinType],
+    feePayer?: AccountAddressInput;
+    options?: InputGenerateTransactionOptions;
+  }): Promise<EntryFunctionTransactionBuilder> {
+    const { aptosConfig, options, feePayer } = args;
+    const payloadBuilder = new this(args);
+    const rawTransactionInput = await buildTransaction({
+      aptosConfig,
+      sender: payloadBuilder.primarySender,
+      payload: payloadBuilder.createPayload(),
+      options,
+      feePayerAddress: feePayer,
+    });
+    const aptos = new Aptos(aptosConfig);
+    return new EntryFunctionTransactionBuilder(payloadBuilder, aptos, rawTransactionInput);
+  }
+
+  static async submit(args: {
+    aptosConfig: AptosConfig;
+    from: Account; // &signer
+    recipients: Array<AccountAddressInput>; // vector<address>
+    amounts: Array<Uint64>; // vector<u64>
+    typeTags: [TypeTagInput]; // [CoinType]
+    feePayer?: Account;
+    options?: InputGenerateTransactionOptions;
+    waitForTransactionOptions?: WaitForTransactionOptions;
+  }): Promise<UserTransactionResponse> {
+    const { from: primarySigner, waitForTransactionOptions, feePayer } = args;
+
+    const transactionBuilder = await BatchTransferCoins.builder({
+      ...args,
+      feePayer: feePayer ? feePayer.accountAddress : undefined,
+      from: primarySigner.accountAddress,
+    });
+    const response = await transactionBuilder.submit({
+      primarySigner,
+      feePayer,
+      options: waitForTransactionOptions,
+    });
+    return response;
+  }
+}
+
+export type TransferCoinsPayloadMoveArguments = {
+  to: AccountAddress;
+  amount: U64;
+};
+
+/**
+ *```
+ *  public entry fun transfer_coins<CoinType>(
+ *     from: &signer,
+ *     to: address,
+ *     amount: u64,
+ *  )
+ *```
+ * */
+
+export class TransferCoins extends EntryFunctionPayloadBuilder {
+  public readonly moduleAddress = AccountAddress.ONE;
+
+  public readonly moduleName = "aptos_account";
+
+  public readonly functionName = "transfer_coins";
+
+  public readonly args: TransferCoinsPayloadMoveArguments;
+
+  public readonly typeTags: [TypeTag]; // [CoinType]
+
+  public readonly primarySender: AccountAddress;
+
+  public readonly secondarySenders: [] = [];
+
+  public readonly feePayer?: AccountAddress;
+
+  private constructor(args: {
+    from: AccountAddressInput; // &signer
+    to: AccountAddressInput; // address
+    amount: Uint64; // u64
+    typeTags: [TypeTagInput]; // [CoinType]
+    feePayer?: AccountAddressInput; // Optional fee payer account to pay gas fees.
+  }) {
+    super();
+    const { from, to, amount, typeTags, feePayer } = args;
+    this.primarySender = AccountAddress.from(from);
+
+    this.args = {
+      to: AccountAddress.from(to),
+      amount: new U64(amount),
+    };
+    this.typeTags = typeTags.map((typeTag) =>
+      typeof typeTag === "string" ? parseTypeTag(typeTag) : typeTag
+    ) as [TypeTag];
+    this.feePayer = feePayer !== undefined ? AccountAddress.from(feePayer) : undefined;
+  }
+
+  static async builder(args: {
+    aptosConfig: AptosConfig;
+    from: AccountAddressInput; // &signer
+    to: AccountAddressInput; // address
+    amount: Uint64; // u64
+    typeTags: [TypeTagInput]; // [CoinType],
+    feePayer?: AccountAddressInput;
+    options?: InputGenerateTransactionOptions;
+  }): Promise<EntryFunctionTransactionBuilder> {
+    const { aptosConfig, options, feePayer } = args;
+    const payloadBuilder = new this(args);
+    const rawTransactionInput = await buildTransaction({
+      aptosConfig,
+      sender: payloadBuilder.primarySender,
+      payload: payloadBuilder.createPayload(),
+      options,
+      feePayerAddress: feePayer,
+    });
+    const aptos = new Aptos(aptosConfig);
+    return new EntryFunctionTransactionBuilder(payloadBuilder, aptos, rawTransactionInput);
+  }
+
+  static async submit(args: {
+    aptosConfig: AptosConfig;
+    from: Account; // &signer
+    to: AccountAddressInput; // address
+    amount: Uint64; // u64
+    typeTags: [TypeTagInput]; // [CoinType]
+    feePayer?: Account;
+    options?: InputGenerateTransactionOptions;
+    waitForTransactionOptions?: WaitForTransactionOptions;
+  }): Promise<UserTransactionResponse> {
+    const { from: primarySigner, waitForTransactionOptions, feePayer } = args;
+
+    const transactionBuilder = await TransferCoins.builder({
+      ...args,
+      feePayer: feePayer ? feePayer.accountAddress : undefined,
+      from: primarySigner.accountAddress,
+    });
+    const response = await transactionBuilder.submit({
+      primarySigner,
+      feePayer,
+      options: waitForTransactionOptions,
+    });
+    return response;
+  }
+}
+
+export type ExistsAtPayloadMoveArguments = {
+  addr: AccountAddress;
+};
+
+/**
+ *```
+ *  #[view]
+ *  public fun exists_at(
+ *     addr: address,
+ *  ): bool
+ *```
+ * */
+
+export class ExistsAt extends ViewFunctionPayloadBuilder<[boolean]> {
+  public readonly moduleAddress = AccountAddress.ONE;
+
+  public readonly moduleName = "account";
+
+  public readonly functionName = "exists_at";
+
+  public readonly args: ExistsAtPayloadMoveArguments;
+
+  public readonly typeTags: [] = [];
+
+  constructor(args: {
+    addr: AccountAddressInput; // address
+  }) {
+    super();
+    const { addr } = args;
+
+    this.args = {
+      addr: AccountAddress.from(addr),
+    };
+  }
+
+  static async view(args: {
+    aptos: Aptos | AptosConfig;
+    addr: AccountAddressInput; // address
+    options?: LedgerVersionArg;
+  }): Promise<boolean> {
+    const [res] = await new ExistsAt(args).view(args);
+    return res;
+  }
+}

--- a/src/typescript/api/src/markets/get-random-emoji.ts
+++ b/src/typescript/api/src/markets/get-random-emoji.ts
@@ -1,0 +1,41 @@
+import { Hex } from "@aptos-labs/ts-sdk";
+
+// If the `symbol_emojis.json` file is empty, please run:
+//
+//   cd <GIT_ROOT>/emojicoin/src/python/move_emojis
+//   poetry install && poetry run python -m scripts.generate_code
+//
+import emojiJsonData from "../../../../python/move_emojis/data/symbol_emojis.json";
+
+export type EmojiData = {
+  emoji: string;
+  version: string;
+  code_points: {
+    num_bytes: number;
+    as_unicode: Array<string>;
+    as_hex: Array<string>;
+  };
+};
+
+const EMOJI_JSON_DATA: Array<EmojiData> = Object.keys(emojiJsonData).map(
+  (k) => emojiJsonData[k as keyof typeof emojiJsonData]
+);
+const decoder = new TextDecoder("utf-8");
+
+
+export const getRandomEmoji = (): {
+    asActualEmoji: string;
+    emojiBytes: Uint8Array;
+} => {
+    let i = 0;
+    const randomIndex = Math.floor(EMOJI_JSON_DATA.length * Math.random());
+    const randomEmoji = EMOJI_JSON_DATA[randomIndex];
+    
+    const emoji = randomEmoji.code_points.as_hex.join("");
+    const emojiBytes = Hex.fromHexInput(emoji).toUint8Array();
+
+    return {
+      asActualEmoji: decoder.decode(emojiBytes),
+      emojiBytes,
+    };
+}

--- a/src/typescript/api/src/markets/get-random-emoji.ts
+++ b/src/typescript/api/src/markets/get-random-emoji.ts
@@ -5,9 +5,11 @@ import { Hex } from "@aptos-labs/ts-sdk";
 //   cd <GIT_ROOT>/emojicoin/src/python/move_emojis
 //   poetry install && poetry run python -m scripts.generate_code
 //
+// @ts-ignore
 import emojiJsonData from "../../../../python/move_emojis/data/symbol_emojis.json";
 
-export type EmojiData = {
+/* eslint-disable-next-line import/no-unused-modules */
+export type EmojiJSONData = {
   emoji: string;
   version: string;
   code_points: {
@@ -17,25 +19,23 @@ export type EmojiData = {
   };
 };
 
-const EMOJI_JSON_DATA: Array<EmojiData> = Object.keys(emojiJsonData).map(
+const EMOJI_JSON_DATA: Array<EmojiJSONData> = Object.keys(emojiJsonData).map(
   (k) => emojiJsonData[k as keyof typeof emojiJsonData]
 );
 const decoder = new TextDecoder("utf-8");
 
-
 export const getRandomEmoji = (): {
-    asActualEmoji: string;
-    emojiBytes: Uint8Array;
+  asActualEmoji: string;
+  emojiBytes: Uint8Array;
 } => {
-    let i = 0;
-    const randomIndex = Math.floor(EMOJI_JSON_DATA.length * Math.random());
-    const randomEmoji = EMOJI_JSON_DATA[randomIndex];
-    
-    const emoji = randomEmoji.code_points.as_hex.join("");
-    const emojiBytes = Hex.fromHexInput(emoji).toUint8Array();
+  const randomIndex = Math.floor(EMOJI_JSON_DATA.length * Math.random());
+  const randomEmoji = EMOJI_JSON_DATA[randomIndex];
 
-    return {
-      asActualEmoji: decoder.decode(emojiBytes),
-      emojiBytes,
-    };
-}
+  const emoji = randomEmoji.code_points.as_hex.join("");
+  const emojiBytes = Hex.fromHexInput(emoji).toUint8Array();
+
+  return {
+    asActualEmoji: decoder.decode(emojiBytes),
+    emojiBytes,
+  };
+};

--- a/src/typescript/api/src/markets/trader.ts
+++ b/src/typescript/api/src/markets/trader.ts
@@ -1,0 +1,275 @@
+/* eslint-disable no-console */
+
+import {
+  Account,
+  type UserTransactionResponse,
+  AccountAddress,
+  Ed25519PrivateKey,
+  APTOS_COIN,
+  Aptos,
+} from "@aptos-labs/ts-sdk";
+import { TextDecoder } from "util";
+import {
+  divideWithPrecision,
+  getEmojicoinMarketAddressAndTypeTags,
+  registerMarketAndGetEmojicoinInfo,
+  truncateAddress,
+} from "./utils";
+import {
+  ONE_APT,
+  QUOTE_VIRTUAL_CEILING,
+  getRegistryAddress,
+  getEvents,
+  QUOTE_VIRTUAL_FLOOR,
+} from "../emojicoin_dot_fun";
+import { getTestHelpers, publishForTest } from "../../tests/utils";
+import { MarketMetadataByEmojiBytes, MarketView, Swap } from "../emojicoin_dot_fun/emojicoin-dot-fun";
+import { BatchTransferCoins, ExistsAt, Mint } from "./batch_transfer";
+import { type Events } from "../emojicoin_dot_fun/events";
+import { getRandomEmoji } from "./get-random-emoji";
+import { EmojicoinInfo } from "../types/contract";
+
+const NUM_TRADERS = 500;
+const TRADERS: Array<Account> = Array.from({ length: NUM_TRADERS }, () => Account.generate());
+const CHUNK_SIZE = 50;
+const TRADER_INITIAL_BALANCE = ONE_APT * 10;
+const DISTRIBUTOR_NECESSARY_BALANCE = CHUNK_SIZE * TRADER_INITIAL_BALANCE;
+const MAX_U64 = 18446744073709551615n;
+const NUM_DISTRIBUTORS = NUM_TRADERS / CHUNK_SIZE;
+const MODULE_ADDRESS = AccountAddress.from(process.env.MODULE_ADDRESS!);
+const PUBLISHER = Account.fromPrivateKey({
+  privateKey: new Ed25519PrivateKey(process.env.PUBLISHER_PK!),
+});
+
+async function main() {
+  const { asActualEmoji, emojiBytes } = getRandomEmoji();
+  const { aptos } = getTestHelpers();
+
+  const registryAddress = await setupTest(aptos);
+
+  // Create distributors that will bear the sequence number for each transaction.
+  const distributors = Array.from({ length: NUM_DISTRIBUTORS }).map(() => Account.generate());
+
+  await fundTraders(aptos, distributors);
+  const { marketAddress, emojicoin, emojicoinLP } = await getOrRegisterMarket({
+    aptos,
+    emojiBytes,
+    registryAddress,
+    asActualEmoji,
+  });
+
+  console.log(`Market address: ${marketAddress}`);
+  console.log(`Emojicoin TypeTag: ${emojicoin.toString()}`);
+  console.log(`EmojicoinLP TypeTag: ${emojicoinLP.toString()}`);
+
+  // Each trade is a buy for some amount between 50% and 100% of their APT balance.
+  const amount = Math.floor(TRADER_INITIAL_BALANCE * (0.5 + Math.random() * 0.5));
+  // All buys.
+  const isSell = false;
+
+  // Await each chunk of traders trading.
+  for (let i = 0; i <= NUM_TRADERS / CHUNK_SIZE; i += 1) {
+    console.log(
+      `-----------------------------------BATCH ${i}-----------------------------------`
+    );
+    const tradersChunk = TRADERS.slice(CHUNK_SIZE * i, (i + 1) * CHUNK_SIZE);
+    const trades = tradersChunk.map((t) => {
+      try {
+        const randIdx = Math.floor(Math.random() * distributors.length);
+
+        const swap = Swap.submit({
+          aptosConfig: aptos.config,
+          marketAddress,
+          swapper: t,
+          inputAmount: amount,
+          isSell,
+          integrator: PUBLISHER.accountAddress,
+          integratorFeeRateBps: 0,
+          typeTags: [emojicoin, emojicoinLP],
+          feePayer: distributors[randIdx],
+          waitForTransactionOptions: {
+            checkSuccess: true,
+            waitForIndexer: false,
+            timeoutSecs: 20,
+          },
+        });
+        return swap.then((res) => {
+          const events = getEvents(res);
+          return [res, events];
+        });
+      } catch (e) {
+        return undefined;
+      }
+    });
+
+    const tradeResults = (await Promise.all(trades))
+      .filter((v): v is [UserTransactionResponse, Events] => typeof v !== "undefined")
+      .sort((tx_a, tx_b) => {
+        const a = Number(tx_a[0].version);
+        const b = Number(tx_b[0].version);
+        return a - b;
+      });
+
+    tradeResults.forEach((tx) => {
+      const [res, events] = tx;
+      const state = events.stateEvents[0] ? events.stateEvents[0].fields : null;
+      const swap = events.swapEvents[0] ? events.swapEvents[0].fields : null;
+      if (state && swap) {
+        const textDecoder = new TextDecoder("utf-8");
+        const emoji = textDecoder.decode(state.marketMetadata.emojiBytes.toUint8Array());
+        const aptSpent = divideWithPrecision({
+          a: state.clammVirtualReserves.quote - QUOTE_VIRTUAL_FLOOR,
+          b: ONE_APT,
+          decimals: 3,
+        }).toFixed(3);
+        const quoteLeftBeforeTransition = divideWithPrecision({
+          a: QUOTE_VIRTUAL_CEILING - state.clammVirtualReserves.quote,
+          b: BigInt(ONE_APT),
+          decimals: 3,
+        }).toFixed(3);
+        const s =
+          `Trade for ${swap.swapper.toString()} completed for emoji market: ${emoji}` +
+          ` with market ID: ${state.marketMetadata.marketId}` +
+          ` at version: ${Number(res.version)}. ${
+            !swap.resultsInStateTransition
+              ? `${aptSpent} APT spent on bonding curve. ${quoteLeftBeforeTransition} to go before the bonding curve ends!`
+              : "We're already in the CPAMM!"
+          }`;
+        console.debug(s);
+      }
+      const outOfBondingCurve = events.swapEvents.some((event) => event.fields.resultsInStateTransition);
+
+      if (outOfBondingCurve) {
+        console.log(`${res.sender.toString()} pushed us out of the bonding curve! Transaction hash: ${res.hash}`);
+      }
+    });
+  }
+
+  // View the current state of the market after all trades.
+  const res = await MarketView.view({
+    aptos,
+    marketAddress,
+    typeTags: [emojicoin, emojicoinLP],
+  });
+;
+  console.log("Market data:");
+  console.log(res);
+
+  return;
+}
+
+// --------------------------------------------------------------------------------------
+//                              Setup and helper functions
+// --------------------------------------------------------------------------------------
+
+const setupTest = async(aptos: Aptos): Promise<AccountAddress> => {
+  // Fund the publisher account if it doesn't exist yet.
+  const fundIfExists = (ExistsAt.view({ aptos, addr: PUBLISHER.accountAddress }).then((exists) => {
+    if (!exists) {
+      console.log("Publisher account doesn't exist yet. Funding...");
+      return aptos.fundAccount({ accountAddress: PUBLISHER.accountAddress, amount: ONE_APT });
+    }
+  }));
+  await fundIfExists;
+
+  // Fund the publisher account with a large amount of APT.
+  const publisherBalance = await aptos.account.getAccountAPTAmount({
+    accountAddress: PUBLISHER.accountAddress,
+  });
+
+  const maxFundAmount = MAX_U64 - BigInt(publisherBalance);
+  if (maxFundAmount > 0) {
+    try {
+      await Mint.submit({
+        aptosConfig: aptos.config,
+        account: PUBLISHER,
+        dstAddr: PUBLISHER.accountAddress,
+        amount: maxFundAmount,
+      });
+      console.log("Funded publisher account.");
+    } catch (e) {
+      console.error(e);
+      console.error(
+        "Failed to fund publisher. Is the Aptos framework using a custom mint function?"
+      );
+    }
+  }
+
+  try {
+    return await getRegistryAddress({ aptos, moduleAddress: MODULE_ADDRESS });
+  } catch (e) {
+    // Not published yet, let's publish.
+    await publishForTest(PUBLISHER.privateKey.toString());
+    return await getRegistryAddress({ aptos, moduleAddress: MODULE_ADDRESS });
+  }
+}
+
+const getOrRegisterMarket = async ({
+  aptos,
+  emojiBytes,
+  registryAddress,
+  asActualEmoji,
+}: {
+  aptos: Aptos;
+  emojiBytes: Uint8Array;
+  registryAddress: AccountAddress;
+  asActualEmoji: string;
+}): Promise<EmojicoinInfo> => {
+  const emojicoinInfo = await MarketMetadataByEmojiBytes.view({
+    aptos,
+    emojiBytes,
+  }).then((res) => {
+    if (res.vec.pop()) {
+      console.log(`Market already exists for emoji: ${asActualEmoji}`);
+      return getEmojicoinMarketAddressAndTypeTags({
+        registryAddress,
+        symbolBytes: emojiBytes,
+      });
+    }
+    return registerMarketAndGetEmojicoinInfo({
+      aptos,
+      registryAddress,
+      emojis: [emojiBytes],
+      sender: PUBLISHER,
+      integrator: PUBLISHER.accountAddress,
+    });
+  });
+
+  return emojicoinInfo;
+}
+
+const fundTraders = async (aptos: Aptos, distributors: Account[]) => {
+  await BatchTransferCoins.submit({
+    aptosConfig: aptos.config,
+    from: PUBLISHER,
+    recipients: distributors.map((d) => d.accountAddress),
+    amounts: distributors.map((_) => BigInt(DISTRIBUTOR_NECESSARY_BALANCE + ONE_APT)),
+    typeTags: [APTOS_COIN],
+  }).then((res) => console.log("Distributed coins to distributors. tx version:", res.version));
+
+  const fundTraderResults: Array<Promise<UserTransactionResponse>> = [];
+  for (let i = 0; i < NUM_TRADERS / CHUNK_SIZE; i += 1) {
+    const chunk = TRADERS.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
+    const res = BatchTransferCoins.submit({
+      aptosConfig: aptos.config,
+      from: distributors[i],
+      recipients: chunk.map((t) => t.accountAddress),
+      amounts: chunk.map((t) => BigInt(TRADER_INITIAL_BALANCE)),
+      feePayer: distributors[i],
+      typeTags: [APTOS_COIN],
+    });
+
+    const addr = truncateAddress(distributors[i].accountAddress.toString());
+
+    console.log(`Funding ${CHUNK_SIZE} traders with distributor[${i}]... => ${addr}`);
+    res.then((r) => console.log(`Funding complete! version: ${r.version}: ${i}`));
+    fundTraderResults.push(res);
+  }
+
+  const res = await Promise.all(fundTraderResults);
+  console.log(`Distributed coins to all ${TRADERS.length} traders`);
+
+  return res;
+}
+
+main();

--- a/src/typescript/api/src/markets/utils.ts
+++ b/src/typescript/api/src/markets/utils.ts
@@ -76,3 +76,21 @@ export const registerMarketAndGetEmojicoinInfo = async (args: {
 
   return { marketAddress, emojicoin, emojicoinLP };
 };
+
+export const divideWithPrecision = (args: {
+  a: bigint | number;
+  b: bigint | number;
+  decimals?: number;
+}): number => {
+  const decimals = args.decimals ?? 3;
+  const a = BigInt(args.a);
+  const b = BigInt(args.b);
+  const f = BigInt(10 ** decimals);
+  return Number((a * f) / b) / Number(f);
+};
+
+export const truncateAddress = (input: AccountAddressInput): string => {
+  const t = AccountAddress.from(input);
+  const s = t.toString();
+  return `${s.substring(0, 6)}...${s.substring(s.length - 4, s.length)}`;
+};

--- a/src/typescript/api/src/types/contract.ts
+++ b/src/typescript/api/src/types/contract.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unused-modules */
 import {
   AccountAddress,
   type AccountAddressInput,
@@ -10,9 +11,30 @@ import {
   type Uint8,
 } from "@aptos-labs/ts-sdk";
 import { type ExtendRef, type SequenceInfo } from "./core";
-import { EMOJICOIN_DOT_FUN_MODULE_NAME, MODULE_ADDRESS } from "../emojicoin_dot_fun";
+import { EMOJICOIN_DOT_FUN_MODULE_NAME, MODULE_ADDRESS } from "../emojicoin_dot_fun/consts";
 
 // Structs specific to `emojicoin_dot_fun`.
+
+export const isMarketMetadata = (v: any): v is MarketMetadata =>
+  typeof v.marketId === "bigint" &&
+  v.marketAddress instanceof AccountAddress &&
+  v.emojiBytes instanceof Hex;
+
+export type MarketMetadata = {
+  marketId: Uint64;
+  marketAddress: AccountAddress;
+  emojiBytes: Hex;
+};
+
+export const toMarketMetadata = (data: {
+  market_id: string;
+  market_address: string;
+  emoji_bytes: string;
+}): MarketMetadata => ({
+  marketId: BigInt(data.market_id),
+  marketAddress: AccountAddress.from(data.market_address),
+  emojiBytes: Hex.fromHexString(data.emoji_bytes),
+});
 
 export type MarketResource = {
   metadata: MarketMetadata;
@@ -103,27 +125,6 @@ export type EmojicoinInfo = {
   emojicoinLP: TypeTag;
 };
 
-export const isMarketMetadata = (v: any): v is MarketMetadata =>
-  typeof v.marketId === "bigint" &&
-  v.marketAddress instanceof AccountAddress &&
-  v.emojiBytes instanceof Hex;
-
-export type MarketMetadata = {
-  marketId: Uint64;
-  marketAddress: AccountAddress;
-  emojiBytes: Hex;
-};
-
-export const toMarketMetadata = (data: {
-  market_id: string;
-  market_address: string;
-  emoji_bytes: string;
-}): MarketMetadata => ({
-  marketId: BigInt(data.market_id),
-  marketAddress: AccountAddress.from(data.market_address),
-  emojiBytes: Hex.fromHexString(data.emoji_bytes),
-});
-
 export const toPeriodicStateMetadata = (data: {
   start_time: string;
   period: string;
@@ -177,7 +178,7 @@ export type LastSwap = {
 
 export type SupportedAggregatorSnapshotTypes = Uint64 | Uint128;
 
-export type AggregatorSnapshot<SupportedAggregatorSnapshotTypes> = {
+export type AggregatorSnapshot = {
   value: SupportedAggregatorSnapshotTypes;
 };
 

--- a/src/typescript/api/src/types/core.ts
+++ b/src/typescript/api/src/types/core.ts
@@ -1,4 +1,4 @@
-import { type AccountAddress, type Uint64 } from "@aptos-labs/ts-sdk";
+import { type EventGuid, type AccountAddress, type Uint64 } from "@aptos-labs/ts-sdk";
 
 export type SequenceInfo = {
   nonce: Uint64;
@@ -7,4 +7,12 @@ export type SequenceInfo = {
 
 export type ExtendRef = {
   self: AccountAddress;
+};
+
+// JSON representation of the Event data from a UserTransactionResponse.
+export type EventJSON = {
+  guid: EventGuid;
+  sequence_number: string;
+  type: string;
+  data: any;
 };

--- a/src/typescript/api/src/types/index.ts
+++ b/src/typescript/api/src/types/index.ts
@@ -1,2 +1,0 @@
-export * from "./contract";
-export * from "./core";

--- a/src/typescript/api/tests/e2e/register.test.ts
+++ b/src/typescript/api/tests/e2e/register.test.ts
@@ -73,12 +73,12 @@ describe("registers a market successfully", () => {
     });
 
     const {
-      market_id: marketId,
-      market_address: marketAddress,
-      emoji_bytes: emojiBytes,
+      marketId,
+      marketAddress,
+      emojiBytes,
     } = marketObjectMarketResource.metadata;
 
-    const { lp_coin_supply: lpCoinSupply, extend_ref: extendRef } = marketObjectMarketResource;
+    const { lpCoinSupply, extendRef } = marketObjectMarketResource;
 
     expect(marketId).toEqual(1n);
     expect(emojiBytes.toString()).toEqual(`0x${emojis[0]}${emojis[1]}`);

--- a/src/typescript/api/tests/e2e/register.test.ts
+++ b/src/typescript/api/tests/e2e/register.test.ts
@@ -72,11 +72,7 @@ describe("registers a market successfully", () => {
       objectAddress: derivedNamedObjectAddress,
     });
 
-    const {
-      marketId,
-      marketAddress,
-      emojiBytes,
-    } = marketObjectMarketResource.metadata;
+    const { marketId, marketAddress, emojiBytes } = marketObjectMarketResource.metadata;
 
     const { lpCoinSupply, extendRef } = marketObjectMarketResource;
 

--- a/src/typescript/api/tests/utils/publish.ts
+++ b/src/typescript/api/tests/utils/publish.ts
@@ -116,10 +116,10 @@ export async function publishForTest(pk: string): Promise<PublishPackageResult> 
 
   const APT_REQUIRED_FOR_TESTS = 4;
   while (publisherBalance < APT_REQUIRED_FOR_TESTS * ONE_APT) {
+    /* eslint-disable-next-line no-await-in-loop */
     await aptos.fundAccount({ accountAddress: publisher.accountAddress, amount: ONE_APT });
     publisherBalance += ONE_APT;
   }
-
   const moduleName = EMOJICOIN_DOT_FUN_MODULE_NAME;
   const packageName = moduleName;
   return publishPackage({

--- a/src/typescript/api/tests/utils/publish.ts
+++ b/src/typescript/api/tests/utils/publish.ts
@@ -110,10 +110,15 @@ export async function publishForTest(pk: string): Promise<PublishPackageResult> 
     privateKey: new Ed25519PrivateKey(Hex.fromHexString(pk).toUint8Array()),
   });
 
-  await aptos.fundAccount({ accountAddress: publisher.accountAddress, amount: ONE_APT });
-  await aptos.fundAccount({ accountAddress: publisher.accountAddress, amount: ONE_APT });
-  await aptos.fundAccount({ accountAddress: publisher.accountAddress, amount: ONE_APT });
-  await aptos.fundAccount({ accountAddress: publisher.accountAddress, amount: ONE_APT });
+  let publisherBalance = await aptos.account
+    .getAccountAPTAmount({ accountAddress: publisher.accountAddress })
+    .catch((_) => 0);
+
+  const APT_REQUIRED_FOR_TESTS = 4;
+  while (publisherBalance < APT_REQUIRED_FOR_TESTS * ONE_APT) {
+    await aptos.fundAccount({ accountAddress: publisher.accountAddress, amount: ONE_APT });
+    publisherBalance += ONE_APT;
+  }
 
   const moduleName = EMOJICOIN_DOT_FUN_MODULE_NAME;
   const packageName = moduleName;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Most changes are in `src/typescript/api/src`

 - [x] Add event types
 - [x] Convert event types to camelCase TypeScript types
 - [x] Add Event parsing helper functions in `events.ts`
 - [x] Add more account derivation/emojicoin data helper utility functions in `emojicoin_dot_fun/utils.ts`
 - [x] Most of the types are in `types/contract.ts` and `types/core.ts`

Also adds the basic mock data buy script in `markets/trade.ts`, creates hundreds of traders, funds them, and has them all buy the same coin. Easiest way to run it is with:

```shell
npx tsx markets/trade.ts
```

# Testing

Updated `register.test.ts` to reflect new type names.

```shell
pnpm jest
```

# Checklist

- [x] ~Did you update relevant documentation?~
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] ~Did you update the changelog?~
- [x] Did you check off all checkboxes from the linked Linear task?
