### PR TITLE
[ECO-1958] Add `useMemo` to sort, deduplicate, and merge chat/swap events that are in state and the server

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -62,7 +62,6 @@ const ChatBox = (props: ChatProps) => {
     return () => unsubscribe.chat(marketID);
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
-  
 
   useEffect(() => {
     setMode("chat");

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import InfiniteScroll from "react-infinite-scroll-component";
 import { useThemeContext } from "context";
 import { Flex, Column } from "@containers";
@@ -12,11 +12,11 @@ import { toCoinTypes } from "@sdk/markets/utils";
 import { Chat } from "@sdk/emojicoin_dot_fun/emojicoin-dot-fun";
 import emojiRegex from "emoji-regex";
 import { type SymbolEmojiData } from "@sdk/emoji_data";
-import { isUserTransactionResponse } from "@aptos-labs/ts-sdk";
 import { useEventStore, useWebSocketClient } from "context/websockets-context";
 import useInputStore from "@store/input-store";
 import EmojiPickerWithInput from "../../../../emoji-picker/EmojiPickerWithInput";
 import { getRankFromChatEvent } from "lib/utils/get-user-rank";
+import { toSortedDedupedEvents } from "lib/utils/sort-events";
 
 const convertChatMessageToEmojiAndIndices = (
   message: string,
@@ -49,21 +49,20 @@ const ChatBox = (props: ChatProps) => {
   const { theme } = useThemeContext();
   const { aptos, account, submit } = useAptos();
   const marketID = props.data.marketID.toString();
+  const clear = useInputStore((state) => state.clear);
+  const setMode = useInputStore((state) => state.setMode);
+  const emojis = useInputStore((state) => state.emojis);
   const chats = useEventStore((s) => s.getMarket(marketID)?.chatEvents ?? props.data.chats);
-  const { subscribe, unsubscribe } = useWebSocketClient((s) => s);
+  const chatEmojiData = useInputStore((state) => state.chatEmojiData);
+  const subscribe = useWebSocketClient((s) => s.subscribe);
+  const unsubscribe = useWebSocketClient((s) => s.unsubscribe);
 
-  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     subscribe.chat(marketID);
     return () => unsubscribe.chat(marketID);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
-  /* eslint-enable react-hooks/exhaustive-deps */
-  const { emojis, clear, chatEmojiData, setMode } = useInputStore((state) => ({
-    emojis: state.emojis,
-    clear: state.clear,
-    chatEmojiData: state.chatEmojiData,
-    setMode: state.setMode,
-  }));
+  
 
   useEffect(() => {
     setMode("chat");
@@ -93,12 +92,17 @@ const ChatBox = (props: ChatProps) => {
         emojiIndicesSequence: new Uint8Array(emojiIndicesSequence),
         typeTags: [emojicoin, emojicoinLP],
       });
-    const { response, error: _ } = (await submit(builderLambda)) ?? {};
-    if (response && isUserTransactionResponse(response)) {
-      console.warn(response);
-    }
+    await submit(builderLambda);
     clear();
   };
+
+  // TODO: Add infinite scroll to this.
+  // For now just don't render more than `HARD_LIMIT` swaps.
+  const sortedChats = useMemo(() => {
+    const HARD_LIMIT = 500;
+    return toSortedDedupedEvents(props.data.chats, chats, "desc").slice(0, HARD_LIMIT);
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [props.data.chats.length, chats.length]);
 
   return (
     <Column className="relative" width="100%" flexGrow={1}>
@@ -126,7 +130,7 @@ const ChatBox = (props: ChatProps) => {
             flexDirection: "column-reverse",
           }}
         >
-          {chats.map((chat, index) => {
+          {sortedChats.map((chat, index) => {
             const message = {
               // TODO: Resolve address to Aptos name, store in state.
               sender: chat.user,

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -96,7 +96,7 @@ const ChatBox = (props: ChatProps) => {
   };
 
   // TODO: Add infinite scroll to this.
-  // For now just don't render more than `HARD_LIMIT` swaps.
+  // For now just don't render more than `HARD_LIMIT` chats.
   const sortedChats = useMemo(() => {
     const HARD_LIMIT = 500;
     return toSortedDedupedEvents(props.data.chats, chats, "desc").slice(0, HARD_LIMIT);

--- a/src/typescript/frontend/src/lib/store/event-utils.ts
+++ b/src/typescript/frontend/src/lib/store/event-utils.ts
@@ -30,34 +30,6 @@ if (MODULE_ADDRESS.toStringWithoutPrefix().startsWith("0")) {
   console.error("-".repeat(80) + "\n");
 }
 
-export const mergeSortedEvents = <T extends AnyEmojicoinEvent>(
-  existing: readonly T[],
-  incoming: T[]
-): T[] => {
-  const merged: T[] = [];
-  let i = 0;
-  let j = 0;
-  while (i < existing.length && j < incoming.length) {
-    if (existing[i].version > incoming[j].version) {
-      merged.push(existing[i]);
-      i++;
-    } else {
-      merged.push(incoming[j]);
-      j++;
-    }
-  }
-  while (i < existing.length) {
-    merged.push(existing[i]);
-    i++;
-  }
-  while (j < incoming.length) {
-    merged.push(incoming[j]);
-    j++;
-  }
-
-  return merged;
-};
-
 type AnyDBJsonEvent = DBJsonData<AnyEmojicoinJSONEvent>;
 
 export type EventDeserializationFunction<

--- a/src/typescript/frontend/src/lib/utils/sort-events.ts
+++ b/src/typescript/frontend/src/lib/utils/sort-events.ts
@@ -24,58 +24,45 @@ export const sortByValue = <T extends bigint | number>(
   return order === "desc" ? -1 : 1;
 };
 
+type Chat = Types.ChatEvent;
+type Swap = Types.SwapEvent;
+type Liquidity = Types.LiquidityEvent;
+type State = Types.StateEvent;
+type PeriodicState = Types.PeriodicStateEvent;
+type MarketRegistration = Types.MarketRegistrationEvent;
+type GlobalState = Types.GlobalStateEvent;
+
 /**
- * This function sorts and returns a copied array.
+ * This function sorts an array. It does *NOT* mutate the original array.
  * NOTE: It assumes that the array is homogenous.
  */
-export const toSortedEvents = <
-  T extends
-    | Types.ChatEvent
-    | Types.SwapEvent
-    | Types.LiquidityEvent
-    | Types.StateEvent
-    | Types.PeriodicStateEvent
-    | Types.MarketRegistrationEvent
-    | Types.GlobalStateEvent,
->(
-  arr: readonly T[],
+export const sortEvents = <T extends AnyEmojicoinEvent>(
+  arr: T[],
   order: "asc" | "desc" = "desc"
-): T[] => {
+) => {
   if (arr.length <= 1) {
-    return [...arr];
+    return;
   } else {
     if (isChatEvent(arr[0])) {
-      return (arr as readonly Types.ChatEvent[]).toSorted((a, b) =>
-        sortByValue(a.emitMarketNonce, b.emitMarketNonce, order)
-      ) as T[];
+      (arr as Chat[]).sort((a, b) => sortByValue(a.emitMarketNonce, b.emitMarketNonce, order));
     } else if (isSwapEvent(arr[0])) {
-      return (arr as readonly Types.SwapEvent[]).toSorted((a, b) =>
-        sortByValue(a.marketNonce, b.marketNonce, order)
-      ) as T[];
+      (arr as Swap[]).sort((a, b) => sortByValue(a.marketNonce, b.marketNonce, order));
     } else if (isLiquidityEvent(arr[0])) {
-      return (arr as readonly Types.SwapEvent[]).toSorted((a, b) =>
-        sortByValue(a.marketNonce, b.marketNonce, order)
-      ) as T[];
+      (arr as Liquidity[]).sort((a, b) => sortByValue(a.marketNonce, b.marketNonce, order));
     } else if (isStateEvent(arr[0])) {
-      return (arr as readonly Types.StateEvent[]).toSorted((a, b) =>
-        sortByValue(a.lastSwap.nonce, b.lastSwap.nonce, order)
-      ) as T[];
+      (arr as State[]).sort((a, b) => sortByValue(a.lastSwap.nonce, b.lastSwap.nonce, order));
     } else if (isPeriodicStateEvent(arr[0])) {
-      return (arr as readonly Types.PeriodicStateEvent[]).toSorted((a, b) =>
+      (arr as PeriodicState[]).sort((a, b) =>
         sortByValue(
           a.periodicStateMetadata.emitMarketNonce,
           b.periodicStateMetadata.emitMarketNonce,
           order
         )
-      ) as T[];
+      );
     } else if (isMarketRegistrationEvent(arr[0])) {
-      return (arr as readonly Types.MarketRegistrationEvent[]).toSorted((a, b) =>
-        sortByValue(a.marketID, b.marketID, order)
-      ) as T[];
+      (arr as MarketRegistration[]).sort((a, b) => sortByValue(a.marketID, b.marketID, order));
     } else if (isGlobalStateEvent(arr[0])) {
-      return (arr as readonly Types.GlobalStateEvent[]).toSorted((a, b) =>
-        sortByValue(a.registryNonce, b.registryNonce, order)
-      ) as T[];
+      (arr as GlobalState[]).sort((a, b) => sortByValue(a.registryNonce, b.registryNonce, order));
     } else {
       throw new Error("Invalid array type.");
     }
@@ -121,5 +108,6 @@ export const toSortedDedupedEvents = <T extends AnyEmojicoinEvent>(
     recorded.add(event.guid);
     return true;
   });
-  return toSortedEvents(deduped, order);
+  sortEvents(deduped, order);
+  return deduped;
 };

--- a/src/typescript/frontend/src/lib/utils/sort-events.ts
+++ b/src/typescript/frontend/src/lib/utils/sort-events.ts
@@ -1,0 +1,125 @@
+import {
+  type AnyEmojicoinEvent,
+  isChatEvent,
+  isGlobalStateEvent,
+  isLiquidityEvent,
+  isMarketRegistrationEvent,
+  isPeriodicStateEvent,
+  isStateEvent,
+  isSwapEvent,
+  type Types,
+} from "@sdk-types";
+
+export const sortByValue = <T extends bigint | number>(
+  nonceA: T,
+  nonceB: T,
+  order: "asc" | "desc" = "desc"
+) => {
+  if (nonceA === nonceB) {
+    return 0;
+  }
+  if (nonceA < nonceB) {
+    return order === "desc" ? 1 : -1;
+  }
+  return order === "desc" ? -1 : 1;
+};
+
+/**
+ * This function sorts and returns a copied array.
+ * NOTE: It assumes that the array is homogenous.
+ */
+export const toSortedEvents = <
+  T extends
+    | Types.ChatEvent
+    | Types.SwapEvent
+    | Types.LiquidityEvent
+    | Types.StateEvent
+    | Types.PeriodicStateEvent
+    | Types.MarketRegistrationEvent
+    | Types.GlobalStateEvent,
+>(
+  arr: readonly T[],
+  order: "asc" | "desc" = "desc"
+): T[] => {
+  if (arr.length <= 1) {
+    return [...arr];
+  } else {
+    if (isChatEvent(arr[0])) {
+      return (arr as readonly Types.ChatEvent[]).toSorted((a, b) =>
+        sortByValue(a.emitMarketNonce, b.emitMarketNonce, order)
+      ) as T[];
+    } else if (isSwapEvent(arr[0])) {
+      return (arr as readonly Types.SwapEvent[]).toSorted((a, b) =>
+        sortByValue(a.marketNonce, b.marketNonce, order)
+      ) as T[];
+    } else if (isLiquidityEvent(arr[0])) {
+      return (arr as readonly Types.SwapEvent[]).toSorted((a, b) =>
+        sortByValue(a.marketNonce, b.marketNonce, order)
+      ) as T[];
+    } else if (isStateEvent(arr[0])) {
+      return (arr as readonly Types.StateEvent[]).toSorted((a, b) =>
+        sortByValue(a.lastSwap.nonce, b.lastSwap.nonce, order)
+      ) as T[];
+    } else if (isPeriodicStateEvent(arr[0])) {
+      return (arr as readonly Types.PeriodicStateEvent[]).toSorted((a, b) =>
+        sortByValue(
+          a.periodicStateMetadata.emitMarketNonce,
+          b.periodicStateMetadata.emitMarketNonce,
+          order
+        )
+      ) as T[];
+    } else if (isMarketRegistrationEvent(arr[0])) {
+      return (arr as readonly Types.MarketRegistrationEvent[]).toSorted((a, b) =>
+        sortByValue(a.marketID, b.marketID, order)
+      ) as T[];
+    } else if (isGlobalStateEvent(arr[0])) {
+      return (arr as readonly Types.GlobalStateEvent[]).toSorted((a, b) =>
+        sortByValue(a.registryNonce, b.registryNonce, order)
+      ) as T[];
+    } else {
+      throw new Error("Invalid array type.");
+    }
+  }
+};
+
+export const mergeSortedEvents = <T extends AnyEmojicoinEvent>(
+  existing: readonly T[],
+  incoming: T[]
+): T[] => {
+  const merged: T[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < existing.length && j < incoming.length) {
+    if (existing[i].version > incoming[j].version) {
+      merged.push(existing[i]);
+      i++;
+    } else {
+      merged.push(incoming[j]);
+      j++;
+    }
+  }
+  while (i < existing.length) {
+    merged.push(existing[i]);
+    i++;
+  }
+  while (j < incoming.length) {
+    merged.push(incoming[j]);
+    j++;
+  }
+
+  return merged;
+};
+
+export const toSortedDedupedEvents = <T extends AnyEmojicoinEvent>(
+  a: readonly T[],
+  b: readonly T[],
+  order: "asc" | "desc" = "desc"
+) => {
+  const recorded = new Set<string>();
+  const deduped = [...a, ...b].filter((event) => {
+    if (recorded.has(event.guid)) return false;
+    recorded.add(event.guid);
+    return true;
+  });
+  return toSortedEvents(deduped, order);
+};


### PR DESCRIPTION
# Description

Every once in a while the component display gets out of sync and it appears the data is delayed but it's actually just at the bottom of the component. I believe this is due to the way the server component (React Server Component, aka RSC) data is merged with the state data. Initially it's RSC payload => state data later.

But if you refresh the page, I believe it's existing state data => RSC payload, which contradicts the normal assumptions I made when displaying this data.

To ensure there are no issues with data presentation, I've added a useMemo function to merge, deduplicate, and sort the swap and chat data from the server and from state.

While this won't ensure we never see stale data, which we will fully address later, it eliminates a possible source of incorrect data presentation.

# Testing

Delete this sentence and provide a description of how to test the changes in
this PR.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

