### PR TITLE
[ECO-1959] Miscellaneous small frontend fixes

### DIFF
--- a/src/typescript/frontend/src/components/emoji-picker/ColoredBytesIndicator.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/ColoredBytesIndicator.tsx
@@ -31,11 +31,11 @@ export const ColoredBytesIndicator = ({ className = "" }: { className?: string }
           transition: { duration: 0.1, repeat: 0 },
         }}
         style={{ scale: 1 }}
-        className={textColorBySum(length, threshold)}
+        className={textColorBySum(length, threshold) + " !no-underline"}
       >
         {length}
       </motion.span>
-      <span className="text-white -rotate-[30deg]">{"/"}</span>
+      <span className="text-white -rotate-[30deg] select-none">{"/"}</span>
       <span className="text-white">{`${threshold}${mode === "register" ? " bytes" : ""}`}</span>
     </div>
   );

--- a/src/typescript/frontend/src/components/error-boundary/styles.css
+++ b/src/typescript/frontend/src/components/error-boundary/styles.css
@@ -19,7 +19,7 @@ p {
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  height: 100vh;
+  height: 100dvh;
 }
 
 .error-container__title {

--- a/src/typescript/frontend/src/components/header/components/mobile-menu-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu-item/index.tsx
@@ -10,6 +10,7 @@ import { type MobileMenuItemProps } from "./types";
 import { StyledItemWrapper } from "./styled";
 
 const MobileMenuItem: React.FC<MobileMenuItemProps> = ({
+  withIcon,
   title,
   onClick = () => {},
   borderBottom = true,
@@ -23,10 +24,21 @@ const MobileMenuItem: React.FC<MobileMenuItemProps> = ({
   });
 
   return (
-    <StyledItemWrapper onMouseOver={replay} onClick={onClick} borderBottom={borderBottom}>
-      <Text textScale="pixelHeading3" color="black" textTransform="uppercase" ref={ref} />
-
-      <Arrow width="18px" color="black" />
+    <StyledItemWrapper
+      onMouseOver={replay}
+      onClick={onClick}
+      borderBottom={borderBottom}
+    >
+      <div className={withIcon?.className}>
+        {withIcon?.icon}
+        <Text
+          textScale={withIcon ? "pixelHeading4" : "pixelHeading3"}
+          color="black"
+          textTransform="uppercase"
+          ref={ref}
+        />
+      </div>
+      {!withIcon && <Arrow width="18px" color="black" />}
     </StyledItemWrapper>
   );
 };

--- a/src/typescript/frontend/src/components/header/components/mobile-menu-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu-item/index.tsx
@@ -24,11 +24,7 @@ const MobileMenuItem: React.FC<MobileMenuItemProps> = ({
   });
 
   return (
-    <StyledItemWrapper
-      onMouseOver={replay}
-      onClick={onClick}
-      borderBottom={borderBottom}
-    >
+    <StyledItemWrapper onMouseOver={replay} onClick={onClick} borderBottom={borderBottom}>
       <div className={withIcon?.className}>
         {withIcon?.icon}
         <Text

--- a/src/typescript/frontend/src/components/header/components/mobile-menu-item/types.ts
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu-item/types.ts
@@ -1,4 +1,10 @@
+import { type ReactElement } from "react";
+
 export type MobileMenuItemProps = {
+  withIcon?: {
+    className: string;
+    icon: ReactElement;
+  }
   title: string;
   onClick?: () => void;
   borderBottom?: boolean;

--- a/src/typescript/frontend/src/components/header/components/mobile-menu-item/types.ts
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu-item/types.ts
@@ -4,7 +4,7 @@ export type MobileMenuItemProps = {
   withIcon?: {
     className: string;
     icon: ReactElement;
-  }
+  };
   title: string;
   onClick?: () => void;
   borderBottom?: boolean;

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/animations.ts
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/animations.ts
@@ -8,7 +8,7 @@ export const slideVariants = {
     opacity: 1,
     transition: {
       duration: 0.3,
-      type: "easyInOut",
+      type: "easeInOut",
     },
   },
 };

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/animations.ts
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/animations.ts
@@ -1,6 +1,6 @@
 export const slideVariants = {
   hidden: {
-    y: "100vh",
+    y: "100dvh",
     opacity: 0,
   },
   visible: {

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/components/animated-dropdown-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/components/animated-dropdown-item/index.tsx
@@ -1,10 +1,5 @@
 import MobileMenuItem from "components/header/components/mobile-menu-item";
-import {
-  type AnimationControls,
-  motion,
-  type TargetAndTransition,
-  type VariantLabels,
-} from "framer-motion";
+import { type AnimationControls, motion } from "framer-motion";
 import { type ReactElement } from "react";
 
 export const AnimatedDropdownItem = ({

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/components/animated-dropdown-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/components/animated-dropdown-item/index.tsx
@@ -1,14 +1,11 @@
 import MobileMenuItem from "components/header/components/mobile-menu-item";
-import { type AnimationControls, motion } from "framer-motion";
+import {
+  type AnimationControls,
+  motion,
+  type TargetAndTransition,
+  type VariantLabels,
+} from "framer-motion";
 import { type ReactElement } from "react";
-
-export const AnimatedBorder = ({ controls }: { controls: AnimationControls }) => (
-  <motion.div
-    animate={controls}
-    initial={{ opacity: 0 }}
-    className="absolute border-b border-dashed border-b-dark-gray bg-transparent h-[1px] w-full"
-  />
-);
 
 export const AnimatedDropdownItem = ({
   title,
@@ -26,7 +23,12 @@ export const AnimatedDropdownItem = ({
   return (
     <>
       <div className="relative">
-        <motion.div className="overflow-hidden" animate={controls} initial={{ height: 0 }}>
+        <motion.div
+          className="overflow-hidden"
+          animate={controls}
+          initial={{ height: 0 }}
+          exit={{ height: 0 }}
+        >
           <MobileMenuItem
             title={title}
             withIcon={{
@@ -37,7 +39,12 @@ export const AnimatedDropdownItem = ({
             borderBottom={false}
           />
         </motion.div>
-        <AnimatedBorder controls={borderControls} />
+        <motion.div
+          animate={borderControls}
+          initial={{ opacity: 0 }}
+          exit={{ opacity: 0 }}
+          className="absolute border-b border-dashed border-b-dark-gray bg-transparent h-[1px] w-full"
+        />
       </div>
     </>
   );

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/components/animated-dropdown-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/components/animated-dropdown-item/index.tsx
@@ -1,0 +1,46 @@
+import MobileMenuItem from "components/header/components/mobile-menu-item";
+import { type AnimationControls, motion } from "framer-motion";
+import { type ReactElement } from "react";
+
+export const AnimatedBorder = ({ controls }: { controls: AnimationControls }) => (
+  <motion.div
+    animate={controls}
+    initial={{ opacity: 0 }}
+    className="absolute border-b border-dashed border-b-dark-gray bg-transparent h-[1px] w-full"
+  />
+);
+
+export const AnimatedDropdownItem = ({
+  title,
+  icon,
+  onClick,
+  controls,
+  borderControls,
+}: {
+  title: string;
+  icon: ReactElement;
+  onClick?: () => void;
+  controls: AnimationControls;
+  borderControls: AnimationControls;
+}) => {
+  return (
+    <>
+      <div className="relative">
+        <motion.div className="overflow-hidden" animate={controls} initial={{ height: 0 }}>
+          <MobileMenuItem
+            title={title}
+            withIcon={{
+              icon,
+              className: "flex flex-row h-full min-h-[40px] justify-center items-center",
+            }}
+            onClick={onClick}
+            borderBottom={false}
+          />
+        </motion.div>
+        <AnimatedBorder controls={borderControls} />
+      </div>
+    </>
+  );
+};
+
+export default AnimatedDropdownItem;

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -37,12 +37,22 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
 
   useEffect(() => {
     if (isOpen) {
-      document.body.style.overflow = "hidden";
+      document.body.style.overflow = "clip";
+      document.body.style.margin = "0";
+      document.body.style.padding = "0";
+      document.body.style.boxSizing = "border-box";
+      
     } else {
       document.body.style.overflow = "auto";
+      document.body.style.margin = "unset";
+      document.body.style.padding = "unset";
+      document.body.style.boxSizing = "unset";
     }
     return () => {
       document.body.style.overflow = "auto";
+      document.body.style.margin = "unset";
+      document.body.style.padding = "unset";
+      document.body.style.boxSizing = "unset";
     };
   }, [isOpen]);
 

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import { MobileMenuInner, MobileMenuWrapper, StyledMotion } from "./styled";
-import { Link } from "components/link";
+import { EXTERNAL_LINK_PROPS, Link } from "components/link";
 import { Flex } from "@containers";
 import { MobileSocialLinks } from "./components/mobile-social-links";
 import { MobileMenuItem } from "../index";
@@ -10,6 +10,19 @@ import { type MobileMenuProps } from "./types";
 
 import { slideVariants } from "./animations";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
+import { useAptos } from "context/wallet-context/AptosContextProvider";
+import {
+  APTOS_CONNECT_ACCOUNT_URL,
+  isAptosConnectWallet,
+  useWallet,
+} from "@aptos-labs/wallet-adapter-react";
+import { Copy, LogOut, User } from "lucide-react";
+import { useWalletModal } from "context/wallet-context/WalletModalContext";
+import { motion, useAnimationControls } from "framer-motion";
+import AnimatedDropdownItem from "./components/animated-dropdown-item";
+import AnimatedBorder from "./components/animated-dropdown-item/AnimatedBorder";
+
+const IconClass = "w-[22px] h-[22px] m-auto ml-[3ch] mr-[1.5ch]";
 
 export const MobileMenu: React.FC<MobileMenuProps> = ({
   isOpen,
@@ -17,6 +30,10 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
   linksForCurrentPage,
   offsetHeight,
 }) => {
+  const { wallet, account, disconnect } = useWallet();
+  const { copyAddress } = useAptos();
+  const { openWalletModal } = useWalletModal();
+
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = "hidden";
@@ -32,6 +49,43 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
     setIsOpen(false);
   };
 
+  const subMenuControls = useAnimationControls();
+  const borderControls = useAnimationControls();
+  const [subMenuOpen, setSubMenuOpen] = useState(false);
+
+  const handleCloseSubMenu = useCallback(() => {
+    setSubMenuOpen(false);
+    borderControls.start({ opacity: 0 });
+    subMenuControls.start({ height: 0 });
+  }, [subMenuControls, borderControls]);
+
+  useEffect(() => {
+    if (!account) {
+      handleCloseSubMenu();
+    }
+    /* eslint-disable-next-line */
+  }, [account]);
+
+  const subMenuOnClick = async () => {
+    if (!account) {
+      openWalletModal();
+    } else {
+      if (!subMenuOpen) {
+        await borderControls.start({
+          opacity: 1,
+          transition: { delay: 0, duration: 0 },
+        });
+        await subMenuControls.start({ height: 40 });
+        setSubMenuOpen(true);
+      } else {
+        const a = borderControls.start({ opacity: 0 });
+        const b = subMenuControls.start({ height: 0 });
+        await Promise.all([a, b]);
+        setSubMenuOpen(false);
+      }
+    }
+  };
+
   return (
     <StyledMotion
       initial="hidden"
@@ -41,7 +95,35 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
     >
       <MobileMenuWrapper offsetHeight={offsetHeight}>
         <MobileMenuInner>
-          <ButtonWithConnectWalletFallback className="w-full" mobile={true} />
+          <ButtonWithConnectWalletFallback
+            className="w-full"
+            mobile={true}
+            onClick={subMenuOnClick}
+          />
+          {wallet && isAptosConnectWallet(wallet) && (
+            <a href={APTOS_CONNECT_ACCOUNT_URL} {...EXTERNAL_LINK_PROPS}>
+              <AnimatedDropdownItem
+                title="Account"
+                icon={<User className={IconClass} />}
+                controls={subMenuControls}
+                borderControls={borderControls}
+              />
+            </a>
+          )}
+          <AnimatedDropdownItem
+            title="Copy address"
+            icon={<Copy className={IconClass} />}
+            onClick={copyAddress}
+            controls={subMenuControls}
+            borderControls={borderControls}
+          />
+          <AnimatedDropdownItem
+            title="Disconnect"
+            icon={<LogOut className={IconClass} />}
+            onClick={disconnect}
+            controls={subMenuControls}
+            borderControls={borderControls}
+          />
           {linksForCurrentPage.map(({ title, path }, i) => {
             return (
               <Link key={title} href={path} onClick={handleCloseMobileMenu} width="100%">

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import { MobileMenuInner, MobileMenuWrapper, StyledMotion } from "./styled";
 import { EXTERNAL_LINK_PROPS, Link } from "components/link";
-import { Flex } from "@containers";
 import { MobileSocialLinks } from "./components/mobile-social-links";
 import { MobileMenuItem } from "../index";
 
@@ -38,21 +37,11 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = "clip";
-      document.body.style.margin = "0";
-      document.body.style.padding = "0";
-      document.body.style.boxSizing = "border-box";
-      
     } else {
       document.body.style.overflow = "auto";
-      document.body.style.margin = "unset";
-      document.body.style.padding = "unset";
-      document.body.style.boxSizing = "unset";
     }
     return () => {
       document.body.style.overflow = "auto";
-      document.body.style.margin = "unset";
-      document.body.style.padding = "unset";
-      document.body.style.boxSizing = "unset";
     };
   }, [isOpen]);
 
@@ -102,11 +91,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
   };
 
   return (
-    <StyledMotion
-      initial="hidden"
-      animate={isOpen ? "visible" : "hidden"}
-      variants={slideVariants}
-    >
+    <StyledMotion initial="hidden" animate={isOpen ? "visible" : "hidden"} variants={slideVariants}>
       <MobileMenuWrapper>
         <MobileMenuInner>
           <ButtonWithConnectWalletFallback
@@ -159,9 +144,9 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
           })}
         </MobileMenuInner>
 
-        <Flex position="absolute" bottom="60px" justifyContent="center" width="100%">
+        <div className="flex fixed bottom-[60px] justify-center w-full">
           <MobileSocialLinks />
-        </Flex>
+        </div>
       </MobileMenuWrapper>
     </StyledMotion>
   );

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -27,7 +27,6 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
   isOpen,
   setIsOpen,
   linksForCurrentPage,
-  offsetHeight,
 }) => {
   const { wallet, account, disconnect } = useWallet();
   const { copyAddress } = useAptos();
@@ -97,9 +96,8 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
       initial="hidden"
       animate={isOpen ? "visible" : "hidden"}
       variants={slideVariants}
-      offsetHeight={offsetHeight}
     >
-      <MobileMenuWrapper offsetHeight={offsetHeight}>
+      <MobileMenuWrapper>
         <MobileMenuInner>
           <ButtonWithConnectWalletFallback
             className="w-full"

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/styled.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/styled.tsx
@@ -17,12 +17,11 @@ export const MobileMenuWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-height: 100vh;
-  min-height: 100vh;
+  height: 100dvh;
   justify-content: center;
   align-items: center;
   background-color: ${ECONIA_BLUE};
-  padding: 60px 18px;
+  padding: 0 18px;
 `;
 
 export const MobileMenuInner = styled.div`

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/styled.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/styled.tsx
@@ -1,26 +1,27 @@
 import styled from "styled-components";
 import { motion } from "framer-motion";
+import { ECONIA_BLUE } from "theme/colors";
 
-export const StyledMotion = styled(motion.div)<{ offsetHeight: number }>`
+export const StyledMotion = styled(motion.div)`
   position: fixed;
   bottom: 0;
-  top: ${({ offsetHeight }) => offsetHeight}px;
+  top: 0;
   right: 0;
   left: 0;
   z-index: ${({ theme }) => theme.zIndices.modal};
-  background-color: ${({ theme }) => theme.colors.econiaBlue};
+  background-color: ${ECONIA_BLUE};
 `;
 
-export const MobileMenuWrapper = styled.div<{ offsetHeight: number }>`
+export const MobileMenuWrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
-  min-height: ${({ offsetHeight }) => `calc(100dvh - ${offsetHeight}px)`};
+  max-height: 100vh;
+  min-height: 100vh;
   justify-content: center;
   align-items: center;
-  background-color: ${({ theme }) => theme.colors.econiaBlue};
+  background-color: ${ECONIA_BLUE};
   padding: 60px 18px;
 `;
 
@@ -28,5 +29,4 @@ export const MobileMenuInner = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  transform: translateY(-50%);
 `;

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/types.ts
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/types.ts
@@ -4,5 +4,4 @@ export interface MobileMenuProps {
   isOpen: boolean;
   setIsOpen: (arg: boolean) => void;
   linksForCurrentPage: (typeof NAVIGATE_LINKS)[number][];
-  offsetHeight: number;
 }

--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -86,12 +86,7 @@ const Header: React.FC<HeaderProps> = ({ isOpen, setIsOpen }) => {
           )}
         </Flex>
       </Container>
-      <MobileMenu
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        linksForCurrentPage={linksForCurrentPage}
-        offsetHeight={offsetHeight}
-      />
+      <MobileMenu isOpen={isOpen} setIsOpen={setIsOpen} linksForCurrentPage={linksForCurrentPage} />
     </StyledContainer>
   );
 };

--- a/src/typescript/frontend/src/components/header/styled.tsx
+++ b/src/typescript/frontend/src/components/header/styled.tsx
@@ -30,7 +30,7 @@ export const StyledMobileHeader = styled(motion.div)`
   top: 0;
   right: 0;
   left: 0;
-  z-index: ${({ theme }) => theme.zIndices.modal};
+  z-index: ${({ theme }) => theme.zIndices.modal + 1};
   background-color: ${({ theme }) => theme.colors.econiaBlue};
   padding: 24px;
   align-items: center;

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -49,6 +49,7 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
     overdrive: false,
     speed: 0.5,
     ignore: [" "],
+    playOnMount: mobile,
     onAnimationStart: () => setEnabled(false),
     onAnimationEnd: () => setEnabled(true),
   });

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -22,7 +22,7 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
   onClick,
 }) => {
   const { connected, account } = useWallet();
-  const { connectWallet } = useWalletModal();
+  const { openWalletModal } = useWalletModal();
   const { t } = translationFunction();
 
   const [enabled, setEnabled] = useState(false);
@@ -70,7 +70,7 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
           }
           onClick={(e) => {
             e.preventDefault();
-            onClick ? onClick() : connectWallet();
+            onClick ? onClick() : openWalletModal();
             handleReplay();
           }}
           onMouseOver={handleReplay}

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -66,7 +66,7 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
       {!connected || !children ? (
         <Button
           className={
-            className + (mobile ? " px-[9px] border-b border-b-dashed border-dark-gray" : "")
+            className + (mobile ? " px-[9px] border-dashed border-b border-b-dark-gray" : "")
           }
           onClick={(e) => {
             e.preventDefault();

--- a/src/typescript/frontend/src/components/link/const.ts
+++ b/src/typescript/frontend/src/components/link/const.ts
@@ -4,4 +4,4 @@
 export const EXTERNAL_LINK_PROPS = {
   target: "_blank",
   rel: "noreferrer noopener",
-};
+} as const;

--- a/src/typescript/frontend/src/components/loader/index.tsx
+++ b/src/typescript/frontend/src/components/loader/index.tsx
@@ -6,7 +6,7 @@ import SpinnerIcon from "components/svg/icons/Spinner";
 
 const Loader: React.FC<FlexProps> = (props) => {
   return (
-    <Flex justifyContent="center" alignItems="center" height="100vh" {...props}>
+    <Flex justifyContent="center" alignItems="center" height="100dvh" {...props}>
       <SpinnerIcon width="44px" />
     </Flex>
   );

--- a/src/typescript/frontend/src/components/modal/BaseModal.tsx
+++ b/src/typescript/frontend/src/components/modal/BaseModal.tsx
@@ -31,8 +31,7 @@ export const BaseModal: React.FC<
         <div className="fixed inset-0 overflow-y-auto">
           <div className="flex min-h-full items-center justify-center p-4 text-center">
             <DialogPanel
-              className={`w-full
-              ${className} max-w-4xl transform border bg-transparent align-middle shadow-xl`}
+              className={`${className} max-w-4xl transform border bg-transparent align-middle shadow-xl`}
             >
               {showBackButton ? (
                 <DialogTitle as="div">

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/ClientLaunchEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/ClientLaunchEmojicoinPage.tsx
@@ -24,7 +24,7 @@ const ClientLaunchEmojicoinPage = () => {
   const registerMarket = useRegisterMarket();
   const setPickerInvisible = useInputStore((state) => state.setPickerInvisible);
   const length = sumBytes(emojis);
-  const invalid = length === 0 || length >= 10;
+  const invalid = length === 0 || length > 10;
 
   useEffect(() => {
     setMode("register");

--- a/src/typescript/frontend/src/components/pages/not-found.tsx
+++ b/src/typescript/frontend/src/components/pages/not-found.tsx
@@ -10,7 +10,7 @@ import { Page } from "components/layout/components/page";
 import Button from "components/button";
 
 export const StyledNotFoundPage = styled(Page)`
-  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
@@ -59,9 +59,9 @@ export const ClientVerifyPage = () => {
 
   return (
     <>
-      <div className="absolute top-0 left-0 w-full h-full bg-black z-50 overflow-clip">
+      <div className="absolute top-0 left-0 w-full h-full bg-black z-50 overflow-hidden">
         <div className="flex items-center justify-center w-full h-full">
-          <div className="flex flex-col uppercase text-ec-blue gap-4 text-2xl">
+          <div className="flex flex-col justify-begin uppercase text-ec-blue gap-4 text-2xl">
             {connected && verified === false && (
               <motion.div
                 onMouseEnter={replayBack}

--- a/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
@@ -59,7 +59,7 @@ export const ClientVerifyPage = () => {
 
   return (
     <>
-      <div className="absolute top-0 left-0 w-full h-full bg-black z-50 overflow-hidden">
+      <div className="absolute top-0 left-0 w-[100dvw] h-[100dvh] bg-black z-50 overflow-hidden">
         <div className="flex items-center justify-center w-full h-full">
           <div className="flex flex-col justify-begin uppercase text-ec-blue gap-4 text-2xl">
             {connected && verified === false && (

--- a/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
@@ -4,15 +4,14 @@ import { type AccountInfo, useWallet } from "@aptos-labs/wallet-adapter-react";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useCallback, useEffect, useState } from "react";
-import { darkColors } from "theme";
 import { createSession } from "./session";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 import { useScramble } from "use-scramble";
+import { motion } from "framer-motion";
 
 export const ClientVerifyPage = () => {
   const { account } = useAptos();
-  const { connected } = useWallet();
-  const [enabled, setEnabled] = useState(false);
+  const { connected, disconnect } = useWallet();
   const [verified, setVerified] = useState<boolean | null>(null);
 
   const { ref, replay } = useScramble({
@@ -25,8 +24,14 @@ export const ClientVerifyPage = () => {
     overdrive: false,
     overflow: true,
     speed: 0.6,
-    onAnimationStart: () => setEnabled(false),
-    onAnimationEnd: () => setEnabled(true),
+    playOnMount: true,
+  });
+
+  const { ref: backRef, replay: replayBack } = useScramble({
+    text: "Back",
+    overdrive: false,
+    overflow: true,
+    speed: 0.6,
   });
 
   const verify = useCallback(
@@ -45,52 +50,50 @@ export const ClientVerifyPage = () => {
     }
   }, [account, connected, verify]);
 
-  const handleReplay = useCallback(() => {
-    if (enabled) {
+  useEffect(() => {
+    setTimeout(() => {
       replay();
-    }
-  }, [enabled, replay]);
+    }, 300);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [verified]);
 
   return (
     <>
-      <div
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          width: "100vw",
-          height: "100vh",
-          backgroundColor: darkColors.black,
-          zIndex: 50,
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            width: "100vw",
-            height: "100vh",
-            textTransform: "uppercase",
-            color: darkColors.econiaBlue,
-            gap: "1rem",
-            fontSize: "1.5rem",
-          }}
-        >
-          <ButtonWithConnectWalletFallback>
-            <div className="flex flex-row">
-              <span className="px-2.5">{"{"}</span>
-              <a
-                ref={ref}
-                href={process.env.NEXT_PUBLIC_GALXE_CAMPAIGN_REDIRECT}
-                className="uppercase"
-                onMouseOver={handleReplay}
-                {...EXTERNAL_LINK_PROPS}
-              />
-              <span className="px-2.5">{"}"}</span>
-            </div>
-          </ButtonWithConnectWalletFallback>
+      <div className="absolute top-0 left-0 w-full h-full bg-black z-50 overflow-clip">
+        <div className="flex items-center justify-center w-full h-full">
+          <div className="flex flex-col uppercase text-ec-blue gap-4 text-2xl">
+            {connected && verified === false && (
+              <motion.div
+                onMouseEnter={replayBack}
+                animate={{ x: 0, y: -60 }}
+                initial={{ x: 2000, y: -60 }}
+                className="absolute flex flex-row px-2.5 hover:cursor-pointer min-w-[12ch] top-[50%]"
+                onClick={() => {
+                  setVerified(null);
+                  disconnect();
+                }}
+                transition={{
+                  type: "just",
+                  duration: 0.3,
+                }}
+              >
+                <span>{"<<"}&nbsp;</span>
+                <span ref={backRef}>Back</span>
+              </motion.div>
+            )}
+            <ButtonWithConnectWalletFallback>
+              <div className="flex flex-row uppercase">
+                <span className="px-2.5">{"{"}</span>
+                <a
+                  ref={ref}
+                  href={process.env.NEXT_PUBLIC_GALXE_CAMPAIGN_REDIRECT}
+                  onMouseEnter={replay}
+                  {...EXTERNAL_LINK_PROPS}
+                />
+                <span className="px-2.5">{"}"}</span>
+              </div>
+            </ButtonWithConnectWalletFallback>
+          </div>
         </div>
       </div>
     </>

--- a/src/typescript/frontend/src/components/svg/icons/RiseIcon.tsx
+++ b/src/typescript/frontend/src/components/svg/icons/RiseIcon.tsx
@@ -1,4 +1,5 @@
 import React, { type SVGProps } from "react";
+import { ECONIA_BLUE } from "theme/colors";
 
 const RiseIcon = (props: SVGProps<SVGSVGElement>) => {
   return (
@@ -16,7 +17,7 @@ const RiseIcon = (props: SVGProps<SVGSVGElement>) => {
       />
       <path
         d="M24.8524 15.2288C24.7774 15.6549 24.3708 15.9999 23.9454 15.9999H16.0001L15.0705 21.2729C14.9956 21.699 14.5897 22.044 14.1636 22.044H6.98934C6.5632 22.044 6.2791 21.699 6.35403 21.2729L7.14778 16.771C7.22271 16.3449 7.62934 15.9999 8.05471 15.9999H16.0001L16.9296 10.7269C17.0046 10.3008 17.4104 9.95581 17.8366 9.95581H25.0108C25.437 9.95581 25.7211 10.3008 25.6461 10.7269L24.8524 15.2288Z"
-        fill="#AAAAAA"
+        fill={ECONIA_BLUE}
       />
     </svg>
   );

--- a/src/typescript/frontend/src/components/wallet/WalletDropdownItem.tsx
+++ b/src/typescript/frontend/src/components/wallet/WalletDropdownItem.tsx
@@ -1,0 +1,42 @@
+import { DropdownItem } from "components/dropdown-menu";
+import { motion } from "framer-motion";
+import { type PropsWithChildren, type ReactElement, useState } from "react";
+import { useScramble } from "use-scramble";
+
+const handleReplay = (enabled: boolean, replay: () => void) => {
+  if (enabled) {
+    replay();
+  }
+};
+
+export type WalletDropdownItemProps = {
+  onSelect?: () => void;
+  scrambleText: string;
+  icon: ReactElement;
+} & PropsWithChildren;
+
+export const WalletDropdownItem = ({ onSelect, scrambleText, icon }: WalletDropdownItemProps) => {
+  const [enabled, setEnabled] = useState(true);
+  const { ref, replay } = useScramble({
+    text: scrambleText,
+    overdrive: false,
+    overflow: false,
+    speed: 0.7,
+    playOnMount: false,
+    onAnimationStart: () => setEnabled(false),
+    onAnimationEnd: () => setEnabled(true),
+  });
+
+  return (
+    <DropdownItem
+      onSelect={onSelect}
+      className="hover:bg-[#00000018] focus:outline-none"
+      onMouseEnter={() => handleReplay(enabled, replay)}
+    >
+      <motion.div whileTap={{ scale: 0.95 }} className="flex flex-row gap-2 items-center p-2">
+        {icon}
+        <span ref={ref}>{scrambleText}</span>
+      </motion.div>
+    </DropdownItem>
+  );
+};

--- a/src/typescript/frontend/src/components/wallet/WalletDropdownMenu.tsx
+++ b/src/typescript/frontend/src/components/wallet/WalletDropdownMenu.tsx
@@ -9,20 +9,21 @@ import {
   DropdownMenu,
   DropdownTrigger,
 } from "components/dropdown-menu";
-import React, { useCallback, useMemo, useState } from "react";
-import { toast } from "react-toastify";
+import React, { useMemo, useState } from "react";
 import { User, Copy, LogOut } from "lucide-react";
 import { translationFunction } from "context/language-context";
 import { truncateAddress } from "@sdk/utils/misc";
 import { useScramble } from "use-scramble";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 import { WalletDropdownItem } from "./WalletDropdownItem";
+import { useAptos } from "context/wallet-context/AptosContextProvider";
 
 const WIDTH = "24ch";
 
 const WalletDropdownMenu = () => {
   const { t } = translationFunction();
   const { account, disconnect, wallet } = useWallet();
+  const { copyAddress } = useAptos();
   const [enabled, setEnabled] = useState(true);
 
   const text = useMemo(() => {
@@ -32,22 +33,6 @@ const WalletDropdownMenu = () => {
       return t("Connected");
     }
   }, [account, t]);
-
-  const copyAddress = useCallback(async () => {
-    if (!account?.address) return;
-    try {
-      await navigator.clipboard.writeText(account.address);
-      toast.success("Copied address to clipboard! 📋", {
-        pauseOnFocusLoss: false,
-        autoClose: 2000,
-      });
-    } catch {
-      toast.error("Failed to copy address to clipboard. 😓", {
-        pauseOnFocusLoss: false,
-        autoClose: 2000,
-      });
-    }
-  }, [account?.address]);
 
   const { ref, replay } = useScramble({
     text,

--- a/src/typescript/frontend/src/components/wallet/WalletDropdownMenu.tsx
+++ b/src/typescript/frontend/src/components/wallet/WalletDropdownMenu.tsx
@@ -1,24 +1,28 @@
-import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import {
+  APTOS_CONNECT_ACCOUNT_URL,
+  isAptosConnectWallet,
+  useWallet,
+} from "@aptos-labs/wallet-adapter-react";
 import {
   DropdownArrow,
   DropdownContent,
-  DropdownItem,
   DropdownMenu,
   DropdownTrigger,
 } from "components/dropdown-menu";
 import React, { useCallback, useMemo, useState } from "react";
 import { toast } from "react-toastify";
-import { Copy, LogOut } from "lucide-react";
+import { User, Copy, LogOut } from "lucide-react";
 import { translationFunction } from "context/language-context";
 import { truncateAddress } from "@sdk/utils/misc";
 import { useScramble } from "use-scramble";
-import { motion } from "framer-motion";
+import { EXTERNAL_LINK_PROPS } from "components/link";
+import { WalletDropdownItem } from "./WalletDropdownItem";
 
 const WIDTH = "24ch";
 
 const WalletDropdownMenu = () => {
   const { t } = translationFunction();
-  const { account, disconnect } = useWallet();
+  const { account, disconnect, wallet } = useWallet();
   const [enabled, setEnabled] = useState(true);
 
   const text = useMemo(() => {
@@ -60,32 +64,8 @@ const WalletDropdownMenu = () => {
   }, [text]);
 
   const handleReplay = (enabled: boolean, replay: () => void) => {
-    if (enabled) {
-      replay();
-    }
+    if (enabled) replay();
   };
-
-  const [copyEnabled, setCopyEnabled] = useState(true);
-  const { ref: copyRef, replay: copyReplay } = useScramble({
-    text: "Copy address",
-    overdrive: false,
-    overflow: false,
-    speed: 0.7,
-    playOnMount: false,
-    onAnimationStart: () => setCopyEnabled(false),
-    onAnimationEnd: () => setCopyEnabled(true),
-  });
-
-  const [disconnectEnabled, setDisconnectEnabled] = useState(true);
-  const { ref: disconnectRef, replay: disconnectReplay } = useScramble({
-    text: "Disconnect",
-    overdrive: false,
-    overflow: false,
-    speed: 0.7,
-    playOnMount: false,
-    onAnimationStart: () => setDisconnectEnabled(false),
-    onAnimationEnd: () => setDisconnectEnabled(true),
-  });
 
   return (
     <div
@@ -116,26 +96,21 @@ const WalletDropdownMenu = () => {
           side="bottom"
         >
           <DropdownArrow className="fill-ec-blue" visibility="visible" />
-          <DropdownItem
+          {wallet && isAptosConnectWallet(wallet) && (
+            <a href={APTOS_CONNECT_ACCOUNT_URL} {...EXTERNAL_LINK_PROPS}>
+              <WalletDropdownItem scrambleText="Account" icon={<User className="h-4 w-4" />} />
+            </a>
+          )}
+          <WalletDropdownItem
             onSelect={copyAddress}
-            className="hover:bg-[#00000018] focus:outline-none"
-            onMouseEnter={() => handleReplay(copyEnabled, copyReplay)}
-          >
-            <motion.div whileTap={{ scale: 0.95 }} className="flex flex-row gap-2 items-center p-2">
-              <Copy className="h-4 w-4" />
-              <span ref={copyRef}>Copy address</span>
-            </motion.div>
-          </DropdownItem>
-          <DropdownItem
+            scrambleText="Copy address"
+            icon={<Copy className="h-4 w-4" />}
+          />
+          <WalletDropdownItem
             onSelect={disconnect}
-            className="hover:bg-[#00000018] focus:outline-none"
-            onMouseEnter={() => handleReplay(disconnectEnabled, disconnectReplay)}
-          >
-            <motion.div whileTap={{ scale: 0.95 }} className="flex flex-row gap-2 items-center p-2">
-              <LogOut className="h-4 w-4" />
-              <span ref={disconnectRef}>Disconnect</span>
-            </motion.div>
-          </DropdownItem>
+            scrambleText="Disconnect"
+            icon={<LogOut className="h-4 w-4" />}
+          />
         </DropdownContent>
       </DropdownMenu>
     </div>

--- a/src/typescript/frontend/src/components/wallet/WalletModal.tsx
+++ b/src/typescript/frontend/src/components/wallet/WalletModal.tsx
@@ -197,7 +197,7 @@ export const WalletModal = ({
 
   return (
     <BaseModal
-      className="md:w-[430px]"
+      className="w-[430px]"
       isOpen={open}
       onClose={handleClose}
       showBackButton={false}

--- a/src/typescript/frontend/src/context/ContentWrapper.tsx
+++ b/src/typescript/frontend/src/context/ContentWrapper.tsx
@@ -1,6 +1,6 @@
 export const ContentWrapper = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="flex flex-col max-w-[100vw] pl-0 pr-0 h-[100vh] overflow-x-hidden">
+    <div className="flex flex-col max-w-[100dvw] pl-0 pr-0 h-[100dvh] overflow-x-hidden">
       {/* eslint-disable-next-line react/no-unknown-property */}
       <style jsx>{`
         div::-webkit-scrollbar {

--- a/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
+++ b/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
@@ -30,6 +30,7 @@ export type AptosContextState = {
   submit: (builderFn: () => Promise<EntryFunctionTransactionBuilder>) => SubmissionResponse;
   signThenSubmit: (builderFn: () => Promise<EntryFunctionTransactionBuilder>) => SubmissionResponse;
   account: WalletContextState["account"];
+  copyAddress: () => void;
 };
 
 export const AptosContext = createContext<AptosContextState | undefined>(undefined);
@@ -50,6 +51,22 @@ export function AptosContextProvider({ children }: PropsWithChildren) {
     }
     return getAptos();
   }, [network]);
+
+  const copyAddress = useCallback(async () => {
+    if (!account?.address) return;
+    try {
+      await navigator.clipboard.writeText(account.address);
+      toast.success("Copied address to clipboard! 📋", {
+        pauseOnFocusLoss: false,
+        autoClose: 2000,
+      });
+    } catch {
+      toast.error("Failed to copy address to clipboard. 😓", {
+        pauseOnFocusLoss: false,
+        autoClose: 2000,
+      });
+    }
+  }, [account?.address]);
 
   const handleTransactionSubmission = useCallback(
     async (
@@ -145,6 +162,7 @@ export function AptosContextProvider({ children }: PropsWithChildren) {
     account,
     submit,
     signThenSubmit,
+    copyAddress,
   };
 
   return <AptosContext.Provider value={value}>{children}</AptosContext.Provider>;

--- a/src/typescript/frontend/src/context/wallet-context/WalletModalContext.tsx
+++ b/src/typescript/frontend/src/context/wallet-context/WalletModalContext.tsx
@@ -2,7 +2,7 @@ import { createContext, type PropsWithChildren, useContext, useState } from "rea
 import { WalletModal } from "components/wallet/WalletModal";
 
 export type WalletModalContextState = {
-  connectWallet: () => void;
+  openWalletModal: () => void;
 };
 
 export const WalletModalContext = createContext<WalletModalContextState | undefined>(undefined);
@@ -10,7 +10,7 @@ export const WalletModalContext = createContext<WalletModalContextState | undefi
 export function WalletModalContextProvider({ children }: PropsWithChildren) {
   const [open, setOpen] = useState<boolean>(false);
   const value: WalletModalContextState = {
-    connectWallet: () => {
+    openWalletModal: () => {
       setOpen(true);
     },
   };


### PR DESCRIPTION
# Description

- [x] Fix Rise icon (fill the icon with the correct color)
- [x] Fix "connect wallet" underline styling for mobile
- [x] Fix the styling for when connected
- [x] ~Fix the underline style in # of bytes indicated on mobile (on register market)~
  - [x] Can't figure this out. No documentation on it online. Not a big deal. Some weird issue on chrome mobile.
- [x] Allow users to disconnect from aptos connect wallet on Mobile by adding a slot in the mobile menu
- [x] Allow users to go to their Aptos Connect page by:
  - [x] Adding a slot in the mobile menu
  - [x] Adding a slot in the dropdown menu on desktop
- [x] Fix # of bytes in emojicoin launch page (fixed invalid # of bytes to `> 10` instead of `>= 10`)
- [x] Added a `<< Back` button to the `Verify` page
- [x] Fixed some questionable code for the mobile menu modal. Centered things more robustly without javascript hacks to get element sizes

# Testing

Visual/manual testing.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
