### PR TITLE
[ECO-1823] Fix infinite connect wallet bug by removing manual autoconnect

### DIFF
--- a/src/typescript/frontend/src/context/providers.tsx
+++ b/src/typescript/frontend/src/context/providers.tsx
@@ -60,7 +60,7 @@ const ThemedApp: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       <QueryClientProvider client={queryClient}>
         <WebSocketEventsProvider>
           <MarketDataProvider>
-            <AptosWalletAdapterProvider plugins={wallets} autoConnect>
+            <AptosWalletAdapterProvider plugins={wallets} autoConnect={true}>
               <ConnectWalletContextProvider>
                 <AptosContextProvider>
                   <GlobalStyle />

--- a/src/typescript/frontend/src/context/wallet-context/ConnectWalletContext.tsx
+++ b/src/typescript/frontend/src/context/wallet-context/ConnectWalletContext.tsx
@@ -1,5 +1,5 @@
-import { useWallet, type WalletName } from "@aptos-labs/wallet-adapter-react";
-import { createContext, type PropsWithChildren, useContext, useEffect, useState } from "react";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { createContext, type PropsWithChildren, useContext, useState } from "react";
 import { toast } from "react-toastify";
 
 import { BaseModal } from "components/modal/BaseModal";
@@ -16,35 +16,6 @@ const WalletItemClassName =
   "transition-all hover:text-ec-blue " +
   "text-black group";
 
-let t: NodeJS.Timeout | null = null;
-const AutoConnect = () => {
-  const { account, connect } = useWallet();
-  useEffect(() => {
-    if (!account && localStorage.getItem("AptosWalletName")) {
-      const f = async () => {
-        try {
-          connect(localStorage.getItem("AptosWalletName") as WalletName);
-        } catch (error) {
-          if (t) {
-            clearInterval(t);
-          }
-        }
-      };
-      f();
-      t = setInterval(f, 100);
-    } else if (t) {
-      clearInterval(t);
-    }
-    return () => {
-      if (t) {
-        clearInterval(t);
-      }
-    };
-  }, [account]); /* eslint-disable-line react-hooks/exhaustive-deps */
-
-  return null;
-};
-
 export function ConnectWalletContextProvider({ children }: PropsWithChildren) {
   const { connect, wallet: activeWallet, wallets, disconnect } = useWallet();
   const [open, setOpen] = useState<boolean>(false);
@@ -56,7 +27,6 @@ export function ConnectWalletContextProvider({ children }: PropsWithChildren) {
 
   return (
     <ConnectWalletContext.Provider value={value}>
-      <AutoConnect />
       {children}
       <BaseModal
         className="md:w-[430px]"


### PR DESCRIPTION
# Description

- [x] Removes the manual autoconnect set to run every 100ms (10 times per second) that was causing a bug
- [x] Ensures the `autoConnect` prop in the wallet provider is `true` instead of just a prop, so autoconnect continuse to work

# Testing

I couldn't reproduce the bug myself, so some more manual testing is necessary here.

- [ ] Ensure the bug is not present anymore

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

