### PR TITLE
[ECO-2062] Fix animation redirect by checking register market time

### DIFF
--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/ClientLaunchEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/ClientLaunchEmojicoinPage.tsx
@@ -11,14 +11,26 @@ import { TAGS } from "lib/queries/cache-utils/tags";
 import { ROUTES } from "router/routes";
 import { useRouter } from "next/navigation";
 import path from "path";
-import { sleep } from "@sdk/utils";
 import { getEvents } from "@sdk/emojicoin_dot_fun";
-import { isUserTransactionResponse } from "@aptos-labs/ts-sdk";
+import {
+  isUserTransactionResponse,
+  type PendingTransactionResponse,
+  type UserTransactionResponse,
+} from "@aptos-labs/ts-sdk";
 import { symbolBytesToEmojis } from "@sdk/emoji_data";
 import MemoizedLaunchAnimation from "./memoized-launch";
 
 const LOADING_TIME = 2000;
 type Stage = "initial" | "loading" | "coding";
+
+const lastMarketRegistration = (
+  response?: PendingTransactionResponse | UserTransactionResponse | null
+) => {
+  if (response && isUserTransactionResponse(response)) {
+    return getEvents(response).marketRegistrationEvents.at(0);
+  }
+  return undefined;
+};
 
 const ClientLaunchEmojicoinPage = () => {
   const searchParams = useSearchParams();
@@ -26,8 +38,13 @@ const ClientLaunchEmojicoinPage = () => {
   const setEmojis = useEmojiPicker((state) => state.setEmojis);
   const setMode = useEmojiPicker((state) => state.setMode);
   const router = useRouter();
-  const { status, lastResponse: lastResponseFromContext } = useAptos();
-  const lastResponse = useRef(lastResponseFromContext?.response);
+  const {
+    status,
+    lastResponse: lastResponseFromContext,
+    lastResponseStoredAt: lastResponseStoredAtFromContext,
+  } = useAptos();
+  const lastResponse = useRef(lastMarketRegistration(lastResponseFromContext?.response));
+  const lastResponseStoredAt = useRef(lastResponseStoredAtFromContext);
   const isLoadingRegisteredMarket = useEmojiPicker((state) => state.isLoadingRegisteredMarket);
   const [stage, setStage] = useState<Stage>(isLoadingRegisteredMarket ? "loading" : "initial");
 
@@ -42,24 +59,16 @@ const ClientLaunchEmojicoinPage = () => {
   // We need to store a reference to the last response in order to navigate to the market page after the market is
   // registered. Otherwise, `lastResponse` will be stale if we try to use it directly in the `handleLoading` function.
   useEffect(() => {
-    if (
-      lastResponseFromContext &&
-      lastResponseFromContext.response &&
-      isUserTransactionResponse(lastResponseFromContext.response)
-    ) {
-      const events = getEvents(lastResponseFromContext.response);
-      if (events.marketRegistrationEvents.length === 1) {
-        lastResponse.current = lastResponseFromContext.response;
-      }
-    }
+    lastResponse.current = lastMarketRegistration(lastResponseFromContext?.response);
   }, [lastResponseFromContext]);
 
-  const handleLoading = useCallback(async () => {
-    const response = lastResponse.current;
-    if (response && isUserTransactionResponse(response)) {
-      const lastResponseEvents = getEvents(response);
-      if (!lastResponseEvents.marketRegistrationEvents.length) return;
+  useEffect(() => {
+    lastResponseStoredAt.current = lastResponseStoredAtFromContext;
+  }, [lastResponseStoredAtFromContext]);
 
+  const handleLoading = useCallback(async () => {
+    const marketRegistrationEvent = lastResponse.current;
+    if (marketRegistrationEvent) {
       // NOTE: revalidateTagAction may cause a flicker in the loading animation because the server
       // rerenders and sends the RSC components again. To avoid this we'll probably need to finish the animation
       // orchestration with a different animation or cover it up somehow, otherwise I'm not sure how to fix it in a
@@ -72,7 +81,6 @@ const ClientLaunchEmojicoinPage = () => {
         // Parse the emojis from the market registration event.
         // We do this in case the emojis are somehow cleared before the response is received. This ensures that
         // the emojis we're referencing are always the static ones that were used to register the market.
-        const marketRegistrationEvent = lastResponseEvents.marketRegistrationEvents[0];
         const { marketID, emojiBytes } = marketRegistrationEvent.marketMetadata;
         const { symbol } = symbolBytesToEmojis(emojiBytes);
         const newPath = path.join(ROUTES.market, symbol);
@@ -87,20 +95,44 @@ const ClientLaunchEmojicoinPage = () => {
         }
       });
     }
-  }, [lastResponse, router]);
+  }, [router]);
+
+  const isMounted = useRef(true);
 
   useEffect(() => {
-    const shouldLoad = status === "pending" || (status === "success" && stage === "initial");
+    isMounted.current = true;
+
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const timeSinceLastResponseStored = Date.now() - lastResponseStoredAt.current;
+    const shouldLoad =
+      status === "pending" ||
+      (status === "success" && stage === "initial" && timeSinceLastResponseStored < 1000);
     if (!shouldLoad) return;
 
     // Start the loading animation.
+    let timeout: number;
     if (stage === "initial") {
       setStage("loading");
-      sleep(LOADING_TIME).then(() => {
-        handleLoading();
-      });
+
+      timeout = window.setTimeout(() => {
+        if (window.location.href.endsWith(ROUTES.launch)) {
+          handleLoading();
+        }
+      }, LOADING_TIME);
     }
 
+    return () => {
+      // If the user navigates away, consider the animation as having been completed and cancel the rest
+      // of the navigational animation orchestration.
+      if (!window.location.href.endsWith(ROUTES.launch)) {
+        window.clearTimeout(timeout);
+      }
+    };
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [status]);
 

--- a/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
+++ b/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
@@ -63,6 +63,7 @@ export type AptosContextState = {
   copyAddress: () => void;
   status: TransactionStatus;
   lastResponse: ResponseType;
+  lastResponseStoredAt: number;
   setEmojicoinType: (type?: TypeTagInput) => void;
   aptBalance: bigint;
   emojicoinBalance: bigint;
@@ -86,6 +87,7 @@ export function AptosContextProvider({ children }: PropsWithChildren) {
   const pushEventFromClient = useEventStore((state) => state.pushEventFromClient);
   const [status, setStatus] = useState<TransactionStatus>("idle");
   const [lastResponse, setLastResponse] = useState<ResponseType>(null);
+  const [lastResponseStoredAt, setLastResponseStoredAt] = useState(-1);
   const [emojicoinType, setEmojicoinType] = useState<string | undefined>();
 
   const { emojicoin, emojicoinLP } = useMemo(() => {
@@ -212,6 +214,7 @@ export function AptosContextProvider({ children }: PropsWithChildren) {
             response,
             error: null,
           });
+          setLastResponseStoredAt(Date.now());
           sleep(DEFAULT_TOAST_CONFIG.autoClose, UnitOfTime.Milliseconds).then(() => {
             setStatus("idle");
           });
@@ -315,6 +318,7 @@ export function AptosContextProvider({ children }: PropsWithChildren) {
     copyAddress,
     status,
     lastResponse,
+    lastResponseStoredAt,
     aptBalance,
     emojicoinBalance,
     emojicoinLPBalance,


### PR DESCRIPTION
# Description

Simple fix to stop the window from navigating when it shouldn't

Fix it by checking window.location.href and by storing the time the last response was emitted in state rather than just the last response, then only fire the animation if it's within the last second.

# Testing

Manually tested it a bunch

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
