### PR TITLE
[ECO-1685] Test package to 100% coverage

### DIFF
--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2481,6 +2481,10 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
         Reserves { base, quote }
     }
 
+    #[test_only] public fun pack_tvl_to_lp_coin_ratio(tvl: u128, lp_coins: u128): TVLtoLPCoinRatio {
+        TVLtoLPCoinRatio { tvl, lp_coins }
+    }
+
     #[test_only] public fun register_market_without_publish(
         registrant: &signer,
         emojis: vector<vector<u8>>,

--- a/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
+++ b/src/move/emojicoin_dot_fun/sources/emojicoin_dot_fun.move
@@ -2658,16 +2658,16 @@ module emojicoin_dot_fun::emojicoin_dot_fun {
     ) {
         let PeriodicStateMetadata {
             start_time,
+            period,
             emit_time,
             emit_market_nonce,
-            period,
             trigger,
         } = periodic_state_metadata;
         (
             start_time,
+            period,
             emit_time,
             emit_market_nonce,
-            period,
             trigger,
         )
     }


### PR DESCRIPTION
# Description

Test package to 100% coverage

## Test code layout

1. Update test-only decoder for `PeriodicStateMetadata` to return fields in
   same order as struct definition.
1. Add helpers functions for asserting an ongoing sequence of periodic state
   events.
1. Add helper functions for getting TVL to LP coin ratio and TVL per LP coin
   growth over a period.
1. Struct packer for `TVLtoLPCoinRatio` for ease of testing.

## New tests

1. Complex triggers test.
1. Assorted expected failure tests.
1. Supplemental chat emoji tests.
1. Invalid coin type failure mode tests.
1. Assorted market metadata getter helpers.
1. Verified emoji failure tests.

## Housekeeping

1. Remove redundant type annotations for vectors.

# Testing

From in `src/move/emojicoin_dot_fun`

```sh
git ls-files | entr -c aptos move test --coverage --dev
```

Compare coverage against bytecode:

```sh
aptos move coverage bytecode --module emojicoin_dot_fun --dev
```

# Checklist

- [x] Did you update relevant documentation (if applicable)?
- [x] Did you add tests to cover new code or a fixed issue (if applicable)?
- [x] Did you update the changelog (if applicable)?
- [x] Did you check all checkboxes from the linked Linear task (if applicable)?