### PR TITLE
[ECO-1845] Fix carousel text to flatten correctly

### DIFF
--- a/src/typescript/frontend/src/components/text-carousel/TextCarousel.tsx
+++ b/src/typescript/frontend/src/components/text-carousel/TextCarousel.tsx
@@ -8,14 +8,14 @@ const Item = ({ children }: { children: React.ReactNode }) => {
     </div>
   );
 };
-
 const TextCarousel = () => {
   const messages = ["Universal ownership", "Universal blockchain", "Universal language"];
-  const firstCarousel = messages
-    .flatMap((message) => Array.from({ length: 5 }, () => message))
+
+  const firstCarousel = Array.from({ length: 5 }, () => messages)
+    .flatMap((m) => m)
     .map((message, index) => <Item key={`first::${message}::${index}`}>{message}</Item>);
-  const secondCarousel = messages
-    .flatMap((message) => Array.from({ length: 5 }, () => message))
+  const secondCarousel = Array.from({ length: 5 }, () => messages)
+    .flatMap((m) => m)
     .map((message, index) => <Item key={`second::${message}::${index}`}>{message}</Item>);
 
   return (


### PR DESCRIPTION
# Description

Fix the text on the carousel so it repeats correctly aka 1, 2, 3, 1, 2, 3, 1, 2, 3 instead of 1, 1, 1, 2, 2, 2, 3, 3, 3.

# Testing

Ocular patdown

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
