### PR TITLE
[ECO-2161] Update market page with new grace period dynamics

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -12,6 +12,7 @@ import MainInfo from "./components/main-info/MainInfo";
 import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
 import { type BrokerEvent } from "@/broker/types";
 import { marketToLatestBars } from "@/store/event/candlestick-bars";
+import { useQueryClient } from "@tanstack/react-query";
 
 const EVENT_TYPES: BrokerEvent[] = ["Chat", "PeriodicState", "Swap"];
 
@@ -32,6 +33,12 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
   }, [props.data]);
 
   useReliableSubscribe({ eventTypes: EVENT_TYPES });
+
+  const queryClient = useQueryClient();
+  const swaps = useEventStore((s) => s.getMarket(props.data.symbolEmojis)?.swapEvents ?? []);
+  useEffect(() => {
+    queryClient.invalidateQueries({queryKey: ["grace-period", props.data.symbol]});
+  }, [swaps]);
 
   return (
     <Box pt="85px">

--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -12,7 +12,6 @@ import MainInfo from "./components/main-info/MainInfo";
 import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
 import { type BrokerEvent } from "@/broker/types";
 import { marketToLatestBars } from "@/store/event/candlestick-bars";
-import { useQueryClient } from "@tanstack/react-query";
 
 const EVENT_TYPES: BrokerEvent[] = ["Chat", "PeriodicState", "Swap"];
 
@@ -33,12 +32,6 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
   }, [props.data]);
 
   useReliableSubscribe({ eventTypes: EVENT_TYPES });
-
-  const queryClient = useQueryClient();
-  const swaps = useEventStore((s) => s.getMarket(props.data.symbolEmojis)?.swapEvents ?? []);
-  useEffect(() => {
-    queryClient.invalidateQueries({queryKey: ["grace-period", props.data.symbol]});
-  }, [swaps]);
 
   return (
     <Box pt="85px">

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
@@ -11,8 +11,10 @@ import { useGracePeriod } from "lib/hooks/queries/use-grace-period";
 import { Text } from "components/text";
 import { useEffect, useState } from "react";
 import { useMatchBreakpoints } from "@hooks/index";
+import { useQueryClient } from "@tanstack/react-query";
 
 const timeLeft = (seconds: number) => {
+  if (seconds <= 0) return "0 s";
   const remainder = seconds % 60;
   const minutes = Math.floor(seconds / 60);
   if (remainder === 0) {
@@ -30,15 +32,19 @@ export const LiquidityButton = (props: GridProps) => {
   const { isDesktop } = useMatchBreakpoints();
   const { t } = translationFunction();
   const [now, setNow] = useState(getNow());
+  const queryClient = useQueryClient();
   const { isLoading, data } = useGracePeriod(props.data.symbol);
-  data;
 
   const isInGracePeriod = isLoading ? false : !data!.gracePeriodOver;
   const registrationTime = Number((data?.flag?.marketRegistrationTime ?? 0n) / 1000000n);
 
   useEffect(() => {
     const id = setInterval(() => {
-      setNow(getNow());
+      const n = getNow();
+      setNow(n);
+      if (60 * 5 - (n - registrationTime) < 0) {
+        queryClient.invalidateQueries({queryKey: ["grace-period", props.data.symbol]});
+      }
     }, 200);
     return () => clearInterval(id);
   });

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
@@ -10,37 +10,24 @@ import { ROUTES } from "router/routes";
 import { useGracePeriod } from "lib/hooks/queries/use-grace-period";
 import { Text } from "components/text";
 import { useEffect, useState } from "react";
+import { useMatchBreakpoints } from "@hooks/index";
 
 const timeLeft = (seconds: number) => {
   const remainder = seconds % 60;
   const minutes = Math.floor(seconds / 60);
-  if (remainder === 0 && minutes === 1) {
-    return `${minutes} minute left`;
-  }
   if (remainder === 0) {
-    return `${minutes} minutes left`;
-  }
-  if (minutes === 0 && remainder === 1) {
-    return `${remainder} second left`;
+    return `${minutes} min`;
   }
   if (minutes === 0) {
-    return `${remainder} seconds left`;
+    return `${remainder} s`;
   }
-  if (remainder === 1 && minutes == 1) {
-    return `${minutes} minute and ${remainder} second left`;
-  }
-  if (minutes === 1) {
-    return `${minutes} minute and ${remainder} seconds left`;
-  }
-  if (remainder === 1) {
-    return `${minutes} minutes and ${remainder} second left`;
-  }
-  return `${minutes} minutes and ${remainder} seconds left`;
+  return `${minutes} min and ${remainder} s`;
 };
 
 const getNow = () => Math.floor(new Date().getTime() / 1000);
 
 export const LiquidityButton = (props: GridProps) => {
+  const { isDesktop } = useMatchBreakpoints();
   const { t } = translationFunction();
   const [now, setNow] = useState(getNow());
   const { isLoading, data } = useGracePeriod(props.data.symbol);
@@ -52,7 +39,7 @@ export const LiquidityButton = (props: GridProps) => {
   useEffect(() => {
     const id = setInterval(() => {
       setNow(getNow());
-    }, 1000);
+    }, 200);
     return () => clearInterval(id);
   });
 
@@ -77,8 +64,12 @@ export const LiquidityButton = (props: GridProps) => {
         </StyledContentHeader>
       ) : (
         <StyledContentHeader>
-          <Flex width="100%" justifyContent="center">
-            <Text>Grace period ({timeLeft(now - registrationTime)} left)</Text>
+          <Flex width="100%" justifyContent="left">
+            <Text
+              textScale={isDesktop ? "pixelHeading3" : "pixelHeading4"}
+              color="lightGray"
+              textTransform="uppercase"
+            >Grace period ({timeLeft(60 * 5 - (now - registrationTime))} left)</Text>
           </Flex>
         </StyledContentHeader>
       )}

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
@@ -7,13 +7,58 @@ import { isInBondingCurve } from "utils/bonding-curve";
 import { AnimatedProgressBar } from "./AnimatedProgressBar";
 import Link from "next/link";
 import { ROUTES } from "router/routes";
+import { useGracePeriod } from "lib/hooks/queries/use-grace-period";
+import { Text } from "components/text";
+import { useEffect, useState } from "react";
+
+const timeLeft = (seconds: number) => {
+  const remainder = seconds % 60;
+  const minutes = Math.floor(seconds / 60);
+  if (remainder === 0 && minutes === 1) {
+    return `${minutes} minute left`;
+  }
+  if (remainder === 0) {
+    return `${minutes} minutes left`;
+  }
+  if (minutes === 0 && remainder === 1) {
+    return `${remainder} second left`;
+  }
+  if (minutes === 0) {
+    return `${remainder} seconds left`;
+  }
+  if (remainder === 1 && minutes == 1) {
+    return `${minutes} minute and ${remainder} second left`;
+  }
+  if (minutes === 1) {
+    return `${minutes} minute and ${remainder} seconds left`;
+  }
+  if (remainder === 1) {
+    return `${minutes} minutes and ${remainder} second left`;
+  }
+  return `${minutes} minutes and ${remainder} seconds left`;
+};
+
+const getNow = () => Math.floor(new Date().getTime() / 1000);
 
 export const LiquidityButton = (props: GridProps) => {
   const { t } = translationFunction();
+  const [now, setNow] = useState(getNow());
+  const { isLoading, data } = useGracePeriod(props.data.symbol);
+  data;
+
+  const isInGracePeriod = isLoading ? false : !data!.gracePeriodOver;
+  const registrationTime = Number((data?.flag?.marketRegistrationTime ?? 0n) / 1000000n);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setNow(getNow());
+    }, 1000);
+    return () => clearInterval(id);
+  });
 
   return (
     <>
-      {!isInBondingCurve(props.data.state.state) ? (
+      {!isInBondingCurve(props.data.state.state) && !isInGracePeriod ? (
         <StyledContentHeader>
           <Flex width="100%" justifyContent="center">
             <Link
@@ -26,9 +71,15 @@ export const LiquidityButton = (props: GridProps) => {
             </Link>
           </Flex>
         </StyledContentHeader>
-      ) : (
+      ) : !isInGracePeriod ? (
         <StyledContentHeader className="!p-0">
           <AnimatedProgressBar geoblocked={props.geoblocked} data={props.data} />
+        </StyledContentHeader>
+      ) : (
+        <StyledContentHeader>
+          <Flex width="100%" justifyContent="center">
+            <Text>Grace period ({timeLeft(now - registrationTime)} left)</Text>
+          </Flex>
         </StyledContentHeader>
       )}
     </>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
@@ -99,7 +99,7 @@ export const SwapButton = ({
             <RewardsAnimation controls={controls} />
           </>
         ) : (
-          <Popup className="max-w-[300px]" content="This market is in its grace period. During the grace period of a market, only the market creator can trade. The grace period ends 5 minutes after the market registration, of atfter the first trade, whichever comes first.">
+          <Popup className="max-w-[300px]" content="This market is in its grace period. During the grace period of a market, only the market creator can trade. The grace period ends 5 minutes after the market registration, of after the first trade, whichever comes first.">
             <div>
               <Button disabled={true} onClick={handleClick} scale="lg">
                 {t("Swap")}

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
@@ -99,10 +99,12 @@ export const SwapButton = ({
             <RewardsAnimation controls={controls} />
           </>
         ) : (
-          <Popup content="This market is in its grace period. During the grace period of a market, only the market creator can trade. The grace period ends 5 minutes after the market registration, of atfter the first trade, whichever comes first.">
-            <Button disabled={true} onClick={handleClick} scale="lg">
-              {t("Swap")}
-            </Button>
+          <Popup className="max-w-[300px]" content="This market is in its grace period. During the grace period of a market, only the market creator can trade. The grace period ends 5 minutes after the market registration, of atfter the first trade, whichever comes first.">
+            <div>
+              <Button disabled={true} onClick={handleClick} scale="lg">
+                {t("Swap")}
+              </Button>
+            </div>
           </Popup>
         )}
       </ButtonWithConnectWalletFallback>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
@@ -12,8 +12,13 @@ import { useAnimationControls } from "framer-motion";
 import { RewardsAnimation } from "./RewardsAnimation";
 import { toast } from "react-toastify";
 import { CongratulationsToast } from "./CongratulationsToast";
-import { useGracePeriod } from "lib/hooks/queries/use-grace-period";
+import { useCanTradeMarket } from "lib/hooks/queries/use-grace-period";
 import Popup from "components/popup";
+
+const GRACE_PERIOD_MESSAGE =
+  "This market is in its grace period. During the grace period of a market, only the market " +
+  "creator can trade. The grace period ends 5 minutes after the market registration or after the first " +
+  "trade, whichever comes first.";
 
 export const SwapButton = ({
   inputAmount,
@@ -35,13 +40,7 @@ export const SwapButton = ({
   const { t } = translationFunction();
   const { aptos, account, submit } = useAptos();
   const controls = useAnimationControls();
-  const { isLoading, data } = useGracePeriod(symbol);
-
-  const isInGracePeriod = isLoading ? false : !data!.gracePeriodOver;
-  // If data not loaded yet, use user address as registrant address in order to not prevent the user from trying to trade.
-  const registrantAddress = data?.flag?.marketRegistrant ?? account?.address;
-
-  const canTrade = !isInGracePeriod || registrantAddress === account?.address;
+  const { canTrade } = useCanTradeMarket(symbol);
 
   const handleClick = useCallback(async () => {
     if (!account) {
@@ -99,7 +98,7 @@ export const SwapButton = ({
             <RewardsAnimation controls={controls} />
           </>
         ) : (
-          <Popup className="max-w-[300px]" content="This market is in its grace period. During the grace period of a market, only the market creator can trade. The grace period ends 5 minutes after the market registration, of after the first trade, whichever comes first.">
+          <Popup className="max-w-[300px]" content={t(GRACE_PERIOD_MESSAGE)}>
             <div>
               <Button disabled={true} onClick={handleClick} scale="lg">
                 {t("Swap")}

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -323,6 +323,7 @@ export default function SwapComponent({
             // the user is connected.
             disabled={!sufficientBalance && !isLoading && !!account}
             geoblocked={geoblocked}
+            symbol={emojicoin}
           />
         </Row>
       </Column>

--- a/src/typescript/frontend/src/context/providers.tsx
+++ b/src/typescript/frontend/src/context/providers.tsx
@@ -31,6 +31,8 @@ import { isMobile, isTablet } from "react-device-detect";
 
 enableMapSet();
 
+const queryClient = new QueryClient();
+
 const ThemedApp: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = ({
   children,
   geoblocked,
@@ -42,8 +44,6 @@ const ThemedApp: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = 
   const isMobileMenuOpen = isOpen && !isDesktop;
 
   const wallets = useMemo(() => [new PontemWallet(), new RiseWallet(), new MartianWallet()], []);
-
-  const queryClient = new QueryClient();
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/typescript/frontend/src/lib/hooks/queries/use-grace-period.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-grace-period.ts
@@ -1,18 +1,115 @@
-import { getRegistrationGracePeriodFlag } from "@sdk/markets";
+import { getRegistrationGracePeriodFlag } from "@sdk/markets/utils";
+import { standardizeAddress } from "@sdk/utils/account-address";
 import { useQuery } from "@tanstack/react-query";
+import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
+import { useEffect, useMemo, useState } from "react";
 
-export const useGracePeriod = (symbol: string) => {
+// -------------------------------------------------------------------------------------------------
+//
+//                        Utilities for calculating the number of seconds left.
+//
+// -------------------------------------------------------------------------------------------------
+const nowSeconds = () => Math.floor(new Date().getTime() / 1000);
+
+const calculateSecondsLeft = (marketRegistrationTime: bigint) => {
+  const registrationTime = marketRegistrationTime;
+  const asSeconds = Math.floor(Number(registrationTime / 1_000_000n));
+  const plusFiveMinutes = asSeconds + 300;
+  return Math.max(plusFiveMinutes - nowSeconds(), 0);
+};
+
+const formattedTimeLeft = (secondsRemaining: number) => {
+  const remainder = secondsRemaining % 60;
+  const minutes = Math.floor(secondsRemaining / 60);
+  return `${minutes.toString().padStart(2, "0")}:${remainder.toString().padStart(2, "0")}` as const;
+};
+
+// -------------------------------------------------------------------------------------------------
+//
+//                  Hook to force the component to re-render on an interval basis.
+//
+// -------------------------------------------------------------------------------------------------
+const useDisplayTimeLeft = (marketRegistrationTime?: bigint) => {
+  const [timeLeft, setTimeLeft] = useState<ReturnType<typeof formattedTimeLeft>>();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (typeof marketRegistrationTime === "undefined") {
+        setTimeLeft(undefined);
+        return;
+      }
+      const secondsLeft = calculateSecondsLeft(marketRegistrationTime);
+      const formatted = formattedTimeLeft(secondsLeft);
+      setTimeLeft(formatted);
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, [marketRegistrationTime]);
+
+  return timeLeft;
+};
+
+// -------------------------------------------------------------------------------------------------
+//
+//            `useQuery` hook that fetches the grace period status on an interval basis.
+//
+// -------------------------------------------------------------------------------------------------
+const useGracePeriod = (symbol: string, hasSwaps: boolean) => {
   const { aptos } = useAptos();
+  const [keepFetching, setKeepFetching] = useState(true);
 
-  return useQuery({
+  // Include the seconds left in the query result to trigger re-renders upon each fetch.
+  const query = useQuery({
     queryKey: ["grace-period", symbol],
-    queryFn: () => {
-      return getRegistrationGracePeriodFlag({
-        aptos,
-        symbol,
-      });
-    },
-    staleTime: 2000,
+    refetchInterval: 2000,
+    refetchIntervalInBackground: true,
+    enabled: keepFetching,
+    queryFn: async () => getRegistrationGracePeriodFlag({ aptos, symbol }),
   });
+
+  // Stop fetching once the market has clearly been registered.
+  useEffect(() => {
+    const notInGracePeriod = query.data?.gracePeriodOver || hasSwaps;
+    if (notInGracePeriod) {
+      setKeepFetching(false);
+    }
+  }, [query.data?.gracePeriodOver, hasSwaps]);
+
+  return query;
+};
+
+// -------------------------------------------------------------------------------------------------
+//
+//          The actual hook to be used in a component to display the amount of seconds left.
+//
+// -------------------------------------------------------------------------------------------------
+export const useCanTradeMarket = (symbol: string) => {
+  const { account } = useAptos();
+  const hasSwaps = useEventStore((s) => (s.markets.get(symbol)?.swapEvents.length ?? 0) > 0);
+  const { isLoading, data } = useGracePeriod(symbol, hasSwaps);
+
+  const { canTrade, marketRegistrationTime } = useMemo(() => {
+    const notInGracePeriod = data?.gracePeriodOver;
+    const userAddress = account?.address && standardizeAddress(account.address);
+    // Assume the user is the market registrant while the query is fetching in order to prevent
+    // disallowing the actual registrant from trading while the query result is being fetched.
+    const userIsRegistrant = data?.flag?.marketRegistrant === userAddress;
+    return {
+      canTrade: isLoading || userIsRegistrant || notInGracePeriod || hasSwaps,
+      marketRegistrationTime: data?.flag?.marketRegistrationTime,
+    };
+  }, [isLoading, data, account?.address, hasSwaps]);
+
+  const displayTimeLeft = useDisplayTimeLeft(marketRegistrationTime);
+
+  return typeof displayTimeLeft === "undefined" || canTrade
+    ? {
+        canTrade: true as const,
+        displayTimeLeft: undefined,
+      }
+    : {
+        canTrade: false as const,
+        displayTimeLeft,
+      };
 };

--- a/src/typescript/frontend/src/lib/hooks/queries/use-grace-period.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-grace-period.ts
@@ -1,0 +1,18 @@
+import { getRegistrationGracePeriodFlag } from "@sdk/markets";
+import { useQuery } from "@tanstack/react-query";
+import { useAptos } from "context/wallet-context/AptosContextProvider";
+
+export const useGracePeriod = (symbol: string) => {
+  const { aptos } = useAptos();
+
+  return useQuery({
+    queryKey: ["grace-period", symbol],
+    queryFn: () => {
+      return getRegistrationGracePeriodFlag({
+        aptos,
+        symbol,
+      });
+    },
+    staleTime: 2000,
+  });
+};


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR integrates the new grace period dynamics:

- When the market is in a grace period:
    - the *BONDING CURVE: XY%* is replaced with *GRACE PERIOD (X MINUTES AND Y SECONDS LEFT)*
    - if the current user is not the market registrant:
        - the swap button is disabled
        - the swap button has an on hover popup that explains why it is disabled

In order to prevent the market registrant to trade on his own market, in case
of query failure, the UI will let anyone try to trade.

On trade, the grace period is automatically updated !

# Screenshots

![image](https://github.com/user-attachments/assets/daff4a37-940a-4750-bd0c-34d2cc80b25c)


# Testing

Go to vercel, register a market, go on the market page with two different accounts (registrant and another one).

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
