### PR TITLE
[ECO-1752] fix mock data

### DIFF
--- a/src/typescript/sdk/tests/utils/generate-mock-data.ts
+++ b/src/typescript/sdk/tests/utils/generate-mock-data.ts
@@ -94,7 +94,7 @@ const insertPeriodicState = async (
   const seq = Number(100000n + state.periodic_state_metadata.emit_market_nonce);
   const time = new Date(Number(state.periodic_state_metadata.emit_time) / 1000);
   await sql`
-    INSERT INTO events
+    INSERT INTO inbox_events
     VALUES (
       ${seq},
       6,
@@ -539,7 +539,7 @@ export const generateMockData = async (aptos: Aptos, publisher: Account) => {
     concatEmoji(MOCK_DATA_MARKETS_EMOJIS[2]),
     marketObjectMarketResource.metadata.marketID,
     publisher.accountAddress.toString(),
-    `${marketObjectMarketResource.metadata.marketAddress}::emojicoin_dot_fun::PeriodicState`,
+    `${publisher.accountAddress.toString()}::emojicoin_dot_fun::PeriodicState`,
     sql
   );
 };


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes a bug where the candlesticks events would be inserted into the wrong table.

It also fixes the address of the generated periodic state events.

# Testing

Run mock data script and check rest api for periodic state events (more than 5).

# Checklist

- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you check all checkboxes from the linked Linear task?
