### PR TITLE
Fix the left grid line not showing up when searching for an emoji; clear search input on navigation to home page

### DIFF
--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -41,7 +41,6 @@ const Header: React.FC<HeaderProps> = ({ isOpen, setIsOpen }) => {
 
   // When the user clicks the home page button, they probably expect the sort to be the same as it was before
   // they clicked. We reset the search bytes and the page here to nothing, which will resolve to their defaults.
-  // Note that we shouldn't need to call `clear` on the picker here because the refetch will clear the picker.
   const linkProps: LinkProps = useMemo(() => {
     const sortParam = searchParams.get("sort");
     const query = sortParam ? { sort: sortParam } : {};

--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import React from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useMatchBreakpoints } from "hooks";
-
-import Link from "components/link/component";
 import Button from "components/button";
 import { Flex, FlexGap, Container } from "@containers";
 import LogoIcon from "../svg/icons/LogoIcon";
@@ -11,37 +9,65 @@ import CloseIcon from "../svg/icons/Close";
 import MenuItem from "components/header/components/menu-item";
 import { MobileMenu } from "components/header/components/mobile-menu";
 import { StyledContainer, StyledClickItem, StyledMobileHeader, StyledCloseIcon } from "./styled";
-
 import { ROUTES } from "router/routes";
 import { NAVIGATE_LINKS } from "./constants";
 import { slideTopVariants } from "./animations";
-
 import { type HeaderProps } from "./types";
 import { translationFunction } from "context/language-context";
-
 import WalletDropdownMenu from "components/wallet/WalletDropdownMenu";
 import ButtonWithConnectWalletFallback from "./wallet-button/ConnectWalletButton";
+import { useSearchParams } from "next/navigation";
+import Link, { type LinkProps } from "next/link";
+import { useEmojiPicker } from "context/emoji-picker-context";
 
 const Header: React.FC<HeaderProps> = ({ isOpen, setIsOpen }) => {
   const { isDesktop } = useMatchBreakpoints();
   const { t } = translationFunction();
-
+  const searchParams = useSearchParams();
   const linksForCurrentPage = NAVIGATE_LINKS;
+  const clear = useEmojiPicker((s) => s.clear);
 
-  const { offsetHeight } = document.getElementById("header") ?? { offsetHeight: 0 };
+  const [offsetHeight, setOffsetHeight] = useState(0);
 
-  const handleCloseMobileMenu = () => {
+  const headerRef = useCallback((node: HTMLElement | null) => {
+    if (node) {
+      setOffsetHeight(node.offsetHeight);
+    }
+  }, []);
+
+  const handleCloseMobileMenu = useCallback(() => {
     setIsOpen(false);
-  };
+  }, [setIsOpen]);
+
+  // When the user clicks the home page button, they probably expect the sort to be the same as it was before
+  // they clicked. We reset the search bytes and the page here to nothing, which will resolve to their defaults.
+  // Note that we shouldn't need to call `clear` on the picker here because the refetch will clear the picker.
+  const linkProps: LinkProps = useMemo(() => {
+    const sort = searchParams.get("sort");
+    return {
+      href: {
+        pathname: ROUTES.home,
+        query: sort
+          ? {
+              sort,
+            }
+          : {},
+      },
+      onClick: () => {
+        handleCloseMobileMenu();
+        clear();
+      },
+    };
+  }, [searchParams, handleCloseMobileMenu, clear]);
 
   return (
-    <StyledContainer id="header">
+    <StyledContainer ref={headerRef}>
       <StyledMobileHeader
         initial="hidden"
         animate={isOpen ? "visible" : "hidden"}
         variants={slideTopVariants(offsetHeight)}
       >
-        <Link href={ROUTES.home} mt="6px" onClick={handleCloseMobileMenu}>
+        <Link className="mt-[6px]" {...linkProps}>
           <StyledClickItem>
             <LogoIcon width="170px" color="black" cursor="pointer" versionBadge={true} />
           </StyledClickItem>
@@ -54,7 +80,7 @@ const Header: React.FC<HeaderProps> = ({ isOpen, setIsOpen }) => {
 
       <Container>
         <Flex my="30px" justifyContent="space-between" alignItems="center">
-          <Link marginLeft="50px" href={ROUTES.home}>
+          <Link className="ml-[50px]" {...linkProps}>
             <StyledClickItem>
               <LogoIcon width="170px" cursor="pointer" versionBadge={true} />
             </StyledClickItem>

--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -43,15 +43,12 @@ const Header: React.FC<HeaderProps> = ({ isOpen, setIsOpen }) => {
   // they clicked. We reset the search bytes and the page here to nothing, which will resolve to their defaults.
   // Note that we shouldn't need to call `clear` on the picker here because the refetch will clear the picker.
   const linkProps: LinkProps = useMemo(() => {
-    const sort = searchParams.get("sort");
+    const sortParam = searchParams.get("sort");
+    const query = sortParam ? { sort: sortParam } : {};
     return {
       href: {
         pathname: ROUTES.home,
-        query: sort
-          ? {
-              sort,
-            }
-          : {},
+        query,
       },
       onClick: () => {
         handleCloseMobileMenu();

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
@@ -161,7 +161,7 @@ export const LiveClientGrid = ({
       {ordered.map((v) => {
         return (
           <TableCard
-            key={`live-${v.key}`}
+            key={`live-${v.marketID}-${v.index}`}
             index={v.index}
             pageOffset={0} // We don't paginate the live grid.
             marketID={v.marketID}

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
@@ -45,7 +45,7 @@ export const ClientGrid = ({
       {ordered.map((v, i) => {
         return (
           <TableCard
-            key={`${sortBy}-${v.key}`}
+            key={`${sortBy}-${v.marketID}-${i}`}
             index={i}
             pageOffset={(page - 1) * MARKETS_PER_PAGE}
             marketID={v.marketID}

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
@@ -7,11 +7,9 @@ import { MARKETS_PER_PAGE } from "lib/queries/sorting/const";
 import { type EmojiPickerStore } from "@store/emoji-picker-store";
 
 export type PropsWithTime = Omit<TableCardProps, "index" | "rowLength"> & {
-  key: string;
   time: number;
 };
 export type PropsWithTimeAndIndex = TableCardProps & {
-  key: string;
   time: number;
 };
 export type WithTimeIndexAndPrev = PropsWithTimeAndIndex & {
@@ -20,7 +18,6 @@ export type WithTimeIndexAndPrev = PropsWithTimeAndIndex & {
 
 export const marketDataToProps = (data: FetchSortedMarketDataReturn["markets"]): PropsWithTime[] =>
   data.map((market) => ({
-    key: market.symbol,
     time: market.bumpTime,
     symbol: market.symbol,
     marketID: market.marketID,
@@ -44,7 +41,6 @@ export const stateEventsToProps = (
     const emojiData = symbolBytesToEmojis(e.marketMetadata.emojiBytes);
     const { symbol, emojis } = emojiData;
     return {
-      key: symbol,
       time: Number(e.stateMetadata.bumpTime),
       symbol,
       emojis,


### PR DESCRIPTION
# Description

![Screenshot 2024-08-08 at 1 21 36 PM](https://github.com/user-attachments/assets/9340cd0c-fc95-42a9-be0b-701c64e0b3c1)


- [x] Fix the left grid line not showing up when searching for an emoji. This happens because the element isn't re-rendered unless we add the searchBytes to the component's key
- [x] Clear the search input when the user navigates to the home page.
  - [x] Adhere to other standard UX:
    - [x] We keep the sortBy if it exists
    - [x] We reset the page regardless
- [x] Convert the height calculation from document query selector to be more React-appropriate; i.e., use a `useCallback` for the `ref` for the header `offsetHeight`

# Testing

Visual/manual testing

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
