### PR TITLE
[ECO-1673] Test chat to 100% coverage, parallelize registry nonce

### DIFF
--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -43,6 +43,7 @@ nazar
 nohup
 octa
 oden
+parallelizable
 permissionless
 postg
 postgrest

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -418,6 +418,13 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
             &mut global_stats_ref_mut.cumulative_chat_messages;
         aggregator_v2::try_add(global_cumulative_chat_messages_ref_mut, 1);
 
+        // Update periodic state trackers.
+        vector::for_each_mut(&mut market_ref_mut.periodic_state_trackers, |e| {
+            // Type declaration per https://github.com/aptos-labs/aptos-core/issues/9508.
+            let tracker_ref_mut: &mut PeriodicStateTracker = e;
+            tracker_ref_mut.n_chat_messages = tracker_ref_mut.n_chat_messages + 1;
+        });
+
         // Emit chat event.
         let (supply_minuend, reserves_ref) =
             assign_supply_minuend_reserves_ref(market_ref_mut, in_bonding_curve);
@@ -2451,12 +2458,13 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     #[test_only] public fun get_PERIOD_1D(): u64 { PERIOD_1D }
     #[test_only] public fun get_POOL_FEE_RATE_BPS(): u8 { POOL_FEE_RATE_BPS }
     #[test_only] public fun get_REGISTRY_NAME(): vector<u8> { REGISTRY_NAME }
+    #[test_only] public fun get_TRIGGER_CHAT(): u8 { TRIGGER_CHAT }
     #[test_only] public fun get_TRIGGER_MARKET_REGISTRATION(): u8 { TRIGGER_MARKET_REGISTRATION }
     #[test_only] public fun get_TRIGGER_PACKAGE_PUBLICATION(): u8 { TRIGGER_PACKAGE_PUBLICATION }
-    #[test_only] public fun get_TRIGGER_SWAP_BUY(): u8 { TRIGGER_SWAP_BUY }
-    #[test_only] public fun get_TRIGGER_SWAP_SELL(): u8 { TRIGGER_SWAP_SELL }
     #[test_only] public fun get_TRIGGER_PROVIDE_LIQUIDITY(): u8 { TRIGGER_PROVIDE_LIQUIDITY }
     #[test_only] public fun get_TRIGGER_REMOVE_LIQUIDITY(): u8 { TRIGGER_REMOVE_LIQUIDITY }
+    #[test_only] public fun get_TRIGGER_SWAP_BUY(): u8 { TRIGGER_SWAP_BUY }
+    #[test_only] public fun get_TRIGGER_SWAP_SELL(): u8 { TRIGGER_SWAP_SELL }
     #[test_only] public fun get_QUOTE_REAL_CEILING(): u64 { QUOTE_REAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_CEILING(): u64 { QUOTE_VIRTUAL_CEILING }
     #[test_only] public fun get_QUOTE_VIRTUAL_FLOOR(): u64 { QUOTE_VIRTUAL_FLOOR }

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -366,9 +366,9 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     ///     [ x"00", x"01", x"02", x"02", x"02", x"01", x"02", x"01" ]
     public entry fun chat<Emojicoin, EmojicoinLP>(
         user: &signer,
+        market_address: address,
         emoji_bytes: vector<vector<u8>>, // The individual emojis to use.
         emoji_indices_sequence: vector<u8>, // Sequence of indices used to construct a chat message.
-        market_address: address,
     ) acquires Market, Registry, RegistryAddress {
 
         assert!(

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -393,7 +393,7 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         assert!(message_length <= MAX_CHAT_MESSAGE_LENGTH, E_CHAT_MESSAGE_TOO_LONG);
         assert!(message_length > 0, E_CHAT_MESSAGE_EMPTY);
 
-        // Construct the chat message from the emoji indices, checking for well-formedness.
+        // Construct the chat message from the emoji indices, checking index and emoji validity.
         let message: String = string::utf8(b"");
         let n_emojis = vector::length(&emoji_bytes);
         vector::for_each(emoji_indices_sequence, |idx| {

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -2310,6 +2310,23 @@
     }
 
     #[test, expected_failure(
+        abort_code = emojicoin_dot_fun::emojicoin_dot_fun::E_CHAT_MESSAGE_EMPTY,
+        location = emojicoin_dot_fun
+    )] fun chat_message_empty() {
+        init_package();
+        init_market(vector[BLACK_CAT]);
+
+        chat<BlackCatEmojicoin, BlackCatEmojicoinLP>(
+            &get_signer(USER),
+            @black_cat_market,
+            vector<vector<u8>> [
+                x"f09f98b7", // Cat face with tears of joy.
+            ],
+            vector[],
+        );
+    }
+
+    #[test, expected_failure(
         abort_code = emojicoin_dot_fun::emojicoin_dot_fun::E_NOT_SUPPORTED_CHAT_EMOJI,
         location = emojicoin_dot_fun
     )] fun chat_message_invalid_emoji() {
@@ -2323,7 +2340,24 @@
                 x"f09f98b7", // Cat face with tears of joy.
                 x"f09f", // Invalid emoji.
             ],
-            vector[ 0, 1],
+            vector[0, 1],
+        );
+    }
+
+    #[test, expected_failure(
+        abort_code = emojicoin_dot_fun::emojicoin_dot_fun::E_INVALID_EMOJI_INDEX,
+        location = emojicoin_dot_fun
+    )] fun chat_message_invalid_emoji_index() {
+        init_package();
+        init_market(vector[BLACK_CAT]);
+
+        chat<BlackCatEmojicoin, BlackCatEmojicoinLP>(
+            &get_signer(USER),
+            @black_cat_market,
+            vector<vector<u8>> [
+                x"f09f98b7", // Cat face with tears of joy.
+            ],
+            vector[1],
         );
     }
 

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -568,7 +568,7 @@
             cumulative_chat_messages,
         ) = unpack_global_state(global_state);
         assert!(emit_time == mock_global_state.emit_time, 0);
-        assert!(registry_nonce == mock_global_state.registry_nonce, 0);
+        assert!(read_snapshot(&registry_nonce) == mock_global_state.registry_nonce, 0);
         assert!(trigger == mock_global_state.trigger, 0);
         assert!(read_snapshot(&cumulative_quote_volume)
             == mock_global_state.cumulative_quote_volume, 0);
@@ -846,7 +846,7 @@
             cumulative_chat_messages,
         ) = unpack_registry_view(registry_view);
         assert!(registry_address == mock_registry_view.registry_address, 0);
-        assert!(nonce == mock_registry_view.nonce, 0);
+        assert!(read_snapshot(&nonce) == mock_registry_view.nonce, 0);
         assert!(last_bump_time == mock_registry_view.last_bump_time, 0);
         assert!(n_markets == mock_registry_view.n_markets, 0);
         assert!(read_snapshot(&cumulative_quote_volume)

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -2171,14 +2171,15 @@
         assert!(vector::all(&emojis, |emoji_ref| { is_a_supported_chat_emoji(*emoji_ref) }), 0);
         chat<BlackCatEmojicoin, BlackCatEmojicoinLP>(
             &get_signer(USER),
+            @black_cat_market,
             emojis,
             vector[1, 0],
-            @black_cat_market,
         );
 
         // Chat again with a longer message.
         chat<BlackCatEmojicoin, BlackCatEmojicoinLP>(
             &get_signer(USER),
+            @black_cat_market,
             vector<vector<u8>> [
                 x"f09f98b6", // Cat face.
                 x"f09f98b7", // Cat face with tears of joy.
@@ -2187,7 +2188,6 @@
                 x"f09f9294", // Broken heart.
             ],
             vector[ 3, 0, 2, 2, 1, 4 ],
-            @black_cat_market,
         );
 
         // Post a max length chat message.
@@ -2197,11 +2197,11 @@
         };
         chat<BlackCatEmojicoin, BlackCatEmojicoinLP>(
             &get_signer(USER),
+            @black_cat_market,
             vector<vector<u8>> [
                 x"f09f9088e2808de2ac9b", // Black cat.
             ],
             emoji_indices_sequence,
-            @black_cat_market,
         );
 
         // Assert the emitted chat events.
@@ -2248,12 +2248,12 @@
 
         chat<BlackCatEmojicoin, BlackCatEmojicoinLP>(
             &get_signer(USER),
+            @black_cat_market,
             vector<vector<u8>> [
                 x"f09f98b7", // Cat face with tears of joy.
                 x"f09f", // Invalid emoji.
             ],
             vector[ 0, 1],
-            @black_cat_market,
         );
     }
 
@@ -2274,9 +2274,9 @@
         };
         chat<BlackCatEmojicoin, BlackCatEmojicoinLP>(
             &get_signer(USER),
+            @black_cat_market,
             emojis,
             emoji_indices_sequence,
-            @black_cat_market,
         );
     }
 
@@ -2286,9 +2286,9 @@
     )] fun chat_no_market() {
         chat<BlackCatEmojicoin, BlackCatEmojicoinLP>(
             &get_signer(USER),
+            @0x0,
             vector[vector[]],
             vector[],
-            @0x0,
         );
     }
 

--- a/src/move/emojicoin_dot_fun/sources/tests.move
+++ b/src/move/emojicoin_dot_fun/sources/tests.move
@@ -2280,6 +2280,18 @@
         );
     }
 
+    #[test, expected_failure(
+        abort_code = emojicoin_dot_fun::emojicoin_dot_fun::E_NO_MARKET,
+        location = emojicoin_dot_fun::emojicoin_dot_fun,
+    )] fun chat_no_market() {
+        chat<BlackCatEmojicoin, BlackCatEmojicoinLP>(
+            &get_signer(USER),
+            vector[vector[]],
+            vector[],
+            @0x0,
+        );
+    }
+
     #[test] fun concatenation() {
         let base = utf8(b"base");
         let additional = utf8(b" additional");


### PR DESCRIPTION
# Description

## Production code

1. Update chat API to list market address second for consistency with other
   APIs.
1. Add missing tracking for number of chat messages in a periodic state tracker.
1. Consolidate loopwise emoji chat operations to minimize gas costs.
1. Add checks on index validity, empty message for chat operations.
1. Parallelize registry nonce.

## Test code layout

1. Update assert helpers for parallelized registry nonce.

## New tests

1. Assorted chat expected failure tests.
1. Chat full state assertion test.

## Test refactors

1. Update `chat_complex_emoji_sequences` to also verify assorted state
   mutations, thusly renaming to `chat_complex`.

## Housekeeping

1. Escape `parallelizable` from spellchecker.

# Testing

From in `src/move/emojicoin_dot_fun`

```sh
git ls-files | entr -c aptos move test --coverage --dev
```

Compare coverage against bytecode:

```sh
aptos move coverage bytecode --module emojicoin_dot_fun --dev
```

# Checklist

- [X] Did you update relevant documentation?
- [X] Did you add tests to cover new code or a fixed issue?
- [X] Did you update the changelog?
- [X] Did you check off all checkboxes from the linked Linear task?