### PR TITLE
[ECO-2059] Remove aggregate-market queries from the home page

### DIFF
--- a/src/typescript/frontend/src/app/home/page.tsx
+++ b/src/typescript/frontend/src/app/home/page.tsx
@@ -1,9 +1,9 @@
 import fetchSortedMarketData, { fetchFeaturedMarket } from "lib/queries/sorting/market-data";
 import { type HomePageParams, toHomePageParamsWithDefault } from "lib/routes/home-page-params";
 import HomePageComponent from "./HomePage";
-import { revalidatePath } from "next/cache";
-import { toMarketDataSortByHomePage } from "lib/queries/sorting/types";
+import { REVALIDATION_TIME } from "lib/server-env";
 
+export const revalidate = REVALIDATION_TIME;
 export const dynamic = "force-dynamic";
 
 export default async function Home({ searchParams }: HomePageParams) {
@@ -25,8 +25,8 @@ export default async function Home({ searchParams }: HomePageParams) {
       markets={sorted.markets}
       count={sorted.count}
       page={page}
-      sortBy={toMarketDataSortByHomePage(sortBy)}
-      searchBytes={q === "0x" ? undefined : q}
+      sortBy={sortBy}
+      searchBytes={q}
     />
   );
 }

--- a/src/typescript/frontend/src/app/layout.tsx
+++ b/src/typescript/frontend/src/app/layout.tsx
@@ -11,6 +11,7 @@ import {
   pixelar,
 } from "styles/fonts";
 import "../app/global.css";
+import DisplayMarketData from "@store/server-to-client/FetchFromServer";
 
 export const metadata: Metadata = getDefaultMetadata();
 export const viewport: Viewport = {
@@ -26,6 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={fontsClassName}>
         <StyledComponentsRegistry>
           <Providers>
+            <DisplayMarketData />
             <SubscribeToMarketRegistrations />
             {children}
           </Providers>

--- a/src/typescript/frontend/src/app/layout.tsx
+++ b/src/typescript/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { type Metadata, type Viewport } from "next";
 import { getDefaultMetadata } from "configs/meta";
 import Providers from "context/providers";
 import StyledComponentsRegistry from "lib/registry";
+import { SubscribeToMarketRegistrations } from "@store/server-to-client/SubscribeToMarketRegistrations";
 import "react-toastify/dist/ReactToastify.css";
 import {
   formaDJRDisplayMedium,
@@ -10,8 +11,6 @@ import {
   pixelar,
 } from "styles/fonts";
 import "../app/global.css";
-import FetchFromServer from "@store/server-to-client/FetchFromServer";
-import { SubscribeToMarketRegistrations } from "@store/server-to-client/SubscribeToMarketRegistrations";
 
 export const metadata: Metadata = getDefaultMetadata();
 export const viewport: Viewport = {
@@ -27,7 +26,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={fontsClassName}>
         <StyledComponentsRegistry>
           <Providers>
-            <FetchFromServer />
             <SubscribeToMarketRegistrations />
             {children}
           </Providers>

--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -7,6 +7,7 @@ import { REVALIDATION_TIME } from "lib/server-env";
 import { fetchContractMarketView } from "lib/queries/aptos-client/market-view";
 import { SYMBOL_DATA } from "@sdk/emoji_data";
 import { pathToEmojiNames } from "utils/pathname-helpers";
+import { prettifyHex } from "lib/utils/prettify-hex";
 
 export const revalidate = REVALIDATION_TIME;
 export const dynamic = "force-dynamic";
@@ -22,8 +23,6 @@ type StaticParams = {
   market: string;
 };
 
-// TODO: Bring back static params or caching with invalidation by some identifier for recent events having happened.
-
 interface EmojicoinPageProps {
   params: StaticParams;
   searchParams: {};
@@ -37,8 +36,9 @@ interface EmojicoinPageProps {
 const EmojicoinPage = async (params: EmojicoinPageProps) => {
   const { market: marketSlug } = params.params;
   const names = pathToEmojiNames(marketSlug);
-  const hex = names.map((n) => SYMBOL_DATA.byName(n)?.hex.slice(2)).join("");
-  const res = await fetchLatestMarketState(`0x${hex}`);
+  const bytes = names.flatMap((n) => Array.from(SYMBOL_DATA.byName(n)?.bytes ?? []));
+  const hex = prettifyHex(bytes);
+  const res = await fetchLatestMarketState(hex);
 
   if (res) {
     const marketID = res.marketID.toString();

--- a/src/typescript/frontend/src/app/market/api/route.ts
+++ b/src/typescript/frontend/src/app/market/api/route.ts
@@ -1,0 +1,30 @@
+import fetchSortedMarketData from "lib/queries/sorting/market-data";
+import { stringifyJSON } from "utils";
+import { constructHomePageSearchParams } from "lib/queries/sorting/query-params";
+import { toHomePageParamsWithDefault } from "lib/routes/home-page-params";
+
+export const dynamic = "force-dynamic";
+
+// Returns market data for a given market. Note that this only
+// supports the search params for a home page request.
+export async function GET(request: Request) {
+  const { searchParams: urlSearchParams } = new URL(request.url);
+  const searchParams = constructHomePageSearchParams(urlSearchParams);
+  const {
+    page,
+    sortBy,
+    orderBy,
+    inBondingCurve,
+    q: searchBytes,
+  } = toHomePageParamsWithDefault(searchParams);
+
+  const data = await fetchSortedMarketData({
+    page,
+    orderBy,
+    sortBy,
+    inBondingCurve,
+    searchBytes,
+    exactCount: true,
+  });
+  return new Response(stringifyJSON(data));
+}

--- a/src/typescript/frontend/src/app/page.tsx
+++ b/src/typescript/frontend/src/app/page.tsx
@@ -3,7 +3,9 @@ import { type HomePageParams, toHomePageParamsWithDefault } from "lib/routes/hom
 import { revalidatePath } from "next/cache";
 import { toMarketDataSortByHomePage } from "lib/queries/sorting/types";
 import HomePageComponent from "./home/HomePage";
+import { REVALIDATION_TIME } from "lib/server-env";
 
+export const revalidate = REVALIDATION_TIME;
 export const dynamic = "force-dynamic";
 
 export default async function Home({ searchParams }: HomePageParams) {

--- a/src/typescript/frontend/src/components/charts/ChartContainer.tsx
+++ b/src/typescript/frontend/src/components/charts/ChartContainer.tsx
@@ -2,16 +2,34 @@
 import Script from "next/script";
 import { type ChartContainerProps } from "./types";
 import React, { Suspense, useEffect } from "react";
-import { useWebSocketClient } from "context/state-store-context";
+import { useEventStore, useWebSocketClient } from "context/state-store-context";
 import Loading from "components/loading";
 import PrivateChart from "./PrivateChart";
-import FetchFromServer from "@store/server-to-client/FetchFromServer";
+import fetchAggregateMarkets from "lib/queries/initial/aggregate-markets";
 
 export const Chart = PrivateChart;
 const MemoizedChart = React.memo(Chart);
 
 export const ChartContainer = (props: Omit<ChartContainerProps, "isScriptReady">) => {
   const [isScriptReady, setIsScriptReady] = React.useState(false);
+  const [isMarketDataReady, setIsMarketDataReady] = React.useState(false);
+
+  const initialize = useEventStore((s) => s.initializeRegisteredMarketsMap);
+
+  useEffect(() => {
+    fetchAggregateMarkets()
+      .then(({ markets }) => {
+        initialize(markets);
+        // Let state propagate so that the chart doesn't re-render before the data is fully loaded into state.
+        setTimeout(() => {
+          setIsMarketDataReady(true);
+        }, 100);
+      })
+      .catch((_error) => {
+        setIsMarketDataReady(true);
+      });
+  }, [initialize]);
+
   const { subscribe, unsubscribe } = useWebSocketClient((s) => s);
 
   // For now, we subscribe to any periodic state event instead of just a specific resolution.
@@ -25,9 +43,8 @@ export const ChartContainer = (props: Omit<ChartContainerProps, "isScriptReady">
 
   return (
     <>
-      {isScriptReady && (
+      {isScriptReady && isMarketDataReady && (
         <Suspense fallback={<Loading emojis={props.emojis} />}>
-          <FetchFromServer />
           <MemoizedChart
             marketID={props.marketID}
             emojis={props.emojis}

--- a/src/typescript/frontend/src/components/charts/ChartContainer.tsx
+++ b/src/typescript/frontend/src/components/charts/ChartContainer.tsx
@@ -5,6 +5,7 @@ import React, { Suspense, useEffect } from "react";
 import { useWebSocketClient } from "context/state-store-context";
 import Loading from "components/loading";
 import PrivateChart from "./PrivateChart";
+import FetchFromServer from "@store/server-to-client/FetchFromServer";
 
 export const Chart = PrivateChart;
 const MemoizedChart = React.memo(Chart);
@@ -26,6 +27,7 @@ export const ChartContainer = (props: Omit<ChartContainerProps, "isScriptReady">
     <>
       {isScriptReady && (
         <Suspense fallback={<Loading emojis={props.emojis} />}>
+          <FetchFromServer />
           <MemoizedChart
             marketID={props.marketID}
             emojis={props.emojis}

--- a/src/typescript/frontend/src/lib/queries/sorting/market-data.ts
+++ b/src/typescript/frontend/src/lib/queries/sorting/market-data.ts
@@ -18,7 +18,7 @@ export const getSortedMarketData = async ({
   offset,
   orderBy,
   sortBy,
-  inBondingCurve = null,
+  inBondingCurve,
   exactCount,
   searchBytes,
 }: GetSortedMarketDataQueryArgs) => {

--- a/src/typescript/frontend/src/lib/queries/sorting/query-params.ts
+++ b/src/typescript/frontend/src/lib/queries/sorting/query-params.ts
@@ -1,97 +1,32 @@
 import { type OrderByStrings } from "@sdk/queries/const";
-import { toPageQueryParam, type SortByPageQueryParams } from "./types";
-import { MARKETS_PER_PAGE } from "./const";
+import { type SortByPageQueryParams } from "./types";
 
 export type HomePageSearchParams = {
-  page: string;
-  sort: SortByPageQueryParams;
-  order: OrderByStrings;
-  bonding: boolean;
-  q: string;
+  page: string | undefined;
+  sort: SortByPageQueryParams | undefined;
+  order: OrderByStrings | undefined;
+  bonding: boolean | undefined;
+  q: string | undefined;
 };
 
-export const calculatePageNumber = ({
-  page,
-  numMarkets,
-  prev,
-}: {
-  page?: string | null;
-  numMarkets: number;
-  prev: boolean;
-}) => {
-  const currentPage = Number(page ?? 1);
-  const newPage = prev ? currentPage - 1 : currentPage + 1;
-  const lastPage = Math.ceil(numMarkets / MARKETS_PER_PAGE);
-
-  if (newPage === 0 && prev) {
-    return lastPage;
-  } else if (newPage > lastPage) {
-    return 1;
-  }
-  return newPage;
+export const DefaultHomePageSearchParams: HomePageSearchParams = {
+  page: "1",
+  sort: "market_cap",
+  order: "desc",
+  bonding: undefined,
+  q: undefined,
 };
 
-export const getSortQueryPath = ({
-  value,
-  searchParams,
-  pathname,
-}: {
-  value: Parameters<typeof toPageQueryParam>[number];
-  searchParams: URLSearchParams;
-  pathname: string;
-}) => {
-  const params = new URLSearchParams(searchParams.toString());
-  const newValue = toPageQueryParam(value);
-  params.set("sort" as keyof HomePageSearchParams, newValue);
-  return `${pathname}?${params.toString()}`;
-};
+export const AllHomePageSearchParams = Object.keys(DefaultHomePageSearchParams) as Array<
+  keyof HomePageSearchParams
+>;
 
-export const getPageQueryPath = ({
-  prev,
-  searchParams,
-  pathname,
-  numMarkets,
-}: {
-  prev: boolean;
-  searchParams: URLSearchParams;
-  pathname: string;
-  numMarkets: number;
-}) => {
-  const page = calculatePageNumber({
-    page: searchParams.get("page"),
-    numMarkets,
-    prev,
+export const constructHomePageSearchParams = (searchParams: URLSearchParams) => {
+  const res = {} as HomePageSearchParams;
+  AllHomePageSearchParams.forEach((key) => {
+    const value = searchParams.get(key);
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    res[key] = value ?? (DefaultHomePageSearchParams[key] as any);
   });
-
-  const params = new URLSearchParams(searchParams.toString());
-  params.set("page" as keyof HomePageSearchParams, page.toString());
-  return `${pathname}?${params.toString()}`;
-};
-
-export const getOrderQueryPath = ({
-  value,
-  searchParams,
-  pathname,
-}: {
-  value: OrderByStrings;
-  searchParams: URLSearchParams;
-  pathname: string;
-}) => {
-  const params = new URLSearchParams(searchParams.toString());
-  params.set("order" as keyof HomePageSearchParams, value);
-  return `${pathname}?${params.toString()}`;
-};
-
-export const getBondingQueryPath = ({
-  value,
-  searchParams,
-  pathname,
-}: {
-  value: boolean;
-  searchParams: URLSearchParams;
-  pathname: string;
-}) => {
-  const params = new URLSearchParams(searchParams.toString());
-  params.set("bonding" as keyof HomePageSearchParams, value.toString());
-  return `${pathname}?${params.toString()}`;
+  return res;
 };

--- a/src/typescript/frontend/src/lib/queries/sorting/types.ts
+++ b/src/typescript/frontend/src/lib/queries/sorting/types.ts
@@ -22,7 +22,7 @@ export type GetSortedMarketDataQueryArgs = {
   offset: number;
   orderBy: ValueOf<typeof ORDER_BY>;
   sortBy: MarketDataSortBy | SortByPostgrestQueryParams;
-  inBondingCurve: boolean | null;
+  inBondingCurve?: boolean;
   exactCount?: boolean;
   searchBytes?: string;
 };

--- a/src/typescript/frontend/src/lib/routes/home-page-params.ts
+++ b/src/typescript/frontend/src/lib/routes/home-page-params.ts
@@ -1,6 +1,6 @@
 import { toOrderBy } from "@sdk/queries/const";
 import { type HomePageSearchParams } from "lib/queries/sorting/query-params";
-import { MarketDataSortBy, toPostgrestQueryParam } from "lib/queries/sorting/types";
+import { toMarketDataSortByHomePage } from "lib/queries/sorting/types";
 
 export interface HomePageParams {
   params?: {};
@@ -9,7 +9,7 @@ export interface HomePageParams {
 
 export const safeParsePage = (pageInput: string | undefined | null): number => {
   try {
-    return parseInt(pageInput ?? "1");
+    return Math.min(parseInt(pageInput ?? "1"), 1);
   } catch (e) {
     return 1;
   }
@@ -18,15 +18,17 @@ export const safeParsePage = (pageInput: string | undefined | null): number => {
 export const toHomePageParamsWithDefault = (searchParams: HomePageSearchParams | undefined) => {
   const {
     page: pageInput,
-    sort = MarketDataSortBy.MarketCap,
+    sort,
     order = "desc",
-    bonding: inBondingCurve = null,
-    q,
+    bonding: inBondingCurve,
+    q: searchBytes,
   } = searchParams ?? {};
 
-  const sortBy = toPostgrestQueryParam(sort);
+  // Ensure the filter is a home-page-only filter.
+  const sortBy = toMarketDataSortByHomePage(sort);
   const page = safeParsePage(pageInput);
   const orderBy = toOrderBy(order);
+  const q = searchBytes === "0x" ? undefined : searchBytes;
 
   return {
     page,

--- a/src/typescript/frontend/src/lib/store/server-to-client/FetchFromServer.tsx
+++ b/src/typescript/frontend/src/lib/store/server-to-client/FetchFromServer.tsx
@@ -1,15 +1,9 @@
-import fetchAggregateMarkets from "lib/queries/initial/aggregate-markets";
+"use client";
+
 import StoreOnClient from "./StoreOnClient";
 
-/**
- * @returns A server component that passes data to the global client store.
- *
- * Right now it only passes aggregated market metadata for registered markets. This is static data that will
- * never change once a market is registered.
- */
-export const FetchFromServer = async () => {
-  const data = await fetchAggregateMarkets();
-  return <>{process.env.NODE_ENV === "development" && <StoreOnClient markets={data.markets} />}</>;
+export const DisplayMarketData = async () => {
+  return <>{process.env.NODE_ENV === "development" && <StoreOnClient />}</>;
 };
 
-export default FetchFromServer;
+export default DisplayMarketData;

--- a/src/typescript/frontend/src/lib/store/server-to-client/StoreOnClient.tsx
+++ b/src/typescript/frontend/src/lib/store/server-to-client/StoreOnClient.tsx
@@ -2,18 +2,12 @@
 // cspell:word mkts
 
 import { MODULE_ADDRESS } from "@sdk/const";
-import { type RegisteredMarket } from "@sdk/emoji_data";
 import { CloseIconWithHover } from "components/svg";
 import { useEventStore, useWebSocketClient } from "context/state-store-context";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
-export type StoreOnClientProps = {
-  markets: Array<RegisteredMarket>;
-};
-
-export const StoreOnClient = ({ markets }: StoreOnClientProps) => {
-  const initialize = useEventStore((s) => s.initializeRegisteredMarketsMap);
+export const StoreOnClient = () => {
   const storeMarkets = useEventStore((s) => s.markets);
   const subscriptions = useWebSocketClient((s) => s.subscriptions);
   const pathname = usePathname();
@@ -25,10 +19,6 @@ export const StoreOnClient = ({ markets }: StoreOnClientProps) => {
   useEffect(() => {
     setEvents(storeMarkets.get(pathname.split("/market/")?.[1]));
   }, [pathname, storeMarkets]);
-
-  useEffect(() => {
-    initialize(markets);
-  }, [initialize, markets]);
 
   return (
     <>

--- a/src/typescript/frontend/src/lib/utils/prettify-hex.ts
+++ b/src/typescript/frontend/src/lib/utils/prettify-hex.ts
@@ -6,7 +6,7 @@
  *
  * @param hex - The hex string to prettify.
  */
-export const prettifyHex = (hex: `0x${string}` | Uint8Array) => {
+export const prettifyHex = (hex: `0x${string}` | Uint8Array | number[]) => {
   const normalized = typeof hex === "string" ? hex : Buffer.from(hex).toString("hex");
-  return `0x${normalized.replace(/0x/g, "").toUpperCase()}`;
+  return `0x${normalized.replace(/0x/g, "").toUpperCase()}` as const;
 };


### PR DESCRIPTION
# Description

As @CRBl69 pointed out, the aggregate-market queries are nearly entirely unnecessary and cause the page to load a lot slower.

We can remove these from the homepage and use existing data to populate the frontend with data for the main page

The only case where we would need to add new data is by replacing the Chart search function. Right now we use the data in state to search for markets, but we can use an asynchronous server action or a `GET` call with a `[markets]/api.ts` to call this.

For now, to keep things simple, I removed the aggregate markets query from the home page and call it when the Chart loads. We can still remove it entirely but it would mean replacing the Chart search logic and behavior.

# Testing

Check the logs on vercel to see if the function is called when the home page is loaded. It shouldn't be.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
