### PR TITLE
[ECO-1835] Fix slider animation

### DIFF
--- a/src/typescript/frontend/tailwind.config.js
+++ b/src/typescript/frontend/tailwind.config.js
@@ -68,7 +68,7 @@ module.exports = {
       },
       carousel: {
         "0%": { transform: "translateX(0)" },
-        "100%": { transform: "translateX(-4527.83)" },
+        "100%": { transform: "translateX(-4527.83px)" },
       },
     },
     animation: {


### PR DESCRIPTION
# Description

- [x] Change `-4500` in animation to `-4500px`. For some reason it works locally but in prod it can't use the no `px` value.

# Testing

👀

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
