### PR TITLE
[ECO-2184] Re-order `allowlist` fetch checks to check `allowlister3000` first

### DIFF
--- a/src/typescript/frontend/src/lib/utils/allowlist.ts
+++ b/src/typescript/frontend/src/lib/utils/allowlist.ts
@@ -19,6 +19,15 @@ export async function isAllowListed(address: string): Promise<boolean> {
     address = `0x${address}`;
   }
 
+  if (ALLOWLISTER3K_URL !== undefined) {
+    const condition = await fetch(`${ALLOWLISTER3K_URL}/${address}`)
+      .then((r) => r.text())
+      .then((data) => data === "true");
+    if (condition) {
+      return true;
+    }
+  }
+
   if (GALXE_CAMPAIGN_ID !== undefined) {
     const condition = await fetch(GALXE_URL, {
       method: "POST",
@@ -42,15 +51,6 @@ export async function isAllowListed(address: string): Promise<boolean> {
     })
       .then((r) => r.json())
       .then((data) => data.data.campaign && data.data.campaign.whitelistInfo.usedCount === 1);
-    if (condition) {
-      return true;
-    }
-  }
-
-  if (ALLOWLISTER3K_URL !== undefined) {
-    const condition = await fetch(`${ALLOWLISTER3K_URL}/${address}`)
-      .then((r) => r.text())
-      .then((data) => data === "true");
     if (condition) {
       return true;
     }


### PR DESCRIPTION
# Description

I noticed since the Galxe campaign may be inactive/unused fairly soon, we can re-order the fetch calls to make the `verify` process a bit faster, since right now it can take about 3-4 seconds.

- [x] Re-order the fetch calls
- [x] Consider removing the Galxe campaign check entirely?

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
