### PR TITLE
[ECO-1926] add add and remove scripts for allowlister

### DIFF
--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -52,6 +52,7 @@ octa
 oden
 parallelizable
 permissionless
+pkill
 postg
 postgrest
 precommit

--- a/src/rust/allowlister3000/README.md
+++ b/src/rust/allowlister3000/README.md
@@ -19,7 +19,8 @@ To update the allowlist, add the desired address(es) to the allowlist file.
 Then, **restart the program**.
 
 Alternatively, you can use `pkill -USR1 allowlister3000` to send a `SIGUSR1`
-signal to the program, which will reload the file without quitting.
+signal to the program, which will reload the file without quitting. Note that
+the `add.sh` and `remove.sh` scripts do this automatically.
 
 ## Allowlist format
 
@@ -80,6 +81,16 @@ Create an allowlist file on the VM.
 Once all the addresses are added to the file, set `ALLOWLIST_FILE` to the path
 of the file.
 
+Two helper scripts are present to help you manage addresses:
+
+- `add.sh`
+- `remove.sh`
+
+Their name documents their purpose very well, and their usage is the following:
+`<SCRIPT> <ADDRESS> <FILE>`. You can also run `<SCRIPT> --help`.
+
+Note: `remove.sh` will always create a backup file.
+
 #### Step 5
 
 Start the AllowLister3K by running `./path_to_binary`.
@@ -98,8 +109,10 @@ cargo build --release --target x86_64-unknown-linux-gnu
 gcloud compute scp \
     ./target/x86_64-unknown-linux-gnu/release/allowlister3000 \
     root@allowlister3000:/
+gcloud compute scp ./add.sh root@allowlister3000:/
+gcloud compute scp ./remove.sh root@allowlister3000:/
 gcloud compute ssh root@allowlister3000
-echo "0x..." >> allowlist.txt
+./add.sh 0x... allowlist.txt
 nohup bash -c 'ALLOWLIST_FILE=./allowlist.txt /allowlister3000 &!'
 ```
 
@@ -115,8 +128,7 @@ To add a new address:
 ```sh
 gcloud config set project YOUR-PROJECT-ID
 gcloud compute ssh root@allowlister3000
-echo 0x123456 >> allowlist.txt
-pkill -USR1 allowlister3000
+./add.sh 0x123456 allowlist.txt
 ```
 
 [gcp-vm-docs]: https://cloud.google.com/compute/docs/instances/create-start-instance

--- a/src/rust/allowlister3000/add.sh
+++ b/src/rust/allowlister3000/add.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+if [ "$#" -eq 1 ]; then
+	if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+		echo "Add address to allowlister file"
+		echo "Usage: $0 <ADDRESS> <FILE>"
+		exit 0
+	fi
+fi
+
+if [ "$#" -ne 2 ]; then
+	echo "Illegal number of parameters"
+	echo "Usage: $0 <ADDRESS> <FILE>"
+	exit 1
+fi
+
+if [ ! -f "$2" ]; then
+	echo "File $2 not found, creating"
+fi
+
+echo "$1" >>"$2"
+
+pkill -USR1 allowlister3000 >/dev/null || :

--- a/src/rust/allowlister3000/remove.sh
+++ b/src/rust/allowlister3000/remove.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+if [ "$#" -eq 1 ]; then
+	if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+		echo "Remove address from allowlister file, creating a backup file"
+		echo "Usage: $0 <ADDRESS> <FILE>"
+		exit 0
+	fi
+fi
+
+if [ "$#" -ne 2 ]; then
+	echo "Illegal number of parameters"
+	echo "Usage: $0 <ADDRESS> <FILE>"
+	exit 1
+fi
+
+if [ ! -f "$2" ]; then
+	echo "File $2 not found"
+	echo "Usage: $0 <ADDRESS> <FILE>"
+	exit 2
+fi
+
+sed -i.bak "/$1/d" "$2"
+
+pkill -USR1 allowlister3000 >/dev/null || :


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds two scripts:

- `add.sh`: adds an address to the allowlister list.
- `remove.sh`: removes an address from the allowlister list, and creates a backup of the old list.

# Testing

Run the `add.sh` and `remove.sh` scripts against a random text file.

# Checklist

- [ ] Did you update relevant documentation?
- [ ] Did you check all checkboxes from the linked Linear task?
