### PR TITLE
[ECO-1888] Add fine-grained token submodule fix

### DIFF
--- a/src/typescript/README.md
+++ b/src/typescript/README.md
@@ -63,3 +63,30 @@ pnpm run full-clean
 
 Note this remove's each project's `node_modules`, although it does not remove
 the `pnpm-lock.yaml` file.
+
+## Vercel deployment
+
+To allow Vercel to clone the private submodule, you'll need to grant it access.
+
+On GitHub:
+
+1. Create a private personal fork of the charting library named
+   `charting_library`.
+1. Create a fine-grained personal access token:
+   1. Select repository access for only your `charting_library` fork.
+   1. Grant read-only access to `Repository permissions > Contents`.
+   1. Grant read-only access to `Repository permissions > Metadata`.
+
+On Vercel project settings:
+
+1. General settings:
+   1. `Build & Development Settings > Install Command`:
+      `pnpm run vercel-install`
+   1. `Root Directory`: `src/typescript/frontend`
+1. Environment variables:
+   1. All variables under `.env.example`.
+   1. `GITHUB_ACCESS_TOKEN`: the token you generated above.
+   1. `TRADING_VIEW_REPO_OWNER`: your GitHub username.
+
+This will allow Vercel to run the `frontend/vercel-install` script in order to
+download the charting library from your private personal fork.

--- a/src/typescript/frontend/vercel-submodule.sh
+++ b/src/typescript/frontend/vercel-submodule.sh
@@ -24,7 +24,6 @@ git clone \
 	--depth 1
 
 # Move files to submodule directory, clean up.
-cd charting_libary
-mv * $TRADING_VIEW_SUBMODULE_PATH/
-cd ../..
+cd ..
+mv tmp/charting_library * $TRADING_VIEW_SUBMODULE_PATH/
 rm -rf tmp

--- a/src/typescript/frontend/vercel-submodule.sh
+++ b/src/typescript/frontend/vercel-submodule.sh
@@ -25,5 +25,5 @@ git clone \
 
 # Move files to submodule directory, clean up.
 cd ..
-mv tmp/charting_library * $TRADING_VIEW_SUBMODULE_PATH/
+mv tmp/charting_library/* $TRADING_VIEW_SUBMODULE_PATH/
 rm -rf tmp

--- a/src/typescript/frontend/vercel-submodule.sh
+++ b/src/typescript/frontend/vercel-submodule.sh
@@ -17,15 +17,14 @@ rm -rf tmp || true
 mkdir tmp
 cd tmp
 
-# Check out submodule
+# Check out submodule.
 git clone \
 	https://$GITHUB_ACCESS_TOKEN@github.com/$TRADING_VIEW_REPO_OWNER/charting_library.git \
 	--branch master \
 	--depth 1
 
-# Cleanup the repository and move the files to the submodule directory.
-cd ..
-rm -rf tmp/.git
-ls
-mv tmp/charting_library * $SUBMODULE_PATH/
+# Move files to submodule directory, clean up.
+cd charting_libary
+mv * $TRADING_VIEW_SUBMODULE_PATH/
+cd ../..
 rm -rf tmp

--- a/src/typescript/frontend/vercel-submodule.sh
+++ b/src/typescript/frontend/vercel-submodule.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
-SUBMODULE_GITHUB=github.com/tradingview/charting_library.git
-SUBMODULE_PATH=public/static
+TRADING_VIEW_SUBMODULE_PATH=public/static
+if [ "$TRADING_VIEW_REPO_OWNER" == "" ]; then
+	echo "Error: TRADING_VIEW_REPO_OWNER is empty. Set it in vercel."
+	exit 1
+fi
 if [ "$GITHUB_ACCESS_TOKEN" == "" ]; then
 	echo "Error: GITHUB_ACCESS_TOKEN is empty. Set it in vercel."
 	exit 1
@@ -14,15 +17,15 @@ rm -rf tmp || true
 mkdir tmp
 cd tmp
 
-# Initialize an empty repository and checkout the submodule.
-git init
-git remote add origin https://$GITHUB_ACCESS_TOKEN@$SUBMODULE_GITHUB
-git fetch origin master
-git checkout master
+# Check out submodule
+git clone \
+	https://$GITHUB_ACCESS_TOKEN@github.com/$TRADING_VIEW_REPO_OWNER/charting_library.git \
+	--branch master \
+	--depth 1
 
 # Cleanup the repository and move the files to the submodule directory.
 cd ..
 rm -rf tmp/.git
 ls
-mv tmp/* $SUBMODULE_PATH/
+mv tmp/charting_library * $SUBMODULE_PATH/
 rm -rf tmp


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Update steps for using fine-grained token access to clone submodule during Vercel build.

# Testing

Deployment build

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
