### PR TITLE
[ECO-2209] Make insufficient balance for market registration clearer

### DIFF
--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
@@ -21,7 +21,7 @@ export const useIsMarketRegistered = () => {
       const length = sumBytes(emojis);
       const invalidLength = length === 0 || length > 10;
       // If not all of the emojis are in the symbol data map, then it can't have been registered.
-      if (!emojis.some((e) => SYMBOL_DATA.byEmoji(e))) {
+      if (!emojis.every(SYMBOL_DATA.byEmoji)) {
         return {
           invalid: true,
           registered: false,

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
@@ -36,13 +36,18 @@ export const useRegisterMarket = () => {
       const publicKey = new Ed25519PublicKey(
         typeof account!.publicKey === "string" ? account!.publicKey : account!.publicKey[0]
       );
-      const r = await RegisterMarket.getGasCost({
-        aptosConfig: aptos.config,
-        registrant: account!.address,
-        registrantPubKey: publicKey,
-        emojis: numMarkets === 0 ? [SYMBOL_DATA.byName("Virgo")!.bytes] : emojiBytes,
-      });
-      return r;
+      try {
+        const r = await RegisterMarket.getGasCost({
+          aptosConfig: aptos.config,
+          registrant: account!.address,
+          registrantPubKey: publicKey,
+          emojis: numMarkets === 0 ? [SYMBOL_DATA.byName("Virgo")!.bytes] : emojiBytes,
+        });
+        return r;
+      } catch (e) {
+        console.error(e);
+        return undefined;
+      }
     },
     staleTime: 1000,
     enabled:

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
@@ -33,13 +33,16 @@ export const useRegisterMarket = () => {
   const { data: gasResult } = useQuery({
     queryKey: ["register-market-cost", numMarkets, account?.address, emojiBytes],
     queryFn: async () => {
+      if (account === null) {
+        return undefined;
+      }
       const publicKey = new Ed25519PublicKey(
-        typeof account!.publicKey === "string" ? account!.publicKey : account!.publicKey[0]
+        typeof account!.publicKey === "string" ? account.publicKey : account.publicKey[0]
       );
       try {
         const r = await RegisterMarket.getGasCost({
           aptosConfig: aptos.config,
-          registrant: account!.address,
+          registrant: account.address,
           registrantPubKey: publicKey,
           emojis: numMarkets === 0 ? [SYMBOL_DATA.byName("Virgo")!.bytes] : emojiBytes,
         });

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
@@ -10,13 +10,11 @@ export const LaunchButtonOrGoToMarketLink = ({
   onWalletButtonClick,
   registered,
   invalid,
-  insufficientBalance,
   geoblocked,
 }: {
   onWalletButtonClick: () => void;
   registered?: boolean;
   invalid: boolean;
-  insufficientBalance: boolean;
   geoblocked: boolean;
 }) => {
   const emojis = useEmojiPicker((state) => state.emojis);
@@ -41,19 +39,13 @@ export const LaunchButtonOrGoToMarketLink = ({
           </Link>
         ) : (
           <Button
-            disabled={insufficientBalance || invalid || typeof registered === "undefined"}
+            disabled={invalid || typeof registered === "undefined"}
             onClick={onWalletButtonClick}
             scale="lg"
             style={{ cursor: invalid ? "not-allowed" : "pointer" }}
             scrambleProps={scrambleProps}
           >
-            {t(
-              insufficientBalance
-                ? "Insufficient balance"
-                : invalid
-                  ? "Invalid input"
-                  : "Launch Emojicoin"
-            )}
+            {t(invalid ? "Invalid input" : "Launch Emojicoin")}
           </Button>
         )}
       </ButtonWithConnectWalletFallback>

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
@@ -10,11 +10,13 @@ export const LaunchButtonOrGoToMarketLink = ({
   onWalletButtonClick,
   registered,
   invalid,
+  insufficientBalance,
   geoblocked,
 }: {
   onWalletButtonClick: () => void;
   registered?: boolean;
   invalid: boolean;
+  insufficientBalance: boolean;
   geoblocked: boolean;
 }) => {
   const emojis = useEmojiPicker((state) => state.emojis);
@@ -39,13 +41,19 @@ export const LaunchButtonOrGoToMarketLink = ({
           </Link>
         ) : (
           <Button
-            disabled={invalid || typeof registered === "undefined"}
+            disabled={insufficientBalance || invalid || typeof registered === "undefined"}
             onClick={onWalletButtonClick}
             scale="lg"
             style={{ cursor: invalid ? "not-allowed" : "pointer" }}
             scrambleProps={scrambleProps}
           >
-            {t("Launch Emojicoin")}
+            {t(
+              insufficientBalance
+                ? "Insufficient balance"
+                : invalid
+                  ? "Invalid input"
+                  : "Launch Emojicoin"
+            )}
           </Button>
         )}
       </ButtonWithConnectWalletFallback>

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
@@ -175,7 +175,8 @@ export const MemoizedLaunchAnimation = ({
           >
             <LaunchButtonOrGoToMarketLink
               geoblocked={geoblocked}
-              invalid={invalid || !sufficientBalance}
+              invalid={invalid}
+              insufficientBalance={!sufficientBalance}
               registered={registered}
               onWalletButtonClick={() => {
                 registerMarket();

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
@@ -137,7 +137,13 @@ export const MemoizedLaunchAnimation = ({
                 </div>
               </div>
               <div className="flex flex-row justify-between">
-                <span className="mr-[2ch]">{t("Your balance")}</span>
+                <div className="flex flex-row">
+                  <span>{t("Your balance")}</span>
+                  <div className={"flex flex-row absolute mt-[2px]"}>
+                    <span className="opacity-0 select-none">{t("Your balance")}</span>
+                    <div className="ml-[3px] text-[12px]">{sufficientBalance ? "✅" : "❌"}</div>
+                  </div>
+                </div>
                 <div>
                   <span
                     className={
@@ -176,7 +182,6 @@ export const MemoizedLaunchAnimation = ({
             <LaunchButtonOrGoToMarketLink
               geoblocked={geoblocked}
               invalid={invalid}
-              insufficientBalance={!sufficientBalance}
               registered={registered}
               onWalletButtonClick={() => {
                 registerMarket();


### PR DESCRIPTION
# Description

Change the launch emojicoin button to say:

- [x] `Invalid Input` if it's an invalid input of emojis somehow (It shouldn't be able to do this)
- [x] `Launch Emojicoin` otherwise
- [x] Add a ✅ or ❌ if the balance appears sufficient/insufficient, respectively
- [x] Fix the `invalid` logic to make sure all emojis are valid, not just checking for one being valid

<img width="468" alt="image" src="https://github.com/user-attachments/assets/43f30cba-8e0e-4a93-b0bc-c534d0a942c1">

<img width="430" alt="image" src="https://github.com/user-attachments/assets/1c0318b0-4aa3-450a-8156-03f6b367915b">


# Testing

Manual testing.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
