### PR TITLE
[ECO 1686] Update TS API calls to reflect new function signatures, fix e2e `Transaction in mempool` error

### DIFF
--- a/src/typescript/api/src/emojicoin_dot_fun/emojicoin-dot-fun.ts
+++ b/src/typescript/api/src/emojicoin_dot_fun/emojicoin-dot-fun.ts
@@ -35,18 +35,18 @@ import {
 import { MODULE_ADDRESS } from "./consts";
 
 export type ChatPayloadMoveArguments = {
+  marketAddress: AccountAddress;
   emojiBytes: MoveVector<MoveVector<U8>>;
   emojiIndicesSequence: MoveVector<U8>;
-  marketAddress: AccountAddress;
 };
 
 /**
  *```
  *  public entry fun chat<Emojicoin, EmojicoinLP>(
  *     user: &signer,
+ *     market_address: address,
  *     emoji_bytes: vector<vector<u8>>,
  *     emoji_indices_sequence: vector<u8>,
- *     market_address: address,
  *  )
  *```
  * */
@@ -70,9 +70,9 @@ export class Chat extends EntryFunctionPayloadBuilder {
 
   private constructor(args: {
     user: AccountAddressInput; // &signer
+    marketAddress: AccountAddressInput; // address
     emojiBytes: Array<HexInput>; // vector<vector<u8>>
     emojiIndicesSequence: HexInput; // vector<u8>
-    marketAddress: AccountAddressInput; // address
     typeTags: [TypeTagInput, TypeTagInput]; // [Emojicoin, EmojicoinLP]
     feePayer?: AccountAddressInput; // Optional fee payer account to pay gas fees.
   }) {
@@ -81,9 +81,9 @@ export class Chat extends EntryFunctionPayloadBuilder {
     this.primarySender = AccountAddress.from(user);
 
     this.args = {
+      marketAddress: AccountAddress.from(marketAddress),
       emojiBytes: new MoveVector(emojiBytes.map((argA) => MoveVector.U8(argA))),
       emojiIndicesSequence: MoveVector.U8(emojiIndicesSequence),
-      marketAddress: AccountAddress.from(marketAddress),
     };
     this.typeTags = typeTags.map((typeTag) =>
       typeof typeTag === "string" ? parseTypeTag(typeTag) : typeTag
@@ -94,9 +94,9 @@ export class Chat extends EntryFunctionPayloadBuilder {
   static async builder(args: {
     aptosConfig: AptosConfig;
     user: AccountAddressInput; // &signer
+    marketAddress: AccountAddressInput; // address
     emojiBytes: Array<HexInput>; // vector<vector<u8>>
     emojiIndicesSequence: HexInput; // vector<u8>
-    marketAddress: AccountAddressInput; // address
     typeTags: [TypeTagInput, TypeTagInput]; // [Emojicoin, EmojicoinLP],
     feePayer?: AccountAddressInput;
     options?: InputGenerateTransactionOptions;
@@ -117,9 +117,9 @@ export class Chat extends EntryFunctionPayloadBuilder {
   static async submit(args: {
     aptosConfig: AptosConfig;
     user: Account; // &signer
+    marketAddress: AccountAddressInput; // address
     emojiBytes: Array<HexInput>; // vector<vector<u8>>
     emojiIndicesSequence: HexInput; // vector<u8>
-    marketAddress: AccountAddressInput; // address
     typeTags: [TypeTagInput, TypeTagInput]; // [Emojicoin, EmojicoinLP]
     feePayer?: Account;
     options?: InputGenerateTransactionOptions;

--- a/src/typescript/api/tests/e2e/chat.test.ts
+++ b/src/typescript/api/tests/e2e/chat.test.ts
@@ -38,7 +38,7 @@ describe("emits a chat message event successfully", () => {
     // Register a market.
     const txResponse = await EmojicoinDotFun.RegisterMarket.submit({
       aptosConfig: aptos.config,
-      registrant: publisher,
+      registrant: user,
       emojis: [blackCatEmoji],
       integrator: randomIntegrator.accountAddress,
       options: {
@@ -74,9 +74,9 @@ describe("emits a chat message event successfully", () => {
     const chatResponse = await EmojicoinDotFun.Chat.submit({
       aptosConfig: aptos.config,
       user,
+      marketAddress,
       emojiBytes: chatEmojis.map(([hex, _]) => hex),
       emojiIndicesSequence: new Uint8Array([0, 1]),
-      marketAddress,
       typeTags: [emojicoin, emojicoinLP],
     });
 
@@ -98,9 +98,9 @@ describe("emits a chat message event successfully", () => {
     const secondChatResponse = await EmojicoinDotFun.Chat.submit({
       aptosConfig: aptos.config,
       user,
+      marketAddress,
       emojiBytes: chatEmojis.map(([hex, _]) => hex),
       emojiIndicesSequence: new Uint8Array(indices),
-      marketAddress,
       typeTags: [emojicoin, emojicoinLP],
     });
 

--- a/src/typescript/api/tests/e2e/register.test.ts
+++ b/src/typescript/api/tests/e2e/register.test.ts
@@ -15,7 +15,7 @@ describe("registers a market successfully", () => {
   const { aptos, publisher, publishPackageResult } = getTestHelpers();
   const user = Account.generate();
 
-  beforeAll(async() => {
+  beforeAll(async () => {
     await aptos.fundAccount({ accountAddress: user.accountAddress, amount: ONE_APT });
   });
 

--- a/src/typescript/api/tests/e2e/register.test.ts
+++ b/src/typescript/api/tests/e2e/register.test.ts
@@ -13,6 +13,11 @@ jest.setTimeout(20000);
 
 describe("registers a market successfully", () => {
   const { aptos, publisher, publishPackageResult } = getTestHelpers();
+  const user = Account.generate();
+
+  beforeAll(async() => {
+    await aptos.fundAccount({ accountAddress: user.accountAddress, amount: ONE_APT });
+  });
 
   it("publishes the emojicoin_dot_fun package and queries the expected resources", async () => {
     const moduleName = EMOJICOIN_DOT_FUN_MODULE_NAME;
@@ -39,7 +44,7 @@ describe("registers a market successfully", () => {
 
     const txResponse = await EmojicoinDotFun.RegisterMarket.submit({
       aptosConfig: aptos.config,
-      registrant: publisher,
+      registrant: user,
       emojis,
       integrator: randomIntegrator.accountAddress,
       options: {

--- a/src/typescript/api/tests/e2e/register.test.ts
+++ b/src/typescript/api/tests/e2e/register.test.ts
@@ -17,6 +17,7 @@ describe("registers a market successfully", () => {
 
   beforeAll(async () => {
     await aptos.fundAccount({ accountAddress: user.accountAddress, amount: ONE_APT });
+    await aptos.fundAccount({ accountAddress: user.accountAddress, amount: ONE_APT });
   });
 
   it("publishes the emojicoin_dot_fun package and queries the expected resources", async () => {


### PR DESCRIPTION
# Description

The `market_address` function argument position changed, so we must update the TS api to reflect this.

Also, in unit tests, previously, the publisher was registering multiple markets at the same time, which would often result in the `Transaction is already in mempool` error.

 - [x] Update the order of the `market_address` field in order to match the new entry function args order
 - [x] Have the user call `register_market` to avoid contention in the transaction mempool due to parallel unit tests

# Testing

Unit tests in the TS api

# Checklist

- [x] ~Did you update relevant documentation?~
- [x] Did you add tests to cover new code or a fixed issue?
- [x] ~Did you update the changelog?~
- [x] ~Did you check off all checkboxes from the linked Linear task?~

