### PR TITLE
[ECO-2191] Remove `Join Here` from the access denied message

### DIFF
--- a/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
@@ -24,7 +24,7 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
       verified === true
         ? "Access Granted"
         : verified === false
-          ? "Access Denied - Join Here"
+          ? "Access Denied"
           : "Verifying...",
     overdrive: false,
     overflow: true,
@@ -94,11 +94,9 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
             <ButtonWithConnectWalletFallback geoblocked={geoblocked} arrow={false}>
               <div className="flex flex-row uppercase">
                 <span className="px-2.5">{"{"}</span>
-                <a
+                <span
                   ref={ref}
-                  href={process.env.NEXT_PUBLIC_GALXE_CAMPAIGN_REDIRECT}
                   onMouseEnter={replay}
-                  {...EXTERNAL_LINK_PROPS}
                 />
                 <span className="px-2.5">{"}"}</span>
               </div>

--- a/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
@@ -92,7 +92,7 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
               </motion.div>
             )}
             <ButtonWithConnectWalletFallback geoblocked={geoblocked} arrow={false}>
-              <div className="flex flex-row uppercase">
+              <div className="flex flex-row uppercase mt-[8ch]">
                 <span className="px-2.5">{"{"}</span>
                 <span
                   ref={ref}


### PR DESCRIPTION
# Description

- [x] Remove `Join Here` from it
- [x] Convert the link `a` element to a `span`

<img width="365" alt="Screenshot 2024-09-18 at 7 46 57 PM" src="https://github.com/user-attachments/assets/eb920024-ad12-49e1-9bbe-c44d2afbb0b6">


# Testing

Manual.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
