### PR TITLE
[ECO-2203] Match search bar with figma design

### DIFF
--- a/src/typescript/frontend/src/components/inputs/search-bar.tsx
+++ b/src/typescript/frontend/src/components/inputs/search-bar.tsx
@@ -28,7 +28,7 @@ export const Border = styled(Flex)`
   height: 33px;
   margin: 6px 0;
   padding: 0 0.5rem;
-  border: 2px solid ${DARK_GRAY};
+  border: 1px solid ${DARK_GRAY};
   border-radius: 2rem;
   @media screen and (max-width: ${breakpointsArray[3]}) {
     width: 100%;

--- a/src/typescript/frontend/src/components/pages/pools/styled.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/styled.tsx
@@ -59,7 +59,7 @@ export const StyledHeaderInner = styled.div`
   width: 100%;
   border-left: 1px solid ${({ theme }) => theme.colors.darkGray};
   border-right: 1px solid ${({ theme }) => theme.colors.darkGray};
-  padding: 0 21px;
+  padding: 0 10px;
 `;
 
 export const StyledInner = styled(Flex)`


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR removes 1px to the width of the border of the search bar and fixes the left padding of the search bar on the pools page.

# Testing

See vercel.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
