### PR TITLE
[ECO-1661] Test provide/remove liquidity operations to 100% coverage

### DIFF
--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -1244,7 +1244,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
 
         // Get FDV, market cap, at start and end of operation, update global stats accordingly.
         let (fdv_start, market_cap_start, fdv_end, market_cap_end) =
-            fdv_market_cap_start_end(reserves_start, *reserves_ref_mut,EMOJICOIN_SUPPLY);
+            fdv_market_cap_start_end(reserves_start, *reserves_ref_mut, EMOJICOIN_SUPPLY);
         update_global_fdv_market_cap_for_liquidity_operation(
             fdv_start,
             market_cap_start,

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2456,6 +2456,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     #[test_only] public fun get_TRIGGER_SWAP_BUY(): u8 { TRIGGER_SWAP_BUY }
     #[test_only] public fun get_TRIGGER_SWAP_SELL(): u8 { TRIGGER_SWAP_SELL }
     #[test_only] public fun get_TRIGGER_PROVIDE_LIQUIDITY(): u8 { TRIGGER_PROVIDE_LIQUIDITY }
+    #[test_only] public fun get_TRIGGER_REMOVE_LIQUIDITY(): u8 { TRIGGER_REMOVE_LIQUIDITY }
     #[test_only] public fun get_QUOTE_REAL_CEILING(): u64 { QUOTE_REAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_CEILING(): u64 { QUOTE_VIRTUAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_FLOOR(): u64 { QUOTE_VIRTUAL_FLOOR }

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -840,8 +840,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     }
 
     public entry fun swap<Emojicoin, EmojicoinLP>(
-        market_address: address,
         swapper: &signer,
+        market_address: address,
         input_amount: u64,
         is_sell: bool,
         integrator: address,
@@ -1111,8 +1111,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     }
 
     public entry fun provide_liquidity<Emojicoin, EmojicoinLP>(
-        market_address: address,
         provider: &signer,
+        market_address: address,
         quote_amount: u64,
     ) acquires LPCoinCapabilities, Market, Registry, RegistryAddress {
 
@@ -1188,8 +1188,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     }
 
     public entry fun remove_liquidity<Emojicoin, EmojicoinLP>(
-        market_address: address,
         provider: &signer,
+        market_address: address,
         lp_coin_amount: u64,
     ) acquires LPCoinCapabilities, Market, Registry, RegistryAddress {
 

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -1242,10 +1242,9 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         aggregator_v2::try_sub(global_total_quote_locked_ref_mut, (event.quote_amount as u128));
         aggregator_v2::try_sub(global_total_value_locked_ref_mut, delta_tvl);
 
-        // Get FDV, market cap, at start and end of operation.
+        // Get FDV, market cap, at start and end of operation, update global stats accordingly.
         let (fdv_start, market_cap_start, fdv_end, market_cap_end) =
             fdv_market_cap_start_end(reserves_start, *reserves_ref_mut,EMOJICOIN_SUPPLY);
-
         update_global_fdv_market_cap_for_liquidity_operation(
             fdv_start,
             market_cap_start,

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -1461,8 +1461,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
 
     #[view]
     public fun simulate_swap(
-        market_address: address,
         swapper: address,
+        market_address: address,
         input_amount: u64,
         is_sell: bool,
         integrator: address,
@@ -1482,8 +1482,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
 
     #[view]
     public fun simulate_provide_liquidity(
-        market_address: address,
         provider: address,
+        market_address: address,
         quote_amount: u64,
     ): Liquidity
     acquires Market {
@@ -1497,8 +1497,8 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
 
     #[view]
     public fun simulate_remove_liquidity<Emojicoin>(
-        market_address: address,
         provider: address,
+        market_address: address,
         lp_coin_amount: u64,
     ): Liquidity
     acquires Market {

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2303,10 +2303,10 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     }
 
     #[test_only] public fun fdv_market_cap_test_only(
-        real_reserves: Reserves,
-        emojicoin_supply: u64,
+        reserves: Reserves,
+        supply_minuend: u64,
     ): (u128, u128) {
-        fdv_market_cap(real_reserves, emojicoin_supply)
+        fdv_market_cap(reserves, supply_minuend)
     }
 
     #[test_only] public fun get_bps_fee_test_only(

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -1556,6 +1556,44 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         (is_sell, avg_execution_price_q64, base_volume, quote_volume, nonce, time)
     }
 
+    public fun unpack_liquidity(liquidity: Liquidity): (
+        u64,
+        u64,
+        u64,
+        address,
+        u64,
+        u64,
+        u64,
+        bool,
+        u64,
+        u64,
+    ) {
+        let Liquidity {
+            market_id,
+            time,
+            market_nonce,
+            provider,
+            base_amount,
+            quote_amount,
+            lp_coin_amount,
+            liquidity_provided,
+            pro_rata_base_donation_claim_amount,
+            pro_rata_quote_donation_claim_amount,
+        } = liquidity;
+        (
+            market_id,
+            time,
+            market_nonce,
+            provider,
+            base_amount,
+            quote_amount,
+            lp_coin_amount,
+            liquidity_provided,
+            pro_rata_base_donation_claim_amount,
+            pro_rata_quote_donation_claim_amount,
+        )
+    }
+
     public fun unpack_market_metadata(metadata: MarketMetadata): (
         u64,
         address,
@@ -2359,6 +2397,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     #[test_only] public fun get_TRIGGER_PACKAGE_PUBLICATION(): u8 { TRIGGER_PACKAGE_PUBLICATION }
     #[test_only] public fun get_TRIGGER_SWAP_BUY(): u8 { TRIGGER_SWAP_BUY }
     #[test_only] public fun get_TRIGGER_SWAP_SELL(): u8 { TRIGGER_SWAP_SELL }
+    #[test_only] public fun get_TRIGGER_PROVIDE_LIQUIDITY(): u8 { TRIGGER_PROVIDE_LIQUIDITY }
     #[test_only] public fun get_QUOTE_REAL_CEILING(): u64 { QUOTE_REAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_CEILING(): u64 { QUOTE_VIRTUAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_FLOOR(): u64 { QUOTE_VIRTUAL_FLOOR }

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -2510,8 +2510,9 @@
         let (base, quote) = unpack_reserves(cpamm_real_reserves);
         let cpamm_real_reserves = MockReserves { base, quote };
 
-        // Declare new amount of quote to provide.
-        let quote_amount = SIMPLE_BUY_INPUT_AMOUNT / 10;
+        // Declare an arbitrary amount of quote to provide: a fraction of the amount of quote
+        // required to exit the bonding curve.
+        let quote_amount = get_QUOTE_REAL_CEILING() / 10;
 
         // Get base amount, for truncation present during proportion calculation.
         let proportion_numerator =
@@ -2520,7 +2521,12 @@
         assert!(proportion_numerator % proportion_denominator != 0, 0);
         let base_amount = ((proportion_numerator / proportion_denominator) as u64) + 1;
 
-        // Determine amount of liquidity tokens provided.
+        // Determine amount of liquidity provider coins provided, such that the proportion of new
+        // LP coins to preexisting LP coins is the same as the proportion of quote input to
+        // preexisting locked quote:
+        //
+        // l_out / l_old = q_in / q_old
+        // l_out = q_in * l_old / q_old
         let lp_coin_amount = ((
             (quote_amount as u128) * (get_LP_TOKENS_INITIAL() as u128) /
             (cpamm_real_reserves.quote as u128)

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -2810,13 +2810,27 @@
     }
 
     #[test] fun tvl_clamm_expected() {
-        // Verify TVL with market having no quote above virtual floor.
         assert_tvl_clamm(
             MockReserves{
                 base: get_BASE_VIRTUAL_CEILING(),
                 quote: get_QUOTE_VIRTUAL_FLOOR(),
             },
             0,
+        );
+
+        let base_out = 10;
+        let quote_in = 50;
+        let reserves = MockReserves{
+            base: get_BASE_VIRTUAL_CEILING() - base_out,
+            quote: get_QUOTE_VIRTUAL_FLOOR() + quote_in,
+        };
+        let base_real_in_bonding_curve = get_BASE_REAL_CEILING() - base_out;
+        let base_locked = base_real_in_bonding_curve + get_EMOJICOIN_REMAINDER();
+        let base_denominated_in_quote =
+            ((base_locked as u128) * (reserves.quote as u128)) / (reserves.base as u128);
+        assert_tvl_clamm(
+            reserves,
+            (quote_in as u128) + base_denominated_in_quote,
         );
     }
 

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -487,6 +487,17 @@
         assert!(coin::name<EmojicoinLP>() == lp_name, 0);
     }
 
+    public fun assert_fdv_market_cap(
+        mock_reserves: MockReserves,
+        supply_minuend: u64,
+        fdv_expected: u128,
+        market_cap_expected: u128
+    ) {
+        let (fdv, market_cap) = fdv_market_cap(pack_mock_reserves(mock_reserves), supply_minuend);
+        assert!(fdv == fdv_expected, 0);
+        assert!(market_cap == market_cap_expected, 0);
+    }
+
     public fun assert_global_state(
         mock_global_state: MockGlobalState,
         global_state: GlobalState

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -539,11 +539,11 @@
 
     public fun assert_fdv_market_cap(
         mock_reserves: MockReserves,
-        supply_minued: u64,
+        supply_minuend: u64,
         fdv_expected: u128,
         market_cap_expected: u128,
     ) {
-        let (fdv, market_cap) = fdv_market_cap(pack_mock_reserves(mock_reserves), supply_minued);
+        let (fdv, market_cap) = fdv_market_cap(pack_mock_reserves(mock_reserves), supply_minuend);
         assert!(fdv == fdv_expected, 0);
         assert!(market_cap == market_cap_expected, 0);
     }
@@ -2513,7 +2513,7 @@
         // Declare new amount of quote to provide.
         let quote_amount = SIMPLE_BUY_INPUT_AMOUNT / 10;
 
-        // Get base amount, for trunction present during proportion calculation.
+        // Get base amount, for truncation present during proportion calculation.
         let proportion_numerator =
             (cpamm_real_reserves.base as u128) * (quote_amount as u128);
         let proportion_denominator = (cpamm_real_reserves.quote as u128);
@@ -2567,7 +2567,7 @@
         // Determine amount of quote to provide.
         let quote_amount = get_QUOTE_REAL_CEILING() / 10;
 
-        // Get base amount, for no trunction during proportion calculation.
+        // Get base amount, for no truncation during proportion calculation.
         let proportion_numerator =
             (setup_market_view.cpamm_real_reserves.base as u128) * (quote_amount as u128);
         let proportion_denominator = (setup_market_view.cpamm_real_reserves.quote as u128);

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -1520,8 +1520,8 @@
         mint_aptos_coin_to(USER, input_amount);
         let integrator_fee_rate_bps = 0;
         swap<Emojicoin, EmojicoinLP>(
-            address_for_registered_market_by_emoji_bytes(emoji_bytes),
             &get_signer(USER),
+            address_for_registered_market_by_emoji_bytes(emoji_bytes),
             input_amount,
             SWAP_BUY,
             INTEGRATOR,
@@ -1549,8 +1549,8 @@
             EXACT_TRANSITION_INTEGRATOR_FEE_RATE_BPS,
         );
         swap<BlackCatEmojicoin, BlackCatEmojicoinLP>(
-            market_address,
             &get_signer(EXACT_TRANSITION_USER),
+            market_address,
             EXACT_TRANSITION_INPUT_AMOUNT,
             SWAP_BUY,
             EXACT_TRANSITION_INTEGRATOR,
@@ -1574,8 +1574,8 @@
             SIMPLE_BUY_INTEGRATOR_FEE_RATE_BPS,
         );
         swap<BlackCatEmojicoin, BlackCatEmojicoinLP>(
-            market_address,
             &get_signer(SIMPLE_BUY_USER),
+            market_address,
             SIMPLE_BUY_INPUT_AMOUNT,
             SWAP_BUY,
             SIMPLE_BUY_INTEGRATOR,
@@ -1673,8 +1673,8 @@
             INTEGRATOR_FEE_RATE_BPS,
         );
         swap<BlackCatEmojicoin, BlackCatEmojicoinLP>(
-            market_address,
             &get_signer(USER),
+            market_address,
             flow.input_amount,
             flow.is_sell,
             INTEGRATOR,
@@ -2466,7 +2466,7 @@
         timestamp::update_global_time_for_test(time);
 
         // Determine amount of quote to provide.
-        let quote_amount = get_QUOTE_REAL_CEILING() / 1_000;
+        let quote_amount = 123_456;
 
         // Get base amount, for no trunction during proportion calculation.
         let proportion_numerator =
@@ -2496,8 +2496,8 @@
             quote_amount
         );
         provide_liquidity<BlackCatEmojicoin, BlackCatEmojicoinLP>(
-            market_address,
             &get_signer(USER),
+            market_address,
             quote_amount,
         );
 
@@ -3018,8 +3018,8 @@
     )] fun swap_no_base() {
         init_package_then_simple_buy();
         swap<BlackCatEmojicoin, BlackCatEmojicoinLP>(
-            base_market_metadata().market_address,
             &get_signer(USER),
+            base_market_metadata().market_address,
             1,
             SWAP_SELL,
             INTEGRATOR,
@@ -3032,8 +3032,8 @@
         location = emojicoin_dot_fun::emojicoin_dot_fun,
     )] fun swap_no_market() {
         swap<BlackCatEmojicoin, BlackCatEmojicoinLP>(
-            @0x0,
             &get_signer(USER),
+            @0x0,
             1,
             SWAP_SELL,
             INTEGRATOR,
@@ -3047,8 +3047,8 @@
     )] fun swap_no_quote() {
         init_package_then_simple_buy();
         swap<BlackCatEmojicoin, BlackCatEmojicoinLP>(
-            base_market_metadata().market_address,
             &get_signer(USER),
+            base_market_metadata().market_address,
             1,
             SWAP_BUY,
             INTEGRATOR,


### PR DESCRIPTION
# Description

## Production code

1. Simplify liquidity provision error codes that can be handled via coin balance
   checks.
1. Offload truncation effects onto LP providers for base provision amount via
   round-up bitmask.
1. Add liquidity event decoder.
1. Update liquidity provide/remove functions to update global stats for FDV &
   market cap, to prevent the accumulation of rounding errors.
1. Update liquidity provision/remove epilogue to reduce redundant calculation of
   values.
1. Sort `&signer` to be first argument in public entry functions, with
   corresponding address first in associated view functions.

## Test code layout

1. Alphabetize test helper functions.
1. Incorporate Liquidity event mocking.
1. Incorporate liquidity provision helper functions.
1. Alphabetize some tests as needed.

## New tests

1. FDV, market cap, TVL function validation.
1. Liquidity provision/removal validation.
1. Expected failure tests for liquidity provision/removal.

## Test refactors

1. Include new FDV/market cap helper function assert in
   `fdv_market_cap_expected()`.

# Testing

From in `src/move/emojicoin_dot_fun`

```sh
git ls-files | entr -c aptos move test --coverage --dev
```

Compare coverage against bytecode:

```sh
aptos move coverage bytecode --module emojicoin_dot_fun --dev
```

# Checklist

- [x] ~Did you update relevant documentation?~
- [x] Did you add tests to cover new code or a fixed issue?
- [x] ~Did you update the changelog?~
- [x] Did you check off all checkboxes from the linked Linear task?