### PR TITLE
[ECO-2016] Add new sell/buy 50%/100% buttons

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -20,8 +20,8 @@ import { Flex, FlexGap } from "@containers";
 import Popup from "components/popup";
 import { Text } from "components/text";
 
-const SmallButton = ({ emoji, descripition, onClick }: { emoji: string, descripition: string, onClick?: MouseEventHandler<HTMLDivElement> }) => {
-  return <Popup content={<Text textScale="pixelHeading4" textTransform="uppercase" color="black">{descripition}</Text>}>
+const SmallButton = ({ emoji, description, onClick }: { emoji: string, description: string, onClick?: MouseEventHandler<HTMLDivElement> }) => {
+  return <Popup content={<Text textScale="pixelHeading4" textTransform="uppercase" color="black">{description}</Text>}>
     <div className="px-[.7rem] py-[.2rem] border-[1px] border-solid rounded-full border-dark-gray h-[1.5rem] cursor-pointer hover:bg-neutral-800" onClick={onClick}>
       <div className="mt-[.11rem]">
         {emoji}
@@ -201,11 +201,11 @@ export default function SwapComponent({
           </div>
           <FlexGap flexDirection="row" gap="5px">
             {isSell ?
-              <SmallButton emoji="🤮" descripition="Sell all" onClick={() => setInputAmount(String(emojicoinBalance))} />
+              <SmallButton emoji="🤮" description="Sell all" onClick={() => setInputAmount(String(emojicoinBalance))} />
               :
               <>
-                <SmallButton emoji="🌓" descripition="Buy half" onClick={() => setInputAmount(String(availableAptBalance / 2n))} />
-                <SmallButton emoji="🌕" descripition="Buy all" onClick={() => setInputAmount(String(availableAptBalance))} />
+                <SmallButton emoji="🌓" description="Buy half" onClick={() => setInputAmount(String(availableAptBalance / 2n))} />
+                <SmallButton emoji="🌕" description="Buy all" onClick={() => setInputAmount(String(availableAptBalance))} />
               </>
             }
           </FlexGap>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -201,11 +201,15 @@ export default function SwapComponent({
           </div>
           <FlexGap flexDirection="row" gap="5px">
             {isSell ?
-              <SmallButton emoji="🤮" description="Sell all" onClick={() => setInputAmount(String(emojicoinBalance))} />
+              <>
+                <SmallButton emoji="🤢" description="Sell 50%" onClick={() => setInputAmount(String(emojicoinBalance / 2n))} />
+                <SmallButton emoji="🤮" description="Sell 100%" onClick={() => setInputAmount(String(emojicoinBalance))} />
+              </>
               :
               <>
-                <SmallButton emoji="🌓" description="Buy half" onClick={() => setInputAmount(String(availableAptBalance / 2n))} />
-                <SmallButton emoji="🌕" description="Buy all" onClick={() => setInputAmount(String(availableAptBalance))} />
+                <SmallButton emoji="🌒" description="Buy 25%" onClick={() => setInputAmount(String(availableAptBalance / 4n))} />
+                <SmallButton emoji="🌓" description="Buy 50%" onClick={() => setInputAmount(String(availableAptBalance / 2n))} />
+                <SmallButton emoji="🌕" description="Buy 100%" onClick={() => setInputAmount(String(availableAptBalance))} />
               </>
             }
           </FlexGap>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -125,7 +125,7 @@ export default function SwapComponent({
 
   const swapResult = useSimulateSwap({
     marketAddress,
-    inputAmount,
+    inputAmount: inputAmount === "" ? "0" : inputAmount,
     isSell,
     numSwaps,
   });
@@ -156,7 +156,7 @@ export default function SwapComponent({
     setOutputAmount(swapResultDisplay);
     setIsLoading(false);
     replay();
-  }, [swapResult, replay]);
+  }, [swapResult, replay, isSell]);
 
   const toDisplayNumber = (value: bigint | number | string, type: "apt" | "emoji" = "apt") => {
     const badString = typeof value === "string" && (value === "" || isNaN(parseInt(value)));
@@ -274,7 +274,11 @@ export default function SwapComponent({
               </div>
               <input
                 className={inputAndOutputStyles + " bg-transparent leading-[32px]"}
-                value={Number(toDisplayNumber(inputAmount, isSell ? "emoji" : "apt"))}
+                value={
+                  inputAmount === ""
+                    ? ""
+                    : Number(toDisplayNumber(inputAmount, isSell ? "emoji" : "apt"))
+                }
                 step={0.01}
                 onChange={handleInput}
                 onKeyDown={handleKeyDown}

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { AptosInputLabel, EmojiInputLabel } from "./InputLabels";
-import { type PropsWithChildren, useEffect, useState, useCallback, useMemo, type MouseEventHandler } from "react";
+import {
+  type PropsWithChildren,
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  type MouseEventHandler,
+} from "react";
 import FlipInputsArrow from "./FlipInputsArrow";
 import { Column, Row } from "components/layout/components/FlexContainers";
 import { SwapButton } from "./SwapButton";
@@ -20,15 +27,32 @@ import { Flex, FlexGap } from "@containers";
 import Popup from "components/popup";
 import { Text } from "components/text";
 
-const SmallButton = ({ emoji, description, onClick }: { emoji: string, description: string, onClick?: MouseEventHandler<HTMLDivElement> }) => {
-  return <Popup content={<Text textScale="pixelHeading4" textTransform="uppercase" color="black">{description}</Text>}>
-    <div className="px-[.7rem] py-[.2rem] border-[1px] border-solid rounded-full border-dark-gray h-[1.5rem] cursor-pointer hover:bg-neutral-800" onClick={onClick}>
-      <div className="mt-[.11rem]">
-        {emoji}
+const SmallButton = ({
+  emoji,
+  description,
+  onClick,
+}: {
+  emoji: string;
+  description: string;
+  onClick?: MouseEventHandler<HTMLDivElement>;
+}) => {
+  return (
+    <Popup
+      content={
+        <Text textScale="pixelHeading4" textTransform="uppercase" color="black">
+          {description}
+        </Text>
+      }
+    >
+      <div
+        className="px-[.7rem] py-[.2rem] border-[1px] border-solid rounded-full border-dark-gray h-[1.5rem] cursor-pointer hover:bg-neutral-800"
+        onClick={onClick}
+      >
+        <div className="mt-[.11rem]">{emoji}</div>
       </div>
-    </div>
-  </Popup>
-}
+    </Popup>
+  );
+};
 
 const SimulateInputsWrapper = ({ children }: PropsWithChildren) => (
   <div className="flex flex-col relative gap-[19px]">{children}</div>
@@ -85,7 +109,10 @@ export default function SwapComponent({
   const [isSell, setIsSell] = useState(!(searchParams.get("sell") === null));
   const [submit, setSubmit] = useState<(() => Promise<void>) | null>(null);
   const { aptBalance, emojicoinBalance, account, setEmojicoinType } = useAptos();
-  const availableAptBalance = useMemo(() => aptBalance - SWAP_GAS_COST > 0 ? aptBalance - SWAP_GAS_COST : 0n, [aptBalance]);
+  const availableAptBalance = useMemo(
+    () => (aptBalance - SWAP_GAS_COST > 0 ? aptBalance - SWAP_GAS_COST : 0n),
+    [aptBalance]
+  );
 
   const numSwaps = useEventStore(
     (s) => s.getMarket(marketEmojis)?.swapEvents.length ?? initNumSwaps
@@ -137,7 +164,10 @@ export default function SwapComponent({
       return "0";
     }
     // We use the APT display decimal amount here to avoid early truncation.
-    return toDisplayCoinDecimals({ num: value, decimals: type === "apt" ? APT_DISPLAY_DECIMALS : EMOJICOIN_DISPLAY_DECIMALS }).toString();
+    return toDisplayCoinDecimals({
+      num: value,
+      decimals: type === "apt" ? APT_DISPLAY_DECIMALS : EMOJICOIN_DISPLAY_DECIMALS,
+    }).toString();
   };
 
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -200,18 +230,38 @@ export default function SwapComponent({
             {t("Trade Emojicoin")}
           </div>
           <FlexGap flexDirection="row" gap="5px">
-            {isSell ?
+            {isSell ? (
               <>
-                <SmallButton emoji="🤢" description="Sell 50%" onClick={() => setInputAmount(String(emojicoinBalance / 2n))} />
-                <SmallButton emoji="🤮" description="Sell 100%" onClick={() => setInputAmount(String(emojicoinBalance))} />
+                <SmallButton
+                  emoji="🤢"
+                  description="Sell 50%"
+                  onClick={() => setInputAmount(String(emojicoinBalance / 2n))}
+                />
+                <SmallButton
+                  emoji="🤮"
+                  description="Sell 100%"
+                  onClick={() => setInputAmount(String(emojicoinBalance))}
+                />
               </>
-              :
+            ) : (
               <>
-                <SmallButton emoji="🌒" description="Buy 25%" onClick={() => setInputAmount(String(availableAptBalance / 4n))} />
-                <SmallButton emoji="🌓" description="Buy 50%" onClick={() => setInputAmount(String(availableAptBalance / 2n))} />
-                <SmallButton emoji="🌕" description="Buy 100%" onClick={() => setInputAmount(String(availableAptBalance))} />
+                <SmallButton
+                  emoji="🌒"
+                  description="Buy 25%"
+                  onClick={() => setInputAmount(String(availableAptBalance / 4n))}
+                />
+                <SmallButton
+                  emoji="🌓"
+                  description="Buy 50%"
+                  onClick={() => setInputAmount(String(availableAptBalance / 2n))}
+                />
+                <SmallButton
+                  emoji="🌕"
+                  description="Buy 100%"
+                  onClick={() => setInputAmount(String(availableAptBalance))}
+                />
               </>
-            }
+            )}
           </FlexGap>
         </Flex>
 
@@ -236,7 +286,7 @@ export default function SwapComponent({
 
           <FlipInputsArrow
             onClick={() => {
-              setInputAmount(toActualCoinDecimals({num: outputAmount}));
+              setInputAmount(toActualCoinDecimals({ num: outputAmount }));
               setIsSell((v) => !v);
             }}
           />

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AptosInputLabel, EmojiInputLabel } from "./InputLabels";
-import { type PropsWithChildren, useEffect, useState, useCallback, useMemo, MouseEventHandler } from "react";
+import { type PropsWithChildren, useEffect, useState, useCallback, useMemo, type MouseEventHandler } from "react";
 import FlipInputsArrow from "./FlipInputsArrow";
 import { Column, Row } from "components/layout/components/FlexContainers";
 import { SwapButton } from "./SwapButton";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AptosInputLabel, EmojiInputLabel } from "./InputLabels";
-import { type PropsWithChildren, useEffect, useState, useCallback, useMemo } from "react";
+import { type PropsWithChildren, useEffect, useState, useCallback, useMemo, MouseEventHandler } from "react";
 import FlipInputsArrow from "./FlipInputsArrow";
 import { Column, Row } from "components/layout/components/FlexContainers";
 import { SwapButton } from "./SwapButton";
@@ -16,6 +16,19 @@ import { translationFunction } from "context/language-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { AnimatePresence, motion } from "framer-motion";
 import { toCoinTypes } from "@sdk/markets/utils";
+import { Flex, FlexGap } from "@containers";
+import Popup from "components/popup";
+import { Text } from "components/text";
+
+const SmallButton = ({ emoji, descripition, onClick }: { emoji: string, descripition: string, onClick?: MouseEventHandler<HTMLDivElement> }) => {
+  return <Popup content={<Text textScale="pixelHeading4" textTransform="uppercase" color="black">{descripition}</Text>}>
+    <div className="px-[.7rem] py-[.2rem] border-[1px] border-solid rounded-full border-dark-gray h-[1.5rem] cursor-pointer hover:bg-neutral-800" onClick={onClick}>
+      <div className="mt-[.11rem]">
+        {emoji}
+      </div>
+    </div>
+  </Popup>
+}
 
 const SimulateInputsWrapper = ({ children }: PropsWithChildren) => (
   <div className="flex flex-col relative gap-[19px]">{children}</div>
@@ -44,6 +57,7 @@ const inputAndOutputStyles = `
 
 const APT_DISPLAY_DECIMALS = 4;
 const EMOJICOIN_DISPLAY_DECIMALS = 1;
+const SWAP_GAS_COST = 52500n;
 
 export default function SwapComponent({
   emojicoin,
@@ -63,7 +77,7 @@ export default function SwapComponent({
     !Number.isNaN(Number(presetInputAmount));
   const { isDesktop } = useMatchBreakpoints();
   const [inputAmount, setInputAmount] = useState(
-    presetInputAmountIsValid ? presetInputAmount! : "1"
+    toActualCoinDecimals({ num: presetInputAmountIsValid ? presetInputAmount! : "1" })
   );
   const [outputAmount, setOutputAmount] = useState("0");
   const [previous, setPrevious] = useState(inputAmount);
@@ -71,6 +85,7 @@ export default function SwapComponent({
   const [isSell, setIsSell] = useState(!(searchParams.get("sell") === null));
   const [submit, setSubmit] = useState<(() => Promise<void>) | null>(null);
   const { aptBalance, emojicoinBalance, account, setEmojicoinType } = useAptos();
+  const availableAptBalance = useMemo(() => aptBalance - SWAP_GAS_COST > 0 ? aptBalance - SWAP_GAS_COST : 0n, [aptBalance]);
 
   const numSwaps = useEventStore(
     (s) => s.getMarket(marketEmojis)?.swapEvents.length ?? initNumSwaps
@@ -83,7 +98,7 @@ export default function SwapComponent({
 
   const swapResult = useSimulateSwap({
     marketAddress,
-    inputAmount: toActualCoinDecimals({ num: inputAmount }),
+    inputAmount,
     isSell,
     numSwaps,
   });
@@ -109,20 +124,20 @@ export default function SwapComponent({
       setIsLoading(true);
       return;
     }
-    const swapResultDisplay = toDisplayNumber(swapResult);
+    const swapResultDisplay = toDisplayNumber(swapResult, isSell ? "apt" : "emoji");
     setPrevious(swapResultDisplay);
     setOutputAmount(swapResultDisplay);
     setIsLoading(false);
     replay();
   }, [swapResult, replay]);
 
-  const toDisplayNumber = (value: bigint | number | string) => {
+  const toDisplayNumber = (value: bigint | number | string, type: "apt" | "emoji" = "apt") => {
     const badString = typeof value === "string" && (value === "" || isNaN(parseInt(value)));
     if (!value || badString) {
       return "0";
     }
     // We use the APT display decimal amount here to avoid early truncation.
-    return toDisplayCoinDecimals({ num: value, decimals: APT_DISPLAY_DECIMALS }).toString();
+    return toDisplayCoinDecimals({ num: value, decimals: type === "apt" ? APT_DISPLAY_DECIMALS : EMOJICOIN_DISPLAY_DECIMALS }).toString();
   };
 
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -133,7 +148,7 @@ export default function SwapComponent({
       e.stopPropagation();
       return;
     }
-    setInputAmount(e.target.value);
+    setInputAmount(toActualCoinDecimals({ num: e.target.value }));
   };
 
   const handleKeyDown = useCallback(
@@ -149,9 +164,9 @@ export default function SwapComponent({
     if (!account || (isSell && !emojicoinBalance) || (!isSell && !aptBalance)) return false;
     if (account) {
       if (isSell) {
-        return emojicoinBalance >= BigInt(toActualCoinDecimals({ num: inputAmount }));
+        return emojicoinBalance >= BigInt(inputAmount);
       }
-      return aptBalance >= BigInt(toActualCoinDecimals({ num: inputAmount }));
+      return aptBalance >= BigInt(inputAmount);
     }
   }, [account, aptBalance, emojicoinBalance, isSell, inputAmount]);
 
@@ -178,11 +193,23 @@ export default function SwapComponent({
   return (
     <>
       <Column className="relative w-full max-w-[414px] h-full justify-center">
-        <div
-          className={`${isDesktop ? "heading-1" : "heading-2"} md:heading-1 text-white uppercase pb-[17px]`}
-        >
-          {t("Trade Emojicoin")}
-        </div>
+        <Flex flexDirection="row" justifyContent="space-between">
+          <div
+            className={`${isDesktop ? "heading-1" : "heading-2"} md:heading-1 text-white uppercase pb-[17px]`}
+          >
+            {t("Trade Emojicoin")}
+          </div>
+          <FlexGap flexDirection="row" gap="5px">
+            {isSell ?
+              <SmallButton emoji="🤮" descripition="Sell all" onClick={() => setInputAmount(String(emojicoinBalance))} />
+              :
+              <>
+                <SmallButton emoji="🌓" descripition="Buy half" onClick={() => setInputAmount(String(availableAptBalance / 2n))} />
+                <SmallButton emoji="🌕" descripition="Buy all" onClick={() => setInputAmount(String(availableAptBalance))} />
+              </>
+            }
+          </FlexGap>
+        </Flex>
 
         <SimulateInputsWrapper>
           <InnerWrapper>
@@ -193,8 +220,7 @@ export default function SwapComponent({
               </div>
               <input
                 className={inputAndOutputStyles + " bg-transparent leading-[32px]"}
-                value={inputAmount}
-                min={0} // min, max, and step don't do anything here. They're here for possible accessibility purposes.
+                value={Number(toDisplayNumber(inputAmount, isSell ? "emoji" : "apt"))}
                 step={0.01}
                 onChange={handleInput}
                 onKeyDown={handleKeyDown}
@@ -206,14 +232,7 @@ export default function SwapComponent({
 
           <FlipInputsArrow
             onClick={() => {
-              const outputAmountNumber = Number(outputAmount);
-              // Keep in mind that we're switching the sell type, so we do the opposite of what you'd expect to see.
-              const switchingToSell = !isSell;
-              if (switchingToSell) {
-                setInputAmount(outputAmountNumber.toFixed(EMOJICOIN_DISPLAY_DECIMALS));
-              } else {
-                setInputAmount(outputAmountNumber.toFixed(APT_DISPLAY_DECIMALS));
-              }
+              setInputAmount(toActualCoinDecimals({num: outputAmount}));
               setIsSell((v) => !v);
             }}
           />
@@ -238,7 +257,7 @@ export default function SwapComponent({
 
         <Row className="justify-center mt-[14px]">
           <SwapButton
-            inputAmount={toActualCoinDecimals({ num: inputAmount })}
+            inputAmount={inputAmount}
             marketAddress={marketAddress}
             isSell={isSell}
             setSubmit={setSubmit}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds a:

- sell 100% of your emojicoins buttom
- buy emojicoins using 50% of your APT balance button
- buy emojicoins using 100% of your APT balance button

on the market page of an emoji.

![image](https://github.com/user-attachments/assets/0566b1a4-4f44-493e-b690-21ef1deb7943)

![image](https://github.com/user-attachments/assets/02cca398-4196-4aea-b977-30794fc86b59)


# Testing

See vercel.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
