### PR TITLE
[ECO-1778] make allowlister3000 hot-reloadable

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -22,6 +22,9 @@ name = "allowlister3000"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "futures",
+ "signal-hook",
+ "signal-hook-tokio",
  "tokio",
  "tower-http",
 ]
@@ -36,6 +39,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
@@ -147,12 +156,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -160,6 +185,40 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
@@ -173,10 +232,16 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -478,6 +543,46 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "signal-hook-tokio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/src/rust/allowlister3000/Cargo.toml
+++ b/src/rust/allowlister3000/Cargo.toml
@@ -2,6 +2,9 @@
 
 [dependencies]
 axum = "0.7.5"
+futures = "0.3.30"
+signal-hook = "0.3.17"
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 tokio = {version = "1.37.0", features = ["rt-multi-thread"]}
 tower-http = {version = "0.5.2", features = ["cors"]}
 

--- a/src/rust/allowlister3000/Cargo.toml
+++ b/src/rust/allowlister3000/Cargo.toml
@@ -4,7 +4,7 @@
 axum = "0.7.5"
 futures = "0.3.30"
 signal-hook = "0.3.17"
-signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
+signal-hook-tokio = {version = "0.3.1", features = ["futures-v0_3"]}
 tokio = {version = "1.37.0", features = ["rt-multi-thread"]}
 tower-http = {version = "0.5.2", features = ["cors"]}
 

--- a/src/rust/allowlister3000/README.md
+++ b/src/rust/allowlister3000/README.md
@@ -13,6 +13,9 @@ then start the program by running `cargo run --release`.
 To update the allowlist, add the desired address(es) to the allowlist file.
 Then, **restart the program**.
 
+Alternatively, you can use `pkill -USR1 allowlister3000` to send a `SIGUSR1`
+signal to the program, which will reload the file without quitting.
+
 ## Allowlist format
 
 The allowlist file format is just a plain text file with one address per line.

--- a/src/rust/allowlister3000/README.md
+++ b/src/rust/allowlister3000/README.md
@@ -1,3 +1,8 @@
+<!---
+cspell:word pkill
+cspell:word sigusr
+-->
+
 # AllowLister3K
 
 AllowLister3K is a simple web server that will respond with either `true` or
@@ -102,5 +107,16 @@ nohup bash -c 'ALLOWLIST_FILE=./allowlist.txt /allowlister3000 &!'
 
 Run `curl IP:3000/0x...` to check that the AllowLister3K is working properly.
 To get `IP`, you can run `gcloud compute instances list`.
+
+#### Adding in new addresses
+
+To add a new address:
+
+```sh
+gcloud config set project YOUR-PROJECT-ID
+gcloud compute ssh root@allowlister3000
+echo 0x123456 >> allowlist.txt
+pkill -USR1 allowlister3000
+```
 
 [gcp-vm-docs]: https://cloud.google.com/compute/docs/instances/create-start-instance

--- a/src/rust/allowlister3000/src/main.rs
+++ b/src/rust/allowlister3000/src/main.rs
@@ -1,14 +1,16 @@
+// cspell:word pkill
+// cspell:word sigusr
 use axum::{
     extract::{Path, State},
     http::Method,
     routing::get,
     Router,
 };
+use futures::stream::StreamExt;
 use signal_hook::consts::SIGUSR1;
 use signal_hook_tokio::Signals;
-use futures::stream::StreamExt;
-use tokio::sync::RwLock;
 use std::{collections::HashSet, sync::Arc};
+use tokio::sync::RwLock;
 use tower_http::cors::{Any, CorsLayer};
 
 // The index of the first piece of actual data in a hex address.
@@ -55,7 +57,7 @@ async fn handle_signals(mut signals: Signals, allowlist_set: Arc<RwLock<HashSet<
         match signal {
             SIGUSR1 => {
                 *allowlist_set.write().await = read_allowlist();
-            },
+            }
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR makes it so that you can change the allowlister3000's allowlist with 0% downtime.

# Testing

Start the allowlister3000 and follow the README instructions to reload the allowlist.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you check all checkboxes from the linked Linear task?
