### PR TITLE
[ECO-2142] Implement retry functionality for the broker

### DIFF
--- a/src/rust/broker/src/main.rs
+++ b/src/rust/broker/src/main.rs
@@ -22,19 +22,19 @@ async fn main() -> Result<(), ()> {
     let (tx, _) = broadcast::channel(CHANNEL_BUFFER_SIZE);
     let tx2 = tx.clone();
 
-    let processor_connection = tokio::spawn(processor_connection::processor_connection(
+    let processor_connection = tokio::spawn(processor_connection::start(
         processor_url,
         tx2,
     ));
 
-    let sse_server = tokio::spawn(server::server(tx, port));
+    let mut sse_server = tokio::spawn(server::server(tx, port));
 
     tokio::select! {
         _ = processor_connection => {
             error!("Processor connection thread terminated.");
             return Err(());
         }
-        result = sse_server => {
+        result = &mut sse_server => {
             if let Err(e) = result {
                 error!("Broker server error: {e}.");
                 return Err(());

--- a/src/rust/broker/src/main.rs
+++ b/src/rust/broker/src/main.rs
@@ -19,18 +19,6 @@ pub enum HealthStatus {
     Dead,
 }
 
-impl Default for HealthStatus {
-    fn default() -> Self {
-        Self::Starting
-    }
-}
-
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct BrokerHealth {
-    processor_connection: HealthStatus,
-    server: HealthStatus,
-}
-
 #[tokio::main]
 async fn main() -> Result<(), ()> {
     env_logger::init();
@@ -45,15 +33,15 @@ async fn main() -> Result<(), ()> {
     let (tx, _) = broadcast::channel(CHANNEL_BUFFER_SIZE);
     let tx2 = tx.clone();
 
-    let broker_health = Arc::new(RwLock::new(BrokerHealth::default()));
+    let processor_connection_health = Arc::new(RwLock::new(HealthStatus::Starting));
 
     let processor_connection = tokio::spawn(processor_connection::start(
         processor_url,
         tx2,
-        broker_health.clone(),
+        processor_connection_health.clone(),
     ));
 
-    let mut sse_server = tokio::spawn(server::server(tx, port, broker_health));
+    let mut sse_server = tokio::spawn(server::server(tx, port, processor_connection_health));
 
     tokio::select! {
         _ = processor_connection => {

--- a/src/rust/broker/src/processor_connection.rs
+++ b/src/rust/broker/src/processor_connection.rs
@@ -1,11 +1,83 @@
+use std::time::{Duration, SystemTime};
+
 use futures_util::StreamExt;
-use log::{error, info, log_enabled, Level};
+use log::{error, info, log_enabled, warn, Level};
 use processor::emojicoin_dot_fun::EmojicoinDbEvent;
 use tokio::sync::broadcast::Sender;
 use tokio_tungstenite::connect_async;
 
-pub async fn processor_connection(processor_url: String, tx: Sender<EmojicoinDbEvent>) {
-    let mut connection = connect_async(processor_url).await.unwrap();
+/// Number of retries before giving up and exiting.
+const CONNECTION_RETRIES: u64 = 10;
+
+/// Amount of seconds after which a connection is considered successful.
+///
+/// If a connection lasts at least this amount, and the connection did not return
+/// [`ConnectionError::ConnectionImpossible`], the number of retries will be reset to 0.
+const RETRY_TRESHOLD: Duration = Duration::from_secs(10);
+
+/// Number of seconds to wait before reconnecting on the first retry.
+const INSTANT_RECONNECTION_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Number of seconds to wait before reconnecting on all but the first retry.
+const DELAYED_RECONNECTION_TIMEOUT: Duration = Duration::from_secs(15);
+
+enum ConnectionError {
+    /// Could not connect to the processor at all.
+    ConnectionImpossible,
+    /// Connection to the processor established but lost.
+    ConnectionLost,
+}
+
+pub async fn start(processor_url: String, tx: Sender<EmojicoinDbEvent>) {
+    // Number of retries since last successful connection.
+    let mut retries = 0;
+
+    // Is this the first iteration of the loop.
+    let mut first_time = true;
+
+    loop {
+        // Timestamp of the start of the connection.
+        let start_timestamp = SystemTime::now();
+        let res = processor_connection(processor_url.clone(), tx.clone()).await;
+        let connection_duration = SystemTime::elapsed(&start_timestamp).unwrap();
+
+        // In the broker connected to the processor and the connection duration was longer than the
+        // retry treshold, it is considered successful.
+        let connection_successful = matches!(res, Err(ConnectionError::ConnectionLost)) && connection_duration > RETRY_TRESHOLD;
+
+        if connection_successful {
+            retries = 0;
+        }
+
+        // If this is the first connection and it was unsuccsessful, do not try to retry.
+        if first_time && !connection_successful {
+            break;
+        }
+
+        first_time = false;
+
+        if retries == 0 { // If this is the first retry, try and reconnect instantly.
+            warn!("Trying to reconnect to the processor. (retries left: {CONNECTION_RETRIES}).");
+            tokio::time::sleep(INSTANT_RECONNECTION_TIMEOUT).await;
+        } else if retries < CONNECTION_RETRIES {
+            warn!("Waiting {DELAYED_RECONNECTION_TIMEOUT:?} then retrying (retries left: {}).", CONNECTION_RETRIES - retries);
+            tokio::time::sleep(DELAYED_RECONNECTION_TIMEOUT).await;
+        } else {
+            error!("No retries left.");
+            break
+        }
+        retries = retries + 1;
+    }
+}
+
+async fn processor_connection(processor_url: String, tx: Sender<EmojicoinDbEvent>) -> Result<(), ConnectionError> {
+    let connection = connect_async(processor_url).await;
+    let mut connection = if let Ok(connection) = connection {
+        connection
+    } else {
+        error!("Could not connect to the processor.");
+        return Err(ConnectionError::ConnectionImpossible);
+    };
     info!("Connected to the processor.");
     while let Some(msg) = connection.0.next().await {
         if msg.is_err() {
@@ -37,4 +109,5 @@ pub async fn processor_connection(processor_url: String, tx: Sender<EmojicoinDbE
         let _ = tx.send(msg);
     }
     info!("Connection to the processor terminated.");
+    Err(ConnectionError::ConnectionLost)
 }

--- a/src/rust/broker/src/processor_connection.rs
+++ b/src/rust/broker/src/processor_connection.rs
@@ -9,7 +9,7 @@ use processor::emojicoin_dot_fun::EmojicoinDbEvent;
 use tokio::sync::{broadcast::Sender, RwLock};
 use tokio_tungstenite::connect_async;
 
-use crate::{BrokerHealth, HealthStatus};
+use crate::HealthStatus;
 
 /// Number of retries before giving up and exiting.
 const CONNECTION_RETRIES: u64 = 10;
@@ -18,7 +18,7 @@ const CONNECTION_RETRIES: u64 = 10;
 ///
 /// If a connection lasts at least this amount, and the connection did not return
 /// [`ConnectionError::ConnectionImpossible`], the number of retries will be reset to 0.
-const RETRY_TRESHOLD: Duration = Duration::from_secs(10);
+const RETRY_THRESHOLD: Duration = Duration::from_secs(10);
 
 /// Number of seconds to wait before reconnecting on the first retry.
 const INSTANT_RECONNECTION_TIMEOUT: Duration = Duration::from_secs(1);
@@ -36,7 +36,7 @@ enum ConnectionError {
 pub async fn start(
     processor_url: String,
     tx: Sender<EmojicoinDbEvent>,
-    broker_health: Arc<RwLock<BrokerHealth>>,
+    processor_connection_health: Arc<RwLock<HealthStatus>>,
 ) {
     // Number of retries since last successful connection.
     let mut retries = 0;
@@ -47,14 +47,18 @@ pub async fn start(
     loop {
         // Timestamp of the start of the connection.
         let start_timestamp = SystemTime::now();
-        let res =
-            processor_connection(processor_url.clone(), tx.clone(), broker_health.clone()).await;
+        let res = processor_connection(
+            processor_url.clone(),
+            tx.clone(),
+            processor_connection_health.clone(),
+        )
+        .await;
         let connection_duration = SystemTime::elapsed(&start_timestamp).unwrap();
 
-        // In the broker connected to the processor and the connection duration was longer than the
-        // retry treshold, it is considered successful.
+        // If the broker connected to the processor and the connection duration was longer than the
+        // retry threshold, it is considered successful.
         let connection_successful = matches!(res, Err(ConnectionError::ConnectionLost))
-            && connection_duration > RETRY_TRESHOLD;
+            && connection_duration > RETRY_THRESHOLD;
 
         if connection_successful {
             retries = 0;
@@ -81,29 +85,29 @@ pub async fn start(
             error!("No retries left.");
             break;
         }
-        retries = retries + 1;
+        retries += 1;
     }
 }
 
 async fn processor_connection(
     processor_url: String,
     tx: Sender<EmojicoinDbEvent>,
-    broker_health: Arc<RwLock<BrokerHealth>>,
+    processor_connection_health: Arc<RwLock<HealthStatus>>,
 ) -> Result<(), ConnectionError> {
     let connection = connect_async(processor_url).await;
     let mut connection = if let Ok(connection) = connection {
         connection
     } else {
-        broker_health.write().await.processor_connection = HealthStatus::Dead;
+        *processor_connection_health.write().await = HealthStatus::Dead;
         error!("Could not connect to the processor.");
         return Err(ConnectionError::ConnectionImpossible);
     };
-    broker_health.write().await.processor_connection = HealthStatus::Ok;
+    *processor_connection_health.write().await = HealthStatus::Ok;
     info!("Connected to the processor.");
     let mut is_sick = false;
     while let Some(msg) = connection.0.next().await {
         if msg.is_err() {
-            broker_health.write().await.processor_connection = HealthStatus::Sick;
+            *processor_connection_health.write().await = HealthStatus::Sick;
             is_sick = true;
             error!("Got an error instead of a message: {}", msg.unwrap_err());
             continue;
@@ -111,7 +115,7 @@ async fn processor_connection(
         let msg = msg.unwrap();
         let msg = msg.to_text();
         if msg.is_err() {
-            broker_health.write().await.processor_connection = HealthStatus::Sick;
+            *processor_connection_health.write().await = HealthStatus::Sick;
             is_sick = true;
             error!("Could not convert message to text: {}", msg.unwrap_err());
             continue;
@@ -119,7 +123,7 @@ async fn processor_connection(
         let msg = msg.unwrap();
         let res: Result<EmojicoinDbEvent, _> = serde_json::de::from_str(msg);
         if res.is_err() {
-            broker_health.write().await.processor_connection = HealthStatus::Sick;
+            *processor_connection_health.write().await = HealthStatus::Sick;
             is_sick = true;
             error!(
                 "Could not parse message: error: {}, message: {}",
@@ -130,7 +134,7 @@ async fn processor_connection(
         }
         let msg = res.unwrap();
         if is_sick {
-            broker_health.write().await.processor_connection = HealthStatus::Ok;
+            *processor_connection_health.write().await = HealthStatus::Ok;
         }
         if log_enabled!(Level::Debug) {
             info!("Got message from processor: {msg:?}.");
@@ -140,6 +144,6 @@ async fn processor_connection(
         let _ = tx.send(msg);
     }
     info!("Connection to the processor terminated.");
-    broker_health.write().await.processor_connection = HealthStatus::Dead;
+    *processor_connection_health.write().await = HealthStatus::Dead;
     Err(ConnectionError::ConnectionLost)
 }

--- a/src/rust/broker/src/server.rs
+++ b/src/rust/broker/src/server.rs
@@ -46,8 +46,15 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<Value> {
     return Json(serde_json::to_value(broker_health.clone()).unwrap());
 }
 
-pub async fn server(tx: Sender<EmojicoinDbEvent>, port: u16, broker_health: Arc<RwLock<BrokerHealth>>) -> Result<(), std::io::Error> {
-    let app_state = AppState { tx, broker_health: broker_health.clone() };
+pub async fn server(
+    tx: Sender<EmojicoinDbEvent>,
+    port: u16,
+    broker_health: Arc<RwLock<BrokerHealth>>,
+) -> Result<(), std::io::Error> {
+    let app_state = AppState {
+        tx,
+        broker_health: broker_health.clone(),
+    };
 
     let app = prepare_app(Router::new().route("/", get(health)));
     let app = app.with_state(Arc::new(app_state));

--- a/src/rust/broker/src/server.rs
+++ b/src/rust/broker/src/server.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
-use axum::{extract::State, routing::get, Json, Router};
-use log::{debug, info, warn};
+use axum::{extract::State, http::StatusCode, routing::get, Router};
+use log::{info, warn};
 use processor::emojicoin_dot_fun::EmojicoinDbEvent;
-use serde_json::Value;
 use tokio::sync::{broadcast::Sender, RwLock};
 
-use crate::{util::shutdown_signal, BrokerHealth, HealthStatus};
+use crate::{util::shutdown_signal, HealthStatus};
 
 #[cfg(feature = "sse")]
 mod sse;
@@ -16,7 +15,7 @@ mod ws;
 struct AppState {
     #[allow(dead_code)]
     tx: Sender<EmojicoinDbEvent>,
-    broker_health: Arc<RwLock<BrokerHealth>>,
+    processor_connection_health: Arc<RwLock<HealthStatus>>,
 }
 
 #[cfg(all(feature = "sse", not(feature = "ws")))]
@@ -40,23 +39,30 @@ fn prepare_app(app: Router<Arc<AppState>>) -> Router<Arc<AppState>> {
     app
 }
 
-async fn health(State(state): State<Arc<AppState>>) -> Json<Value> {
-    let broker_health = state.broker_health.read().await;
-    debug!("Health check: {broker_health:?}");
-    return Json(serde_json::to_value(broker_health.clone()).unwrap());
+async fn root() {}
+
+async fn health(State(state): State<Arc<AppState>>) -> StatusCode {
+    match *state.processor_connection_health.read().await {
+        HealthStatus::Ok | HealthStatus::Starting => StatusCode::OK,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
 }
 
 pub async fn server(
     tx: Sender<EmojicoinDbEvent>,
     port: u16,
-    broker_health: Arc<RwLock<BrokerHealth>>,
+    processor_connection_health: Arc<RwLock<HealthStatus>>,
 ) -> Result<(), std::io::Error> {
     let app_state = AppState {
         tx,
-        broker_health: broker_health.clone(),
+        processor_connection_health: processor_connection_health.clone(),
     };
 
-    let app = prepare_app(Router::new().route("/", get(health)));
+    let app = prepare_app(
+        Router::new()
+            .route("/", get(root))
+            .route("/health", get(health)),
+    );
     let app = app.with_state(Arc::new(app_state));
 
     let listener = tokio::net::TcpListener::bind(&format!("0.0.0.0:{port}"))
@@ -75,8 +81,6 @@ pub async fn server(
     if cfg!(all(not(feature = "ws"), not(feature = "sse"))) {
         warn!("Starting web server with no endpoints.");
     }
-
-    broker_health.write().await.server = HealthStatus::Ok;
 
     axum::serve(listener, app)
         .with_graceful_shutdown(async {

--- a/src/rust/broker/src/util.rs
+++ b/src/rust/broker/src/util.rs
@@ -5,6 +5,7 @@ use tokio::signal;
 use crate::types::Subscription;
 
 /// Get the market ID of a EmojicoinDbEvent of a given EventType
+#[allow(dead_code)]
 pub fn get_market_id(event: &EmojicoinDbEvent) -> Result<u64, String> {
     let market_id: Result<u64, _> = match event {
         EmojicoinDbEvent::Swap(s) => s.market_id,
@@ -28,6 +29,7 @@ pub fn get_market_id(event: &EmojicoinDbEvent) -> Result<u64, String> {
 }
 
 /// Returns true if the given subscription should receive the given event.
+#[allow(dead_code)]
 pub fn is_match(subscription: &Subscription, event: &EmojicoinDbEvent) -> bool {
     // If all fields of a subscription are empty, all events should be sent there.
     if subscription.markets.is_empty() && subscription.event_types.is_empty() {


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds retry functionality for the broker.

A connection is considered successful when a network connection was established and the network connection lasted for at least 10 seconds.

- When starting the broker, if a successful connection cannot be established, exit.
- When a connection breaks, the broker will try to reconnect 10 times.
- When a connection breaks, retry instantly (after 1 second).
- When a retry fails, retry after 15 seconds.
- When no retries are left, exit.
- When a retry results in a successful connection, reset the number of retries left.

# Testing

1. Export `RUST_LOG=broker=trace` to get as much info as possible.
1. Start the broker by itself, assert that it does not try to reconnect.
1. Start the processor with docker compose.
1. Start the broker, it should connect.
1. Wait 10 seconds so that the broker considers the connection successful.
1. Stop the processor.
1. Witness the retries.
1. Start the processor.
1. Witness the successful connection.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
