### PR TITLE
[ECO-2169] Fix animations by updating the component `keys` for the emoji grid items

### DIFF
--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
@@ -161,7 +161,7 @@ export const LiveClientGrid = ({
       {ordered.map((v) => {
         return (
           <TableCard
-            key={`live-${v.marketID}${v.searchEmojisKey}`}
+            key={`live-${v.marketID}-${v.searchEmojisKey}`}
             index={v.index}
             pageOffset={0} // We don't paginate the live grid.
             marketID={v.marketID}

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
@@ -161,7 +161,7 @@ export const LiveClientGrid = ({
       {ordered.map((v) => {
         return (
           <TableCard
-            key={`live-${v.marketID}-${v.index}`}
+            key={`live-${v.marketID}${v.searchEmojisKey}`}
             index={v.index}
             pageOffset={0} // We don't paginate the live grid.
             marketID={v.marketID}

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
@@ -47,7 +47,7 @@ export const ClientGrid = ({
       {ordered.map((v, i) => {
         return (
           <TableCard
-            key={`live-${v.marketID}${v.searchEmojisKey}`}
+            key={`live-${v.marketID}-${v.searchEmojisKey}`}
             index={i}
             pageOffset={(page - 1) * MARKETS_PER_PAGE}
             marketID={v.marketID}

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
@@ -9,6 +9,7 @@ import MemoizedGridRowLines from "./components/grid-row-lines";
 import { type MarketDataSortByHomePage } from "lib/queries/sorting/types";
 import { useEffect, useMemo, useRef } from "react";
 import "./module.css";
+import { useEmojiPicker } from "context/emoji-picker-context";
 
 export const ClientGrid = ({
   data,
@@ -20,10 +21,11 @@ export const ClientGrid = ({
   sortBy: MarketDataSortByHomePage;
 }) => {
   const rowLength = useGridRowLength();
+  const searchEmojis = useEmojiPicker((s) => s.emojis);
 
   const ordered = useMemo(() => {
-    return marketDataToProps(data);
-  }, [data]);
+    return marketDataToProps(data, searchEmojis);
+  }, [data, searchEmojis]);
 
   const initialRender = useRef(true);
 
@@ -45,7 +47,7 @@ export const ClientGrid = ({
       {ordered.map((v, i) => {
         return (
           <TableCard
-            key={`${sortBy}-${v.marketID}-${i}`}
+            key={`live-${v.marketID}${v.searchEmojisKey}`}
             index={i}
             pageOffset={(page - 1) * MARKETS_PER_PAGE}
             marketID={v.marketID}


### PR DESCRIPTION
# Description

The animations got screwed up a bit back when I was fixing the lack of a grid line when search emojis are used.

I added the `index` to each grid item component key, meaning it re-animates any time its position in the grid changes, but that's not what we want, because for bump order in particular, the animations are set up to be triggered by changes to the `orderedGrid` variable, not the component key. (They're set up this way by `framer-motion`, which animates the grid order, indicated by the presence of the `layout` prop in an animated component)

In order to fix this bug while still respecting the original fix, I've added the `searchEmojis` to the component keys and removed the `index` from the component key.

Thus the `searchEmojis` changing will trigger a re-render, which subsequently forces the component to re-checks if the grid line on its left should be present. However, if the grid re-orders due to the `bumpOrder` changing, the component will animate properly because its key will remain the same, since the `index` is no longer in the key. 

# Testing

Tested it on the `production` branch to visually ensure things are working as expected now, but the fixes can go in right now to `main` and will work as expected down the road when everything is set up

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
