### PR TITLE
[ECO-1950] Add local caching for trade and swap history

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -17,7 +17,7 @@ import useInputStore from "@store/input-store";
 import EmojiPickerWithInput from "../../../../emoji-picker/EmojiPickerWithInput";
 import { getRankFromChatEvent } from "lib/utils/get-user-rank";
 import { toSortedDedupedEvents } from "lib/utils/sort-events";
-import { Types } from "@sdk/types/types";
+import type { Types } from "@sdk/types/types";
 import { parseJSON } from "utils";
 
 const convertChatMessageToEmojiAndIndices = (

--- a/src/typescript/frontend/src/lib/utils/sort-events.ts
+++ b/src/typescript/frontend/src/lib/utils/sort-events.ts
@@ -33,7 +33,7 @@ type MarketRegistration = Types.MarketRegistrationEvent;
 type GlobalState = Types.GlobalStateEvent;
 
 /**
- * This function sorts an array. It does *NOT* mutate the original array.
+ * This function sorts an array. It mutates the original array and returns nothing.
  * NOTE: It assumes that the array is homogenous.
  */
 export const sortEvents = <T extends AnyEmojicoinEvent>(

--- a/src/typescript/sdk/src/emoji_data/utils.ts
+++ b/src/typescript/sdk/src/emoji_data/utils.ts
@@ -164,12 +164,9 @@ export const isValidEmojiHex = (input: HexInput) => {
 export const encodeEmojis = (emojis: string[]) => {
   const encoder = new TextEncoder();
   // eslint-disable-next-line prefer-template
-  return (
-    `0x${
-    emojis.reduce(
-      (acc: string, emoji) =>
-        `${acc}${[...encoder.encode(emoji)].map((e) => e.toString(16)).join("")}`,
-      ""
-    )}`
-  );
+  return `0x${emojis.reduce(
+    (acc: string, emoji) =>
+      `${acc}${[...encoder.encode(emoji)].map((e) => e.toString(16)).join("")}`,
+    ""
+  )}`;
 };

--- a/src/typescript/sdk/src/types/types.ts
+++ b/src/typescript/sdk/src/types/types.ts
@@ -8,16 +8,18 @@ import { type EMOJICOIN_DOT_FUN_MODULE_NAME } from "../const";
 
 export type AnyNumberString = number | string | bigint;
 
+export type EventName =
+  | "Swap"
+  | "Chat"
+  | "MarketRegistration"
+  | "PeriodicState"
+  | "State"
+  | "GlobalState"
+  | "Liquidity";
+
 export type WithVersionAndGUID = {
   version: number;
-  guid: `${
-    | "Swap"
-    | "Chat"
-    | "MarketRegistration"
-    | "PeriodicState"
-    | "State"
-    | "GlobalState"
-    | "Liquidity"}::${string}`;
+  guid: `${EventName}::${string}`;
 };
 
 export type WithMarketID = {
@@ -699,4 +701,28 @@ export function isLiquidityEvent(e: AnyEmojicoinEvent): e is Types.LiquidityEven
 
 export function isPeriodicStateView(e: any): e is Types.PeriodicStateView {
   return typeof e.startTime === "number" && isPeriodicStateEvent(e);
+}
+
+// NOTE: The below code structure strongly suggests we should be using classes instead of types.
+// However, we cannot use them with server components easily- hence the following code.
+export function getEmojicoinEventTime(e: AnyEmojicoinEvent): bigint {
+  if (isSwapEvent(e)) return e.time;
+  if (isChatEvent(e)) return e.emitTime;
+  if (isMarketRegistrationEvent(e)) return e.time;
+  if (isPeriodicStateEvent(e)) return e.periodicStateMetadata.emitTime;
+  if (isStateEvent(e)) return e.stateMetadata.bumpTime;
+  if (isGlobalStateEvent(e)) return e.emitTime;
+  if (isLiquidityEvent(e)) return e.time;
+  throw new Error(`Unknown event type: ${e}`);
+}
+
+export function getEventTypeName(e: AnyEmojicoinEvent): EventName {
+  if (isSwapEvent(e)) return "Swap";
+  if (isChatEvent(e)) return "Chat";
+  if (isMarketRegistrationEvent(e)) return "MarketRegistration";
+  if (isPeriodicStateEvent(e)) return "PeriodicState";
+  if (isStateEvent(e)) return "State";
+  if (isGlobalStateEvent(e)) return "GlobalState";
+  if (isLiquidityEvent(e)) return "Liquidity";
+  throw new Error(`Unknown event type: ${e}`);
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR stores the latest trades in `localStorage` to avoid not seeing your
trades when refreshing really quick after a trade.

Trade A will be deleted from `localStorage` after a trade B that happens 60
seconds after trade A. This ensures every trade is saved for at least 60
seconds, which should always be enough for inbox to catch up.

# Testing

Make a trade and refresh as fast as possible. The trade should appear in trade
history.

Check the `Application` tab in your browser dev tools and check that there is a
field named `swaps` in your `localStorage` after making a trade.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?
