### PR TITLE
[ECO-1956] Attempt to fix nextjs caching issues

### DIFF
--- a/src/typescript/frontend/next.config.mjs
+++ b/src/typescript/frontend/next.config.mjs
@@ -12,6 +12,7 @@ const styledComponentsConfig = {
   fileName: true,
   minify: false,
 };
+/** @type {import('next').NextConfig} */
 const debugConfigOptions = {
   productionBrowserSourceMaps: true,
   outputFileTracing: true,
@@ -20,6 +21,10 @@ const debugConfigOptions = {
   experimental: {
     serverMinification: false,
     serverSourceMaps: true,
+    staleTimes: {
+      dynamic: 0, // Default is normally 30s.
+      static: 30, // Default is normally 180s.
+    },
   },
   logging: {
     fetches: {


### PR DESCRIPTION
# Description

The default behavior of nextjs's  client-side Router Cache is unfortunately opaque and problematic, since it is an opt-out caching behavior that is independent of the caching mechanisms/configurations you can set for server requests, and it affects all data flowing through a client. Note that it is on a per-client basis- meaning the client's browser data supersedes the server cache.

That is, if you're a user visiting an emojicoin's market page and you make 5 trades and refresh the page- you won't see those 5 trades for at least 30 seconds because of the opt-out client-side router cache. But if a new user visits the page in the next 2 seconds after you make those trades, they will see the right data, but only because they're on an entirely separate client. This is why hard refresh tends to work.

To fix this issue, it's fairly simple, because nextjs had to address so many people having issues with it:

- [x] Set experimental config options to set dynamic route caches to 0 seconds and static to 30 seconds. This should reinstate more predictable behavior with our data caching.

# Testing

Submit a trade and refresh the page or navigate somewhere and come back to see if the data is the same or different.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
