### PR TITLE
[ECO-2058] Add click here to launch when emojis not found on home page

### DIFF
--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
@@ -29,6 +29,9 @@ import { constructURLForHomePage, isHomePageURLDifferent } from "lib/queries/sor
 import { AnimatePresence, motion } from "framer-motion";
 import { EMOJI_GRID_ITEM_WIDTH } from "../const";
 import { useGridRowLength } from "./hooks/use-grid-items-per-line";
+import { Text } from "components/text";
+import Link from "next/link";
+import { ROUTES } from "router/routes";
 
 export interface EmojiTableProps {
   data: FetchSortedMarketDataReturn["markets"];
@@ -134,36 +137,49 @@ const EmojiTable = (props: EmojiTableProps) => {
           </motion.div>
           {/* Each version of the grid must wait for the other to fully exit animate out before appearing.
               This provides a smooth transition from grids of varying row lengths. */}
-          <AnimatePresence mode="wait">
-            <motion.div
-              className="relative w-full h-full"
-              id="emoji-grid"
-              key={rowLength}
-              style={{
-                // We set these so the grid layout doesn't snap when the number of items per row changes.
-                // This actually seems to work better than the css media queries, although I've left them in module.css
-                // in case we want to use them for other things.
-                maxWidth: rowLength * EMOJI_GRID_ITEM_WIDTH + GRID_PADDING * 2,
-                minWidth: rowLength * EMOJI_GRID_ITEM_WIDTH + GRID_PADDING * 2,
-              }}
-              exit={{
-                opacity: 0,
-                transition: {
-                  duration: 0.35,
-                  type: "just",
-                },
-              }}
-            >
-              <StyledGrid>
-                {shouldAnimateGrid ? (
-                  <LiveClientGrid data={data} sortBy={sort ?? MarketDataSortBy.MarketCap} />
-                ) : (
-                  <ClientGrid data={data} page={page} sortBy={sort ?? MarketDataSortBy.MarketCap} />
-                )}
-              </StyledGrid>
-            </motion.div>
-          </AnimatePresence>
-          <ButtonsBlock value={page} onChange={handlePageChange} numPages={pages} />
+          {
+            data.length > 0 ?
+              <>
+                <AnimatePresence mode="wait">
+                  <motion.div
+                    className="relative w-full h-full"
+                    id="emoji-grid"
+                    key={rowLength}
+                    style={{
+                      // We set these so the grid layout doesn't snap when the number of items per row changes.
+                      // This actually seems to work better than the css media queries, although I've left them in module.css
+                      // in case we want to use them for other things.
+                      maxWidth: rowLength * EMOJI_GRID_ITEM_WIDTH + GRID_PADDING * 2,
+                      minWidth: rowLength * EMOJI_GRID_ITEM_WIDTH + GRID_PADDING * 2,
+                    }}
+                    exit={{
+                      opacity: 0,
+                      transition: {
+                        duration: 0.35,
+                        type: "just",
+                      },
+                    }}
+                  >
+                    <StyledGrid>
+                      {shouldAnimateGrid ? (
+                        <LiveClientGrid data={data} sortBy={sort ?? MarketDataSortBy.MarketCap} />
+                      ) : (
+                        <ClientGrid data={data} page={page} sortBy={sort ?? MarketDataSortBy.MarketCap} />
+                      )}
+                    </StyledGrid>
+                  </motion.div>
+                </AnimatePresence>
+                <ButtonsBlock value={page} onChange={handlePageChange} numPages={pages} />
+              </>
+              :
+              <div className="py-10">
+                <Link href={`${ROUTES.launch}?emojis=${emojis.join("")}`}>
+                <Text textScale="pixelHeading3" color="econiaBlue">
+                  Click here to launch {emojis.join("")} !
+                </Text>
+                </Link>
+              </div>
+          }
         </InnerGridContainer>
       </OuterContainer>
     </OutermostContainer>


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds a "Click here to launch ${emojis} !" link on the home page when a user searches for an unexisting market.

This redirects him directly to the lanch page, with the previously searched emojis prefilled.

# Testing

Search for a market that does not exist. Click on the "Click here to launch ${emojis} !" button.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
