### PR TITLE
[ECO-2116] Add a branch protection rule to only allow merging to `production` from `main`

### DIFF
--- a/.github/workflows/production-branch-protection.yaml
+++ b/.github/workflows/production-branch-protection.yaml
@@ -1,15 +1,24 @@
+# yamllint disable rule:empty-lines rule:key-ordering
+---
 name: 'Production Branch Protection'
 
-on:
+"on":
   pull_request:
+    types:
+    - 'opened'
+    - 'reopened'
+    - 'synchronize'
+    - 'edited'
 
 jobs:
   production-branch-protection:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-latest'
     steps:
-      - name: "Check if the PR is targeting the production branch"
-        id: check_branch
-        if: github.base_ref == 'production' && github.head_ref != 'main'
-        run: |
-          echo "ERROR: You can only merge to the production branch from `main`."
-          exit 1
+    - name: 'Check if the PR is targeting the production branch'
+      id: 'check_branch'
+      if: |
+        github.base_ref == 'production' && github.head_ref != 'main'
+      run: |
+        echo ERROR: You can only merge to the production branch from main.
+        exit 1
+...

--- a/.github/workflows/production-branch-protection.yaml
+++ b/.github/workflows/production-branch-protection.yaml
@@ -1,0 +1,15 @@
+name: 'Production Branch Protection'
+
+on:
+  pull_request:
+
+jobs:
+  production-branch-protection:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check if the PR is targeting the production branch"
+        id: check_branch
+        if: github.base_ref == 'production' && github.head_ref != 'main'
+        run: |
+          echo "ERROR: You can only merge to the production branch from `main`."
+          exit 1

--- a/src/rust/example.env
+++ b/src/rust/example.env
@@ -19,7 +19,8 @@ EMOJICOIN_MODULE_ADDRESS="0x11113ddc70ea051ffd8a7cde7b96818326aabf56fdfd47807f77
 # For mainnet: https://grpc.mainnet.aptoslabs.com:443
 # For testnet: https://grpc.testnet.aptoslabs.com:443
 # For devnet: https://grpc.devnet.aptoslabs.com:443
-# For a local end-to-end testing chain: http://streamer:50051
+# For a local end-to-end testing chain: http://host.docker.internal:50051,
+#   or http://localhost:50051 if that doesn't work.
 GRPC_DATA_SERVICE_URL="https://grpc.testnet.aptoslabs.com:443"
 
 # For a public chain you have to get this token from https://developers.aptoslabs.com/.


### PR DESCRIPTION
# Description

- [x] Add a branch protection rule to only allow merging to `production` from `main`

# Testing

When trying to merge into `production` from `ECO-2116`:
![Screenshot 2024-08-22 at 4 19 38 PM](https://github.com/user-attachments/assets/95615076-f5a6-4bd8-9244-35c43671487c)

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
