### PR TITLE
[ECO-1983] Fix borders for trade history entries

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/table-row/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/table-row/index.tsx
@@ -39,22 +39,17 @@ const TableCellStyles = "h-[33px]";
 const TableRow = ({ item, showBorder }: TableRowDesktopProps) => {
   const { theme } = useThemeContext();
   const [isPopupVisible, setIsPopupVisible] = useState(false);
-  const [isHover, setIsHover] = useState(false);
   return (
-    <tr
-      className={TableRowStyles}
-      onMouseEnter={() => setIsHover(true)}
-      onMouseLeave={() => setIsHover(false)}
-      style={{
-        boxShadow:
-          isHover && showBorder
-            ? "var(--ec-blue) 1px 1px inset, var(--ec-blue) -1px -1px inset"
-            : "",
-      }}
-      id="grid-hover"
-    >
+    <tr className={TableRowStyles} id="grid-hover">
       <td
-        className={`min-w-[60px] xl:min-w-[71px] xl:ml-[0.5ch] xl:mr-[-0.5ch] ${TableCellStyles} relative`}
+        className={
+          "absolute w-full h-full bg-transparent group-hover:inline-flex " +
+          "border-b-[1px] border-solid group-hover:border-[1px] group-hover:border-ec-blue z-[1] border-dark-gray" +
+          (showBorder ? "" : " border-b-transparent")
+        }
+      />
+      <td
+        className={`min-w-[60px] xl:min-w-[71px] xl:ml-[0.5ch] xl:mr-[-0.5ch] ${TableCellStyles}`}
       >
         <div
           style={{

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.css
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.css
@@ -1,5 +1,5 @@
 .scrollbar-track::-webkit-scrollbar-track {
-  border-left: 1px solid #33343D;
+  border-left: 1px solid #33343d;
 }
 
 .scrollbar-track::-webkit-scrollbar-thumb {

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.css
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.css
@@ -1,3 +1,7 @@
+.scrollbar-track::-webkit-scrollbar-track {
+  border-left: 1px solid #33343D;
+}
+
 .scrollbar-track::-webkit-scrollbar-thumb {
   background: #086cd9;
   border-radius: 2px;


### PR DESCRIPTION

# Description
The borders for trade history row entries was removed in a previous PR but shouldn't have been.

- [x] Add them back in.
- [x] Works with no trades, some trades, and more than 10 trades (scrollbar present)
- [x] Looks good on mobile

# Testing

Visual

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
