### PR TITLE
[ECO-2178] Speed up the startup time of the `deployer` image

### DIFF
--- a/src/docker/compose.local.yaml
+++ b/src/docker/compose.local.yaml
@@ -44,5 +44,5 @@ services:
     container_name: 'deployer'
     depends_on:
       localnet:
-        condition: 'service_healthy'
+        condition: 'service_started'
 ...

--- a/src/docker/deployer/sh/entrypoint.sh
+++ b/src/docker/deployer/sh/entrypoint.sh
@@ -8,6 +8,17 @@ fund_amount=20000000000000000
 extra_for_gas=200000000
 gas_unit_price=100
 
+check_faucet_and_rest_API() {
+	faucet_url="http://host.docker.internal:8081"
+	rest_url="http://host.docker.internal:8080/v1"
+	curl -s "$faucet_url" >/dev/null && curl -s "$rest_url" >/dev/null
+}
+
+# We only need to wait for the REST API, not the full indexer API.
+while ! check_faucet_and_rest_API; do
+	sleep 0.1
+done
+
 # ------------------------------------------------------------------------------
 #               Re-initialize the CLI publisher profile if necessary
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The `deployer` image for local e2e/ci tests does not need to wait for all services to be ready. It can merely wait for the `localnet` service to be started, and then check to make sure the REST API and the faucet API are ready.

- [x] Change `depends_on` to be `started` not `healthy`
- [x] Update the `entrypoint.sh` script in `deployer` to check the REST API and the faucet before doing anything else.

# Testing

Ran a lot of manual tests with bash. Will be running it all day, too.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
