### PR TITLE
[ECO-2215] Update "Start here" button to "Docs" and fix mobile menu button not launching in new tab

### DIFF
--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -139,7 +139,13 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
           </AnimatePresence>
           {linksForCurrentPage.map(({ title, path }, i) => {
             return (
-              <Link key={title} href={path} onClick={handleCloseMobileMenu} width="100%">
+              <Link
+                key={title}
+                href={path}
+                target={path.startsWith("https://") ? "_blank" : undefined}
+                onClick={handleCloseMobileMenu}
+                width="100%"
+              >
                 <MobileMenuItem title={title} borderBottom={i !== linksForCurrentPage.length - 1} />
               </Link>
             );

--- a/src/typescript/frontend/src/components/header/constants.ts
+++ b/src/typescript/frontend/src/components/header/constants.ts
@@ -4,5 +4,5 @@ export const NAVIGATE_LINKS = [
   { title: "home", path: ROUTES.home, width: "45px" },
   { title: "pools", path: ROUTES.pools, width: "52px" },
   { title: "launch emojicoin", path: ROUTES.launch, width: "158px" },
-  { title: "start here", path: ROUTES.startHere, width: "100px" },
+  { title: "docs", path: ROUTES.docs, width: "42px" },
 ];

--- a/src/typescript/frontend/src/router/routes.ts
+++ b/src/typescript/frontend/src/router/routes.ts
@@ -6,6 +6,6 @@ export const ROUTES = {
   launch: "/launch",
   pools: "/pools",
   verify: "/verify",
-  startHere: "https://docs.emojicoin.fun/category/--start-here",
+  docs: "https://docs.emojicoin.fun/category/--start-here",
   notFound: "/not-found",
 } as const;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR updates the "START HERE" button to say "DOCS".

It also fixes an old bug that made it so that the moblie menu version of the "START HERE" button did not open in a new tab. Now it does.

# Testing

See Vercel.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->

