### PR TITLE
[ECO-2211] Fix emoji picker not deplaying correctly for users with light mode as default

### DIFF
--- a/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
+++ b/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
@@ -214,9 +214,11 @@ export default function EmojiPicker(
     }
   }, []);
 
+  const { drag, ...propsRest } = props;
+
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <div {...props} className="relative bg-black rounded-xl shadow-econia">
+      <div {...propsRest} className="relative bg-black rounded-xl shadow-econia">
         <div
           className="right-0 relative h-[29px] w-[100%] bg-ec-blue z-5"
           style={{
@@ -232,6 +234,7 @@ export default function EmojiPicker(
           style={{ marginTop: "-10px" }}
         >
           <Picker
+            theme="dark"
             perLine={8}
             exceptEmojis={[]}
             onEmojiSelect={(v: EmojiSelectorData) => {

--- a/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
+++ b/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
@@ -226,7 +226,7 @@ export default function EmojiPicker(
             borderTopLeftRadius: "8px",
             borderTopRightRadius: "8px",
           }}
-          onPointerDown={props.drag}
+          onPointerDown={drag}
         ></div>
 
         <div


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes the emoji picker not rendering correctly in browers where light mode is set as default.

It also fixes a long lasting bug that simply prints errors in the console. This was due to the `drag` property being applied to the `div` when decontructing `props` (`{...props}`).

# Testing

See Vercel.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
