### PR TITLE
[ECO-2025] Remove invalid emojis from emoji picker based on mode

### DIFF
--- a/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
+++ b/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
@@ -1,21 +1,79 @@
 "use client";
-// cspell:word couldn
 
-import { type HTMLAttributes, Suspense, useEffect } from "react";
+import { type HTMLAttributes, Suspense, use, useEffect, useMemo } from "react";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { default as Picker } from "@emoji-mart/react";
 import { init, SearchIndex } from "emoji-mart";
 import { type EmojiMartData, type EmojiPickerSearchData, type EmojiSelectorData } from "./types";
 import { unifiedCodepointsToEmoji } from "utils/unified-codepoint-to-emoji";
-import { type EmojiName, type SymbolEmojiData } from "@sdk/emoji_data";
+import { SYMBOL_DATA, type SymbolEmojiData } from "@sdk/emoji_data";
 import { normalizeHex } from "@sdk/utils";
+import { sumBytes } from "@sdk/utils/sum-emoji-bytes";
 
-// This is 400KB of lots of repeated data, we can use a smaller version of this if necessary later.
-// TBH, we should probably just fork the library.
+// We need to create two sets of data - one for the emoji picker for registration or home/pools ("search") mode and
+// another for the emoji picker for chat mode.
+// The non-chat data will basically exclude all skin variants that won't fit in the 10-byte limit.
+
+// In order to exclude symbol emojis that are too big in a way that is compliant with the emoji mart data,
+// we'll have to create separate IDs for the register mode data. We'll create custom emojis (it lets us create them)
+// with those IDs and then include/exclude them based on the mode.
+
+// THEN, we'll also iterate over the current # of emojis, and if all invariants are invalid (because too many bytes,
+// or the ensuing combinations are all already registered markets), we'll exclude the emoji ID from the picker.
+
+// Essentially we'll have to create three sets of emoji IDs, where they're all completely distinct values:
+// 1. IDs that are valid for both register + chat
+// 2. IDs that are valid for chat only
+// 3. IDs that are valid for register only
+//
+// We exclude #2 when we're in register mode, and we exclude #3 when we're in chat mode.
+
+// 1. Test adding custom emojis and see how it works. See if we can truly split them into two sets.
+
 const data = fetch("https://cdn.jsdelivr.net/npm/@emoji-mart/data@latest/sets/15/native.json").then(
   (res) =>
-    res.json().then((data) => {
-      return data as EmojiMartData;
+    res.json().then((data: EmojiMartData) => {
+      const emojisToPickerIDs = new Map<string, string>();
+      const invalidSymbolEmojiIDs = new Set<string>();
+      const validSymbolEmojiIDs = new Set<string>();
+      const chatEmojiData = new Map<string, SymbolEmojiData>();
+
+      Object.keys(data.emojis).forEach((key) => {
+        const skinVariants = data.emojis[key].skins.map((skin) => skin.unified);
+        const { name, id } = data.emojis[key];
+        // To be safe, we parse and store this data ourselves, instead of relying on the library
+        // for the native emoji value.
+        const asEmojis = skinVariants.map((skin) =>
+          unifiedCodepointsToEmoji(skin as `${string}-${string}`)
+        );
+        // Because the emoji picker groups each emoji by its skin tone variants, we can only exclude emojis
+        // where *none* of the skin tone variants are valid.
+        let allVariantsInvalid = true;
+        asEmojis.forEach((emoji) => {
+          const bytes = new TextEncoder().encode(emoji);
+          const hex = normalizeHex(bytes);
+          emojisToPickerIDs.set(emoji, id);
+          allVariantsInvalid = allVariantsInvalid && !SYMBOL_DATA.hasEmoji(emoji);
+          chatEmojiData.set(emoji, {
+            name,
+            emoji,
+            hex,
+            bytes,
+          });
+        });
+        if (allVariantsInvalid) {
+          invalidSymbolEmojiIDs.add(id);
+        } else {
+          validSymbolEmojiIDs.add(id);
+        }
+      });
+      return {
+        emojiMartData: data,
+        emojisToPickerIDs,
+        invalidSymbolEmojiIDs,
+        validSymbolEmojiIDs,
+        chatEmojiData,
+      };
     })
 );
 
@@ -33,68 +91,56 @@ export default function EmojiPicker(props: HTMLAttributes<HTMLDivElement>) {
   const mode = useEmojiPicker((s) => s.mode);
   const onClickOutside = useEmojiPicker((s) => s.onClickOutside);
   const host = document.querySelector("em-emoji-picker");
-  const insertEmojiTextInput = useEmojiPicker((s) => s.insertEmojiTextInput);
+  const setEmojis = useEmojiPicker((s) => s.setEmojis);
+  const emojis = useEmojiPicker((s) => s.emojis);
+
+  const {
+    emojiMartData,
+    emojisToPickerIDs,
+    invalidSymbolEmojiIDs,
+    validSymbolEmojiIDs,
+    chatEmojiData,
+  } = use(data);
+
+  const exclusionSet = useMemo(() => {
+    if (mode === "register" && emojiMartData) {
+      // Exclude any non-symbol emojis.
+      console.log(invalidSymbolEmojiIDs.values());
+      const exclusionSet = Array.from(invalidSymbolEmojiIDs.values());
+      // console.log(exclusionSet);
+      // const exclusionSet = new Set(invalidSymbolEmojiIDs);
+      const numBytes = sumBytes(emojis);
+      // Exclude any emojis that would exceed the byte limit.
+      for (const emojiID of validSymbolEmojiIDs) {
+        const emoji = emojiMartData.emojis[emojiID];
+        // const emojiData = SYMBOL_DATA.byID(emojiID);
+        // if (emojiData && numBytes + emojiData.bytes.length > 10) {
+        // exclusionSet.add(emojiID);
+        // }
+      }
+
+      return exclusionSet;
+    }
+    return [];
+  }, [mode, emojiMartData, emojis, invalidSymbolEmojiIDs]);
+
+  useEffect(() => {
+    init({ set: "native", data: emojiMartData });
+  }, [emojiMartData]);
 
   // TODO: Verify that the length of this set is the same length as the valid chat emojis array in the Move contract.
   // Load the data from the emoji picker library and then extract the valid chat emojis from it.
   // This way we don't have to construct our own `chat-emojis.json` file.
   useEffect(() => {
-    data.then((d) => {
-      const chatEmojiData = new Map<string, SymbolEmojiData>();
-
-      Object.keys(d.emojis).forEach((key) => {
-        const skinVariants = d.emojis[key].skins.map((skin) => skin.unified);
-        const name = d.emojis[key].name;
-        // To be safe, we parse and store this data ourselves, instead of relaying on the library
-        // for the native emoji value.
-        const asEmojis = skinVariants.map((skin) =>
-          unifiedCodepointsToEmoji(skin as `${string}-${string}`)
-        );
-        asEmojis.forEach((emoji) => {
-          const bytes = new TextEncoder().encode(emoji);
-          const hex = normalizeHex(bytes);
-          chatEmojiData.set(emoji, {
-            name: name as EmojiName,
-            emoji,
-            hex,
-            bytes,
-          });
-        });
-      });
-
-      setChatEmojiData(chatEmojiData);
-      init({ set: "native", data: d });
-    });
-
+    setChatEmojiData(chatEmojiData);
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, []);
+  }, [chatEmojiData]);
 
   useEffect(() => {
     setPickerRef(host as HTMLDivElement);
   }, [host, setPickerRef]);
 
   const previewSelector = host?.shadowRoot?.querySelector("div.margin-l");
-  const search = host?.shadowRoot?.querySelector("div.search input");
-
-  useEffect(() => {
-    if (!search || !host) return;
-    const inputHandler = (_e: Event) => {
-      const previewSubtitle = host.shadowRoot?.querySelector("div.preview-subtitle");
-      if (!previewSubtitle) return;
-      const text = previewSubtitle.textContent;
-      const failedSearch =
-        text && text.includes("That emoji couldn") && text.endsWith("t be found");
-      if (failedSearch) {
-        // There's a weird apostrophe character in the text, so just check startsWith and endsWith here.
-        previewSubtitle.textContent = "That emoji couldn't be found";
-      }
-    };
-    search?.addEventListener("input", inputHandler);
-
-    return () => {
-      search?.removeEventListener("input", inputHandler);
-    };
-  }, [search, host]);
 
   useEffect(() => {
     // We use query selector here because we're working with a shadow root in the DOM,
@@ -109,7 +155,6 @@ export default function EmojiPicker(props: HTMLAttributes<HTMLDivElement>) {
           mutations.forEach((mutation, _i) => {
             mutation.addedNodes.forEach((node) => {
               const text = node.textContent;
-
               // The `text` here is the short code the library uses, aka `:smile:` or `:rolling_on_the_floor_laughing:`
               if (text?.at(0) === ":" && text?.at(-1) === ":") {
                 // No matter what we need to replace the text, so let's just reset it if we can even find it.
@@ -132,7 +177,6 @@ export default function EmojiPicker(props: HTMLAttributes<HTMLDivElement>) {
                   const formattedBytes = `${" ".repeat(2 - bytes.length)}${bytes}`;
                   if (mode === "register" && numBytes > 10) {
                     const span = document.createElement("span");
-                    span.id = "emoji-byte-size";
                     node.textContent = "";
                     span.textContent = `${formattedBytes} bytes`;
                     span.style.setProperty("color", "red", "important");
@@ -174,6 +218,7 @@ export default function EmojiPicker(props: HTMLAttributes<HTMLDivElement>) {
       const sheet = new CSSStyleSheet();
       sheet.replaceSync(`
         section {
+          min-width: 316px !important;
           --font-family: var(--font-pixelar) !important;
           --font-transform: uppercase !important;
           text-transform: uppercase !important;
@@ -218,14 +263,41 @@ export default function EmojiPicker(props: HTMLAttributes<HTMLDivElement>) {
     <Suspense fallback={<div>Loading...</div>}>
       <div {...props}>
         <Picker
-          // TODO: Use this function later instead of the current stuff we have, aka using `onBlur()`.
           onClickOutside={onClickOutside}
-          perLine={8}
-          exceptEmojis={[]}
+          // perLine={8}
+          dynamicWidth
+          set="native" // TODO: Use "apple" if not on an apple device...? It has the best looking emojis.
+          exceptEmojis={exclusionSet}
           onEmojiSelect={(v: EmojiSelectorData) => {
             const newEmoji = unifiedCodepointsToEmoji(v.unified as `${string}-${string}`);
-            insertEmojiTextInput([newEmoji]);
+            setEmojis([newEmoji]);
           }}
+          custom={(() => {
+            const emojis = emojiMartData.emojis;
+            // We need to separate each individual category into the 3 sets of emoji IDs.
+            // where they are: pickerBaseEmojis, pickerChatEmojis, pickerSymbolEmojis.
+            // 1. If all variants are under 10 bytes, we include it in the base set and don't change its ID.
+            // 2. If any variants are over 10 bytes, we split the 10 byte emojis into a separate set.
+            //      a. The 10 byte emojis will have their IDs changed to `$CHAT::${emoji.id}`.
+            //      b. The < 10 byte emojis will have their IDs changed to `$REGISTER::${emoji.id}`.
+            //      c. Then we exclude the original ID of the emoji that contains the <=10 and >10 byte variants.
+            //      d. In summary, we create a custom ID for the first two, then exclude the original ID from the picker.
+            // 3. If all variants are over 10 bytes, for simplicity's sake, we'll remove the emoji from the base set
+            //    and add it to the > 10 byte set.
+
+            // First let's test that we can even create a custom emoji and remove the original one from the picker.
+            const last = emojiMartData.categories[0].emojis.pop();
+            console.log(emojiMartData.categories[0], last);
+            return null;
+            // Object.values(emojiMartData.categories).map(({ id, emojis }) => (
+            //   const
+
+            //   {
+            //   id: `custom-${emoji.id}`,
+            //   name: emoji.name,
+            //   emojis: emoji.skins
+            // }))
+          })()}
         />
       </div>
     </Suspense>


### PR DESCRIPTION
# Description

- [ ] Remove invalid emojis from emoji picker based on the current mode
- [ ] Chat does nothing different
- [ ] Register and search (aka pools/home page) filter out non-symbol emojis
- [ ] Filter out emojis where all variants are currently invalid (based on # of possible bytes left in symbol)

# Testing

Use the picker and test it.

# Checklist

- [ ] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [ ] Did you check all checkboxes from the linked Linear task?
