### PR TITLE
[ECO-2061] Add test event generator for the frontend

### DIFF
--- a/src/typescript/frontend/src/components/pages/home/components/table-card/LinkOrAnimationTrigger.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/LinkOrAnimationTrigger.tsx
@@ -1,0 +1,31 @@
+import { type SymbolEmojiData } from "@sdk/emoji_data/types";
+import { useGenerateEvent } from "../../test-generate-event/use-generate-event";
+import { type PropsWithChildren } from "react";
+import { ROUTES } from "router/routes";
+import { emojiNamesToPath } from "utils/pathname-helpers";
+import Link from "next/link";
+import { VERCEL } from "@sdk/const";
+
+export const LinkOrAnimationTrigger = ({
+  emojis,
+  marketID,
+  ...props
+}: { emojis: SymbolEmojiData[]; marketID: number } & PropsWithChildren) => {
+  const generateEvent = useGenerateEvent({ marketID, emojis, stateOnly: true });
+
+  return (
+    <>
+      {VERCEL ||
+      process.env.NODE_ENV !== "development" ||
+      process.env.NEXT_PUBLIC_ANIMATION_TEST !== "true" ? (
+        <Link href={`${ROUTES.market}/${emojiNamesToPath(emojis.map((x) => x.name))}`}>
+          {props.children}
+        </Link>
+      ) : (
+        <div onClick={generateEvent}>{props.children}</div>
+      )}
+    </>
+  );
+};
+
+export default LinkOrAnimationTrigger;

--- a/src/typescript/frontend/src/components/pages/home/test-generate-event/event-generator.ts
+++ b/src/typescript/frontend/src/components/pages/home/test-generate-event/event-generator.ts
@@ -1,0 +1,309 @@
+import { Account, AccountAddress, type AccountAddressInput } from "@aptos-labs/ts-sdk";
+import { toAnyEmojicoinEvent, type Types, type AnyNumberString } from "@sdk-types";
+import { MAX_SYMBOL_LENGTH, StateTrigger } from "@sdk/const";
+import { getRandomEmoji, type SymbolEmojiData, type EmojicoinSymbol } from "@sdk/emoji_data";
+import { getEmojicoinData } from "@sdk/markets/utils";
+import type JSONTypes from "@sdk/types/json-types";
+import { STRUCT_STRINGS } from "@sdk/utils";
+import Big from "big.js";
+import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS } from "lib/env";
+
+/**
+ * Note that this data is generated solely for animation purposes. It isn't logically consistent
+ * and a lot of the fields are incorrect or inconsistent in terms of what could actually exist
+ * on-chain.
+ */
+
+type AnimationTriggers =
+  | StateTrigger.MARKET_REGISTRATION
+  | StateTrigger.SWAP_BUY
+  | StateTrigger.SWAP_SELL
+  | StateTrigger.PROVIDE_LIQUIDITY
+  | StateTrigger.REMOVE_LIQUIDITY
+  | StateTrigger.CHAT;
+
+const getRandomAnimationTrigger = () => {
+  const triggers = [
+    StateTrigger.MARKET_REGISTRATION,
+    StateTrigger.SWAP_BUY,
+    StateTrigger.SWAP_SELL,
+    StateTrigger.PROVIDE_LIQUIDITY,
+    StateTrigger.REMOVE_LIQUIDITY,
+    StateTrigger.CHAT,
+  ] as const;
+  return triggers[Math.floor(Math.random() * triggers.length)];
+};
+
+const triggerToStructString = (trigger: AnimationTriggers) => {
+  if (trigger === StateTrigger.MARKET_REGISTRATION) return STRUCT_STRINGS.MarketRegistrationEvent;
+  if (trigger === StateTrigger.SWAP_BUY) return STRUCT_STRINGS.SwapEvent;
+  if (trigger === StateTrigger.SWAP_SELL) return STRUCT_STRINGS.SwapEvent;
+  if (trigger === StateTrigger.PROVIDE_LIQUIDITY) return STRUCT_STRINGS.LiquidityEvent;
+  if (trigger === StateTrigger.REMOVE_LIQUIDITY) return STRUCT_STRINGS.LiquidityEvent;
+  if (trigger === StateTrigger.CHAT) return STRUCT_STRINGS.ChatEvent;
+  throw new Error(`Invalid trigger: ${trigger}`);
+};
+
+const generateRandomSymbol = () => {
+  const emojis: SymbolEmojiData[] = [];
+  let i = 0;
+  const sumBytes = (bytes: Uint8Array[]) => bytes.reduce((acc, b) => acc + b.length, 0);
+  // Try 10 times. Guaranteed to return at least one emoji, but possibly multiple.
+  while (i < 10) {
+    const randomEmoji = getRandomEmoji();
+    if (sumBytes([...emojis.map((e) => e.bytes), randomEmoji.bytes]) < MAX_SYMBOL_LENGTH) {
+      emojis.push(randomEmoji);
+      i++;
+    }
+  }
+  return emojis;
+};
+
+export type RandomEventArgs = {
+  marketID: AnyNumberString;
+  time?: AnyNumberString;
+  marketNonce?: AnyNumberString;
+  emojis?: EmojicoinSymbol;
+  trigger?: AnimationTriggers;
+  version?: AnyNumberString;
+};
+
+let nonce = 0;
+
+export const generateRandomEvent = ({
+  marketID,
+  version,
+  time = Date.now() * 1000,
+  marketNonce = nonce++,
+  emojis = generateRandomSymbol(),
+  trigger = getRandomAnimationTrigger(),
+}: RandomEventArgs) => {
+  const args = {
+    marketID,
+    time,
+    marketNonce,
+    emojis,
+  };
+  const eventType = triggerToStructString(trigger);
+  const jsonEvent = (() => {
+    switch (trigger) {
+      case StateTrigger.MARKET_REGISTRATION:
+        return generateMarketRegistrationJSON(args);
+      case StateTrigger.SWAP_BUY:
+        return generateSwapJSON({ ...args, isSell: false });
+      case StateTrigger.SWAP_SELL:
+        return generateSwapJSON({ ...args, isSell: true });
+      case StateTrigger.PROVIDE_LIQUIDITY:
+        return generateLiquidityJSON({ ...args, liquidityProvided: true });
+      case StateTrigger.REMOVE_LIQUIDITY:
+        return generateLiquidityJSON({ ...args, liquidityProvided: false });
+      case StateTrigger.CHAT:
+        return generateChatJSON(args);
+      default:
+        throw new Error(`Invalid trigger: ${trigger}`);
+    }
+  })();
+  const specificEvent = toAnyEmojicoinEvent(eventType, jsonEvent, Number(version));
+  const stateJSON = generateStateJSON({ ...args, trigger });
+  const stateEvent = toAnyEmojicoinEvent(STRUCT_STRINGS.StateEvent, stateJSON, Number(version));
+
+  return {
+    triggeringEvent: specificEvent,
+    stateEvent: stateEvent as Types.StateEvent,
+  } as const;
+};
+
+const generateMarketRegistrationJSON = ({
+  marketID,
+  emojis,
+  time,
+  registrant = AccountAddress.from(Account.generate().accountAddress),
+}: {
+  marketID: AnyNumberString;
+  emojis: EmojicoinSymbol;
+  time: AnyNumberString;
+  registrant?: AccountAddressInput;
+}): JSONTypes.MarketRegistrationEvent => {
+  const { marketAddress, symbolBytes } = getEmojicoinData(emojis);
+  return {
+    integrator: INTEGRATOR_ADDRESS,
+    integrator_fee: "0",
+    market_metadata: {
+      emoji_bytes: symbolBytes,
+      market_address: marketAddress.toString(),
+      market_id: marketID.toString(),
+    },
+    registrant: AccountAddress.from(registrant).toString(),
+    time: time.toString(),
+  };
+};
+
+const generateLiquidityJSON = ({
+  marketID,
+  marketNonce,
+  time = Date.now() * 1000,
+  liquidityProvided,
+}: {
+  marketID: AnyNumberString;
+  marketNonce: AnyNumberString;
+  time?: AnyNumberString;
+  liquidityProvided: boolean;
+}): JSONTypes.LiquidityEvent => ({
+  base_amount: "1524336998",
+  liquidity_provided: liquidityProvided,
+  lp_coin_amount: "1212122424",
+  market_id: marketID.toString(),
+  market_nonce: marketNonce.toString(),
+  pro_rata_base_donation_claim_amount: "0",
+  pro_rata_quote_donation_claim_amount: "0",
+  provider: "0xbad225596d685895aa64d92f4f0e14d2f9d8075d3b8adf1e90ae6037f1fcbabe",
+  quote_amount: "1200000000",
+  time: time.toString(),
+});
+
+const generateStateJSON = ({
+  marketID,
+  marketNonce,
+  trigger,
+  emojis,
+  time = Date.now() * 1000,
+  lastSwapNonce = marketNonce,
+  lastSwapTime = Date.now() * 1000,
+  isSell = Math.random() > 0.5,
+}: {
+  marketID: AnyNumberString;
+  marketNonce: AnyNumberString;
+  trigger: StateTrigger;
+  emojis: EmojicoinSymbol;
+  time?: AnyNumberString;
+  lastSwapNonce?: AnyNumberString;
+  lastSwapTime?: AnyNumberString;
+  isSell?: boolean;
+}): JSONTypes.StateEvent => {
+  const { marketAddress, symbolBytes } = getEmojicoinData(emojis);
+  return {
+    clamm_virtual_reserves: {
+      base: "49000000000000000",
+      quote: "400000000000",
+    },
+    cpamm_real_reserves: {
+      base: "0",
+      quote: "0",
+    },
+    cumulative_stats: {
+      base_volume: "0",
+      integrator_fees: "100000000",
+      n_chat_messages: "3",
+      n_swaps: "0",
+      pool_fees_base: "0",
+      pool_fees_quote: "0",
+      quote_volume: "0",
+    },
+    instantaneous_stats: {
+      fully_diluted_value: "367346938775",
+      market_cap: "0",
+      total_quote_locked: "0",
+      total_value_locked: "0",
+    },
+    last_swap: {
+      avg_execution_price_q64: "0",
+      base_volume: "0",
+      is_sell: isSell,
+      nonce: lastSwapNonce.toString(),
+      quote_volume: "0",
+      time: lastSwapTime.toString(),
+    },
+    lp_coin_supply: "0",
+    market_metadata: {
+      emoji_bytes: symbolBytes,
+      market_address: marketAddress.toString(),
+      market_id: marketID.toString(),
+    },
+    state_metadata: {
+      bump_time: time.toString(),
+      market_nonce: marketNonce.toString(),
+      trigger,
+    },
+  };
+};
+
+const generateSwapJSON = ({
+  isSell,
+  marketID,
+  marketNonce,
+  inputAmount = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(),
+  time = Date.now() * 1000,
+  swapper = AccountAddress.from(Account.generate().accountAddress),
+  resultsInStateTransition = false,
+  startsInBondingCurve = true,
+}: {
+  isSell: boolean;
+  marketID: AnyNumberString;
+  marketNonce: AnyNumberString;
+  inputAmount?: AnyNumberString;
+  time?: AnyNumberString;
+  resultsInStateTransition?: boolean;
+  startsInBondingCurve?: boolean;
+  swapper?: AccountAddressInput;
+}): JSONTypes.SwapEvent => {
+  return {
+    // The ratios here are based on a random swap in the contract generated on-chain.
+    avg_execution_price_q64: Big(153481808316888)
+      .div(17302124)
+      .mul(inputAmount.toString())
+      .round()
+      .toString(),
+    // prettier-ignore
+    base_volume: Big(2079515851811)
+      .div(17302124)
+      .mul(inputAmount.toString())
+      .round()
+      .toString(),
+    input_amount: inputAmount.toString(),
+    integrator: INTEGRATOR_ADDRESS,
+    integrator_fee: "0",
+    integrator_fee_rate_bps: INTEGRATOR_FEE_RATE_BPS,
+    is_sell: isSell,
+    market_id: marketID.toString(),
+    market_nonce: marketNonce.toString(),
+    net_proceeds: "2079515851811",
+    pool_fee: "0",
+    quote_volume: "17302124",
+    results_in_state_transition: resultsInStateTransition,
+    starts_in_bonding_curve: startsInBondingCurve,
+    swapper: AccountAddress.from(swapper).toString(),
+    time: time.toString(),
+  };
+};
+
+const generateChatJSON = ({
+  marketID,
+  time = Date.now() * 1000,
+  marketNonce,
+  emojis,
+  user = AccountAddress.from(Account.generate().accountAddress),
+}: {
+  marketID: AnyNumberString;
+  marketNonce: AnyNumberString;
+  user?: AccountAddressInput;
+  emojis: EmojicoinSymbol;
+  time?: AnyNumberString;
+}): JSONTypes.ChatEvent => {
+  const { marketAddress, symbolBytes } = getEmojicoinData(emojis);
+  return {
+    balance_as_fraction_of_circulating_supply_q64: "0",
+    circulating_supply: "0",
+    emit_market_nonce: marketNonce.toString(),
+    emit_time: time.toString(),
+    market_metadata: {
+      emoji_bytes: symbolBytes,
+      market_address: marketAddress.toString(),
+      market_id: marketID.toString(),
+    },
+    message: Array.from({ length: Math.random() * 10 })
+      .map(() => getRandomEmoji().emoji)
+      .join(""),
+    user: AccountAddress.from(user).toString(),
+    user_emojicoin_balance: "0",
+  };
+};

--- a/src/typescript/sdk/src/emoji_data/types.ts
+++ b/src/typescript/sdk/src/emoji_data/types.ts
@@ -1,4 +1,6 @@
+import { type getEmojicoinMarketAddressAndTypeTags } from "../markets";
 import type AllSymbolEmojiJSON from "./symbol-emojis.json";
+import { type symbolBytesToEmojis } from "./utils";
 
 export type AllSymbolEmojiData = typeof AllSymbolEmojiJSON;
 export type EmojiName = keyof AllSymbolEmojiData;
@@ -16,3 +18,12 @@ export type RegisteredMarket = {
   symbolBytes: `0x${string}`;
   marketAddress: `0x${string}`;
 };
+
+/**
+ * Represents either the raw emoji symbol or symbol array or the emoji data.
+ * This should *NOT* represent emojis as hex strings/bytes.
+ */
+export type EmojicoinSymbol = string | string[] | SymbolEmojiData | SymbolEmojiData[];
+
+export type DerivedEmojicoinData = ReturnType<typeof getEmojicoinMarketAddressAndTypeTags> &
+  ReturnType<typeof symbolBytesToEmojis> & { symbolBytes: `0x${string}` };

--- a/src/typescript/sdk/src/emoji_data/utils.ts
+++ b/src/typescript/sdk/src/emoji_data/utils.ts
@@ -163,12 +163,18 @@ export const isValidEmojiHex = (input: HexInput) => {
   }
 };
 
-export const encodeEmojis = (emojis: string[]) => {
-  const encoder = new TextEncoder();
-  // eslint-disable-next-line prefer-template
-  return `0x${emojis.reduce(
-    (acc: string, emoji) =>
-      `${acc}${[...encoder.encode(emoji)].map((e) => e.toString(16)).join("")}`,
-    ""
-  )}`;
-};
+export const encodeText = (s: string) => new TextEncoder().encode(s);
+
+export const isStringArray = (arr: Array<unknown>): arr is Array<string> =>
+  Array.isArray(arr) && arr.every((val) => typeof val === "string");
+
+export const encodeSymbolData = (data: SymbolEmojiData[]) =>
+  Buffer.from(data.flatMap((v) => Array.from(v.bytes))).toString("hex");
+
+export const encodeEmojis = (emojis: string[] | SymbolEmojiData[]) =>
+  `0x${
+    isStringArray(emojis) ? encodeText(emojis.join("")) : encodeSymbolData(emojis)
+  }` as `0x${string}`;
+
+// For ease of use, we alias `encodeEmojis` to `encodeSymbols`.
+export const encodeSymbols = encodeEmojis;

--- a/src/typescript/sdk/src/markets/utils.ts
+++ b/src/typescript/sdk/src/markets/utils.ts
@@ -27,6 +27,13 @@ import {
 import { type Types, toMarketResource, toRegistrantGracePeriodFlag } from "../types/types";
 import type JSONTypes from "../types/json-types";
 import { sleep } from "../utils";
+import {
+  type DerivedEmojicoinData,
+  type EmojicoinSymbol,
+  encodeSymbols,
+  symbolBytesToEmojis,
+  type SymbolEmojiData,
+} from "../emoji_data";
 
 export function toCoinTypes(inputAddress: AccountAddressInput): {
   emojicoin: TypeTag;
@@ -68,6 +75,25 @@ export function getEmojicoinMarketAddressAndTypeTags(args: {
     emojicoinLP,
   };
 }
+
+/**
+ * Helper function to get all emoji data based from a symbol.
+ *
+ * Note that the market metadata is implicitly derived from the hardcoded module address constant.
+ */
+export const getEmojicoinData = (symbol: EmojicoinSymbol): DerivedEmojicoinData => {
+  const symbolArray = Array.isArray(symbol)
+    ? symbol
+    : ([symbol] as Array<string> | Array<SymbolEmojiData>);
+  const symbolBytes = encodeSymbols(symbolArray);
+  const data = symbolBytesToEmojis(symbolBytes);
+  const metadata = getEmojicoinMarketAddressAndTypeTags({ symbolBytes });
+  return {
+    ...data,
+    ...metadata,
+    symbolBytes,
+  };
+};
 
 // TODO: Consolidate all resource types into one place at some point.
 export const GRACE_PERIOD_FLAG_RESOURCE_TYPE =

--- a/src/typescript/sdk/src/types/json-types.ts
+++ b/src/typescript/sdk/src/types/json-types.ts
@@ -293,25 +293,25 @@ export type AnyEmojicoinJSONEvent =
   | JSONTypes.LiquidityEvent;
 
 export function isJSONSwapEvent(e: EventJSON): boolean {
-  return e.type.startsWith("Swap");
+  return e.type.endsWith("Swap");
 }
 export function isJSONChatEvent(e: EventJSON): boolean {
-  return e.type.startsWith("Chat");
+  return e.type.endsWith("Chat");
 }
 export function isJSONMarketRegistrationEvent(e: EventJSON): boolean {
-  return e.type.startsWith("MarketRegistration");
+  return e.type.endsWith("MarketRegistration");
 }
 export function isJSONPeriodicStateEvent(e: EventJSON): boolean {
-  return e.type.startsWith("PeriodicState");
+  return e.type.endsWith("PeriodicState");
 }
 export function isJSONStateEvent(e: EventJSON): boolean {
-  return e.type.startsWith("State");
+  return e.type.endsWith("State");
 }
 export function isJSONGlobalStateEvent(e: EventJSON): boolean {
-  return e.type.startsWith("GlobalState");
+  return e.type.endsWith("GlobalState");
 }
 export function isJSONLiquidityEvent(e: EventJSON): boolean {
-  return e.type.startsWith("Liquidity");
+  return e.type.endsWith("Liquidity");
 }
 export function isRegistrantGracePeriodFlag(e: EventJSON["data"][number]) {
   return (

--- a/src/typescript/sdk/src/types/types.ts
+++ b/src/typescript/sdk/src/types/types.ts
@@ -5,6 +5,17 @@ import type JSONTypes from "./json-types";
 import { fromAggregatorSnapshot } from "./core";
 import { normalizeAddress } from "../utils/account-address";
 import { type StateTrigger, toStateTrigger, type EMOJICOIN_DOT_FUN_MODULE_NAME } from "../const";
+import {
+  type AnyEmojicoinJSONEvent,
+  isJSONChatEvent,
+  isJSONGlobalStateEvent,
+  isJSONLiquidityEvent,
+  isJSONMarketRegistrationEvent,
+  isJSONPeriodicStateEvent,
+  isJSONStateEvent,
+  isJSONSwapEvent,
+} from "./json-types";
+import { type STRUCT_STRINGS } from "../utils";
 
 export type AnyNumberString = number | string | bigint;
 
@@ -748,4 +759,24 @@ export function getEventTypeName(e: AnyEmojicoinEvent): EventName {
 
 export interface WithTime {
   time: bigint;
+}
+
+export function toAnyEmojicoinEvent(
+  type: (typeof STRUCT_STRINGS)[keyof typeof STRUCT_STRINGS],
+  data: AnyEmojicoinJSONEvent,
+  version?: number
+): AnyEmojicoinEvent {
+  const event = { type, data };
+  if (isJSONSwapEvent(event)) return toSwapEvent(data as JSONTypes.SwapEvent, version ?? -1);
+  if (isJSONChatEvent(event)) return toChatEvent(data as JSONTypes.ChatEvent, version ?? -1);
+  if (isJSONMarketRegistrationEvent(event))
+    return toMarketRegistrationEvent(data as JSONTypes.MarketRegistrationEvent, version ?? -1);
+  if (isJSONPeriodicStateEvent(event))
+    return toPeriodicStateEvent(data as JSONTypes.PeriodicStateEvent, version ?? -1);
+  if (isJSONStateEvent(event)) return toStateEvent(data as JSONTypes.StateEvent, version ?? -1);
+  if (isJSONGlobalStateEvent(event))
+    return toGlobalStateEvent(data as JSONTypes.GlobalStateEvent, version ?? -1);
+  if (isJSONLiquidityEvent(event))
+    return toLiquidityEvent(data as JSONTypes.LiquidityEvent, version ?? -1);
+  throw new Error(`Unknown event type: ${type}`);
 }

--- a/src/typescript/sdk/tests/unit/emoji-regex.test.ts
+++ b/src/typescript/sdk/tests/unit/emoji-regex.test.ts
@@ -1,5 +1,11 @@
 import { SYMBOL_DATA } from "../../src";
-import { getEmojisInString, isValidSymbol, symbolToEmojis } from "../../src/emoji_data/utils";
+import {
+  encodeEmojis,
+  encodeSymbols,
+  getEmojisInString,
+  isValidSymbol,
+  symbolToEmojis,
+} from "../../src/emoji_data/utils";
 import SymbolEmojiData from "../../src/emoji_data/symbol-emojis.json";
 
 describe("tests emojis against the emoji regex to ensure they're properly validated", () => {
@@ -80,5 +86,29 @@ describe("tests the emojis in a string, and the emoji data for each one", () => 
     emojiData.emojis.forEach((emoji) => {
       expect(names.has(emoji.name)).toBe(true);
     });
+  });
+
+  it("encodes emojis correctly", () => {
+    const symbolsForward = [
+      SYMBOL_DATA.byStrictName("ATM sign"),
+      SYMBOL_DATA.byStrictName("Aquarius"),
+      SYMBOL_DATA.byStrictName("yin yang"),
+      SYMBOL_DATA.byStrictName("Cancer"),
+      SYMBOL_DATA.byStrictName("world map"),
+      SYMBOL_DATA.byStrictName("yellow heart"),
+      SYMBOL_DATA.byStrictName("black cat"),
+    ];
+    const symbolsReverse = symbolsForward.toReversed();
+
+    // Encode forwards and backwards to ensure we don't encounter a padding error.
+    for (const symbols of [symbolsForward, symbolsReverse]) {
+      const enc1 = `0x${Buffer.from(symbols.flatMap((v) => Array.from(v.bytes))).toString("hex")}`;
+      const enc2 = `0x${symbols.flatMap((d) => [...d.bytes].map((v) => v.toString(16))).join("")}`;
+      const enc3 = encodeEmojis(symbols);
+      const enc4 = encodeSymbols(symbols);
+      expect(enc1).toEqual(enc2);
+      expect(enc1).toEqual(enc3);
+      expect(enc1).toEqual(enc4);
+    }
   });
 });


### PR DESCRIPTION
# Description

- [x] Allow for generating events on the frontend on click
- [x] Only include/build this in the "development" builds, more specifically:
  - [x] `VERCEL || process.env.NODE_ENV !== "development" || process.env.NEXT_PUBLIC_ANIMATION_TEST !== "true"`

# Testing

Visual testing + using it an incredible amount to test things visually.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
