### PR TITLE
[ECO-1991] Fix emoji name resolution in `middleware.ts`

### DIFF
--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -5,7 +5,7 @@ import {
 import { authenticate } from "components/pages/verify/verify";
 import { NextResponse, type NextRequest } from "next/server";
 import { ROUTES } from "router/routes";
-import { normalizeMarketPath } from "utils/pathname-helpers";
+import { normalizePossibleMarketPath } from "utils/pathname-helpers";
 
 export default async function middleware(request: NextRequest) {
   const pathname = new URL(request.url).pathname;
@@ -17,14 +17,11 @@ export default async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Parse the path if it's an emojicoin market path. If the path has emojis in it,
-  // this will resolve the emojis to their names and normalize the path with the correct delimiters.
-  if (pathname.startsWith("/market/")) {
-    const newPath = normalizeMarketPath(pathname, request.url);
-    if (newPath) {
-      return NextResponse.redirect(newPath);
-    }
+  const possibleMarketPath = normalizePossibleMarketPath(pathname, request.url);
+  if (possibleMarketPath) {
+    return NextResponse.redirect(possibleMarketPath);
   }
+  
   const hashed = request.cookies.get(COOKIE_FOR_HASHED_ADDRESS)?.value;
   const address = request.cookies.get(COOKIE_FOR_ACCOUNT_ADDRESS)?.value;
 

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -16,9 +16,14 @@ export default async function middleware(request: NextRequest) {
   ) {
     return NextResponse.next();
   }
+
+  // Parse the path if it's an emojicoin market path. If the path has emojis in it,
+  // this will resolve the emojis to their names and normalize the path with the correct delimiters.
   if (pathname.startsWith("/market/")) {
     const newPath = normalizeMarketPath(pathname, request.url);
-    return NextResponse.redirect(newPath);
+    if (newPath) {
+      return NextResponse.redirect(newPath);
+    }
   }
   const hashed = request.cookies.get(COOKIE_FOR_HASHED_ADDRESS)?.value;
   const address = request.cookies.get(COOKIE_FOR_ACCOUNT_ADDRESS)?.value;

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -1,4 +1,3 @@
-import { SYMBOL_DATA } from "@sdk/emoji_data";
 import {
   COOKIE_FOR_ACCOUNT_ADDRESS,
   COOKIE_FOR_HASHED_ADDRESS,
@@ -6,6 +5,7 @@ import {
 import { authenticate } from "components/pages/verify/verify";
 import { NextResponse, type NextRequest } from "next/server";
 import { ROUTES } from "router/routes";
+import { normalizeMarketPath } from "utils/pathname-helpers";
 
 export default async function middleware(request: NextRequest) {
   const pathname = new URL(request.url).pathname;
@@ -17,13 +17,8 @@ export default async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
   if (pathname.startsWith("/market/")) {
-    const slug = decodeURIComponent(pathname.slice(8));
-    const emojis = [...new Intl.Segmenter().segment(slug)].map((x) => x.segment);
-    const chars = emojis.map((x) => SYMBOL_DATA.byEmoji(x)?.name);
-    if (chars.reduce((p, c) => p && c !== undefined, true)) {
-      const name = chars.join(";");
-      return NextResponse.redirect(new URL(`/market/${name}`, request.url));
-    }
+    const newPath = normalizeMarketPath(pathname, request.url);
+    return NextResponse.redirect(newPath);
   }
   const hashed = request.cookies.get(COOKIE_FOR_HASHED_ADDRESS)?.value;
   const address = request.cookies.get(COOKIE_FOR_ACCOUNT_ADDRESS)?.value;

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -21,7 +21,7 @@ export default async function middleware(request: NextRequest) {
   if (possibleMarketPath) {
     return NextResponse.redirect(possibleMarketPath);
   }
-  
+
   const hashed = request.cookies.get(COOKIE_FOR_HASHED_ADDRESS)?.value;
   const address = request.cookies.get(COOKIE_FOR_ACCOUNT_ADDRESS)?.value;
 

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -21,7 +21,7 @@ export default async function middleware(request: NextRequest) {
     const emojis = [...new Intl.Segmenter().segment(slug)].map((x) => x.segment);
     const chars = emojis.map((x) => SYMBOL_DATA.byEmoji(x)?.name);
     if (chars.reduce((p, c) => p && c !== undefined, true)) {
-      const name = chars.join(",");
+      const name = chars.join(";");
       return NextResponse.redirect(new URL(`/market/${name}`, request.url));
     }
   }

--- a/src/typescript/frontend/src/utils/pathname-helpers.ts
+++ b/src/typescript/frontend/src/utils/pathname-helpers.ts
@@ -1,4 +1,6 @@
+import { SYMBOL_DATA } from "@sdk/emoji_data/symbol-data";
 import { languageList } from "configs";
+import { NextRequest, NextResponse } from "next/server";
 
 export const removeLangParamFromPathname = (pathname: string, language?: string) => {
   return pathname
@@ -30,10 +32,39 @@ export const removeTrailingSlashIfExists = (path: string) => {
   return path;
 };
 
+/**
+ * The delimiter for multiple emoji names; i.e.,
+ * for splitting "emoji_name_1;emoji_name_2"
+ */
+export const EMOJI_PATH_DELIMITER = ";";
+
+/**
+ * The delimiter for intra-segment emoji names; i.e.,
+ * for changing "Happy face emoji" to "Happy_face_emoji".
+ */
+export const EMOJI_PATH_INTRASEGMENT_DELIMITER = "_";
+
+export const ONE_SPACE = " ";
+
+export const emojisToPath = (emojis: string[]) => {
+  const names = emojis
+    .map((x) => SYMBOL_DATA.byEmoji(x)?.name)
+    .filter((x) => typeof x !== "undefined");
+  return emojiNamesToPath(names);
+};
+
 export const emojiNamesToPath = (emojiNames: string[]) =>
-  emojiNames.map((x) => encodeURIComponent(x.replace(/ /g, "_"))).join(";");
+  emojiNames
+    .map((x) => encodeURIComponent(x.replaceAll(ONE_SPACE, EMOJI_PATH_INTRASEGMENT_DELIMITER)))
+    .join(EMOJI_PATH_DELIMITER);
 
 export const pathToEmojiNames = (path: string) =>
   decodeURIComponent(path)
-    .split(";")
-    .map((n) => n.replace(/_/g, " "));
+    .split(EMOJI_PATH_DELIMITER)
+    .map((n) => n.replaceAll(EMOJI_PATH_INTRASEGMENT_DELIMITER, ONE_SPACE));
+
+export const normalizeMarketPath = (pathname: string, requestUrlString: string) => {
+  const slug = decodeURIComponent(pathname.slice(8));
+  const emojis = [...new Intl.Segmenter().segment(slug)].map((x) => x.segment);
+  return new URL(`market/${emojisToPath(emojis)}`, requestUrlString);
+};

--- a/src/typescript/frontend/src/utils/pathname-helpers.ts
+++ b/src/typescript/frontend/src/utils/pathname-helpers.ts
@@ -1,6 +1,5 @@
 import { SYMBOL_DATA } from "@sdk/emoji_data/symbol-data";
 import { languageList } from "configs";
-import { NextRequest, NextResponse } from "next/server";
 import { ROUTES } from "router/routes";
 
 export const removeLangParamFromPathname = (pathname: string, language?: string) => {

--- a/src/typescript/frontend/src/utils/pathname-helpers.ts
+++ b/src/typescript/frontend/src/utils/pathname-helpers.ts
@@ -42,7 +42,7 @@ export const EMOJI_PATH_DELIMITER = ";";
  * The delimiter for intra-segment emoji names; i.e.,
  * for changing "Happy face emoji" to "Happy_face_emoji".
  */
-export const EMOJI_PATH_INTRASEGMENT_DELIMITER = "_";
+export const EMOJI_PATH_INTRA_SEGMENT_DELIMITER = "_";
 
 export const ONE_SPACE = " ";
 
@@ -55,17 +55,17 @@ export const emojisToPath = (emojis: string[]) => {
 
 export const emojiNamesToPath = (emojiNames: string[]) =>
   emojiNames
-    .map((x) => encodeURIComponent(x.replaceAll(ONE_SPACE, EMOJI_PATH_INTRASEGMENT_DELIMITER)))
+    .map((x) => encodeURIComponent(x.replaceAll(ONE_SPACE, EMOJI_PATH_INTRA_SEGMENT_DELIMITER)))
     .join(EMOJI_PATH_DELIMITER);
 
 export const pathToEmojiNames = (path: string) =>
   decodeURIComponent(path)
     .split(EMOJI_PATH_DELIMITER)
-    .map((n) => n.replaceAll(EMOJI_PATH_INTRASEGMENT_DELIMITER, ONE_SPACE));
+    .map((n) => n.replaceAll(EMOJI_PATH_INTRA_SEGMENT_DELIMITER, ONE_SPACE));
 
 /**
  * Used to normalize a potential emojicoin market path by replacing emojis with their properly
- * path-ified names based on our routing conventions.
+ * normalized paths based on our routing conventions.
  * @param pathname
  * @param requestUrlString
  * @returns a normalized path we can redirect to.

--- a/src/typescript/frontend/src/utils/pathname-helpers.ts
+++ b/src/typescript/frontend/src/utils/pathname-helpers.ts
@@ -1,6 +1,7 @@
 import { SYMBOL_DATA } from "@sdk/emoji_data/symbol-data";
 import { languageList } from "configs";
 import { NextRequest, NextResponse } from "next/server";
+import { ROUTES } from "router/routes";
 
 export const removeLangParamFromPathname = (pathname: string, language?: string) => {
   return pathname
@@ -63,9 +64,19 @@ export const pathToEmojiNames = (path: string) =>
     .split(EMOJI_PATH_DELIMITER)
     .map((n) => n.replaceAll(EMOJI_PATH_INTRASEGMENT_DELIMITER, ONE_SPACE));
 
-export const normalizeMarketPath = (pathname: string, requestUrlString: string) => {
-  const slug = decodeURIComponent(pathname.slice(8));
-  const emojis = [...new Intl.Segmenter().segment(slug)].map((x) => x.segment);
-  const normalizedPath = emojisToPath(emojis);
-  return normalizedPath.length === 0 ? undefined : new URL(`${normalizedPath}`, requestUrlString);
+/**
+ * Used to normalize a potential emojicoin market path by replacing emojis with their properly
+ * path-ified names based on our routing conventions.
+ * @param pathname
+ * @param requestUrlString
+ * @returns a normalized path we can redirect to.
+ */
+export const normalizePossibleMarketPath = (pathname: string, requestUrlString: string) => {
+  if (pathname.startsWith(`${ROUTES.market}/`)) {
+    const slug = decodeURIComponent(pathname.slice(8));
+    const emojis = [...new Intl.Segmenter().segment(slug)].map((x) => x.segment);
+    const normalizedPath = emojisToPath(emojis);
+    return normalizedPath.length === 0 ? undefined : new URL(`${normalizedPath}`, requestUrlString);
+  }
+  return undefined;
 };

--- a/src/typescript/frontend/src/utils/pathname-helpers.ts
+++ b/src/typescript/frontend/src/utils/pathname-helpers.ts
@@ -49,7 +49,7 @@ export const ONE_SPACE = " ";
 export const emojisToPath = (emojis: string[]) => {
   const names = emojis
     .map((x) => SYMBOL_DATA.byEmoji(x)?.name)
-    .filter((x) => typeof x !== "undefined");
+    .filter((x) => typeof x !== "undefined") as string[];
   return emojiNamesToPath(names);
 };
 

--- a/src/typescript/frontend/src/utils/pathname-helpers.ts
+++ b/src/typescript/frontend/src/utils/pathname-helpers.ts
@@ -66,5 +66,6 @@ export const pathToEmojiNames = (path: string) =>
 export const normalizeMarketPath = (pathname: string, requestUrlString: string) => {
   const slug = decodeURIComponent(pathname.slice(8));
   const emojis = [...new Intl.Segmenter().segment(slug)].map((x) => x.segment);
-  return new URL(`market/${emojisToPath(emojis)}`, requestUrlString);
+  const normalizedPath = emojisToPath(emojis);
+  return normalizedPath.length === 0 ? undefined : new URL(`${normalizedPath}`, requestUrlString);
 };


### PR DESCRIPTION
# Description

- The middleware.ts resolves names by joining them with a comma even though the standard is using a ; semicolon.
- This PR aims to fix it and consolidate the logic to a single place.
- [x] Fix broken name resolution
- [x] Consolidate the logic so we can change it in a single place and not have to worry about it breaking later

# Testing

Test registering a market and test viewing markets that already exist with multiple emojis.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

