### PR TITLE
[ECO-2141] Declaratively kill stack

### DIFF
--- a/src/cloud-formation/deploy-dev.yaml
+++ b/src/cloud-formation/deploy-dev.yaml
@@ -12,7 +12,7 @@ parameters:
   ProvisionPostgrest: 'true'
   ProvisionProcessor: 'true'
   ProvisionRouteTables: 'true'
-  ProvisionStack: 'true'
+  ProvisionStack: 'false'
   ProvisionVpc: 'true'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Kill the `dev` stack due to CIDR conflicts on subnet rename/replace operation

# Testing

TBD

# Checklist