### PR TITLE
[ECO-2216] Add new button scale "xl" and set core interaction buttons to be "xl"

### DIFF
--- a/src/typescript/frontend/src/components/button/index.tsx
+++ b/src/typescript/frontend/src/components/button/index.tsx
@@ -8,7 +8,7 @@ import SpinnerIcon from "components/svg/icons/Spinner";
 import { Text } from "components/text";
 import { FlexGap } from "@containers";
 
-import { type ButtonProps } from "./types";
+import { scaleToPx, type ButtonProps } from "./types";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 
 const Button = <E extends React.ElementType = "button">({
@@ -63,7 +63,7 @@ const Button = <E extends React.ElementType = "button">({
                 textScale="pixelHeading4"
                 color={isDisabled ? "darkGray" : "econiaBlue"}
                 textTransform="uppercase"
-                fontSize={scale === "sm" ? "20px" : "24px"}
+                fontSize={scaleToPx(scale)}
               >
                 {"{ "}
               </Text>
@@ -71,14 +71,14 @@ const Button = <E extends React.ElementType = "button">({
                 textScale="pixelHeading4"
                 color={isDisabled ? "darkGray" : "econiaBlue"}
                 textTransform="uppercase"
-                fontSize={scale === "sm" ? "20px" : "24px"}
+                fontSize={scaleToPx(scale)}
                 ref={isScramble ? ref : undefined}
               />
               <Text
                 textScale="pixelHeading4"
                 color={isDisabled ? "darkGray" : "econiaBlue"}
                 textTransform="uppercase"
-                fontSize={scale === "sm" ? "20px" : "24px"}
+                fontSize={scaleToPx(scale)}
               >
                 {" }"}
               </Text>

--- a/src/typescript/frontend/src/components/button/types.ts
+++ b/src/typescript/frontend/src/components/button/types.ts
@@ -13,10 +13,19 @@ export const variants = {
 export const scales = {
   SMALL: "sm",
   LARGE: "lg",
+  VERY_LARGE: "xl",
 } as const;
 
 export type Scale = (typeof scales)[keyof typeof scales];
 export type Variant = (typeof variants)[keyof typeof variants];
+
+export const scaleToPx = (scale: Scale) => {
+  switch (scale) {
+    case "sm": return "20px";
+    case "lg": return "24px";
+    case "xl": return "30px";
+  }
+}
 
 export interface BaseButtonProps
   extends LayoutProps,

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -10,12 +10,14 @@ import Arrow from "@icons/Arrow";
 import { useNameStore } from "context/event-store-context";
 import Popup from "components/popup";
 import Text from "components/text";
+import { type Scale, scaleToPx } from "components/button/types";
 
 export interface ConnectWalletProps extends PropsWithChildren<{ className?: string }> {
   mobile?: boolean;
   onClick?: () => void;
   geoblocked: boolean;
   arrow?: boolean;
+  scale?: Scale;
 }
 
 const CONNECT_WALLET = "Connect Wallet";
@@ -27,6 +29,7 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
   onClick,
   geoblocked,
   arrow = true,
+  scale = "lg",
 }) => {
   const { connected, account } = useWallet();
   const { openWalletModal } = useWalletModal();
@@ -86,7 +89,7 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
         onMouseOver={handleReplay}
       >
         <div
-          className={`flex flex-row text-${geoblocked ? "dark-gray" : "ec-blue"} text-2xl justify-between`}
+          className={`flex flex-row text-${geoblocked ? "dark-gray" : "ec-blue"} justify-between`} style={{fontSize: scaleToPx(scale)}}
         >
           <div className="flex flex-row">
             <OuterConnectText

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
@@ -79,8 +79,8 @@ export const SwapButton = ({
 
   return (
     <>
-      <ButtonWithConnectWalletFallback geoblocked={geoblocked}>
-        <Button disabled={disabled} onClick={handleClick} scale="lg">
+      <ButtonWithConnectWalletFallback geoblocked={geoblocked} scale="xl">
+        <Button disabled={disabled} onClick={handleClick} scale="xl">
           {t("Swap")}
         </Button>
         <RewardsAnimation controls={controls} />

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -313,7 +313,7 @@ export default function SwapComponent({
           </InnerWrapper>
         </SimulateInputsWrapper>
 
-        <Row className="justify-center mt-[14px]">
+        <Row className="justify-center mt-[24px]">
           <SwapButton
             inputAmount={inputAmount}
             marketAddress={marketAddress}

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
@@ -27,7 +27,7 @@ export const LaunchButtonOrGoToMarketLink = ({
 
   return (
     <>
-      <ButtonWithConnectWalletFallback geoblocked={geoblocked}>
+      <ButtonWithConnectWalletFallback geoblocked={geoblocked} scale="xl">
         {registered ? (
           <Link
             className="font-pixelar text-lg uppercase text-ec-blue"
@@ -41,7 +41,7 @@ export const LaunchButtonOrGoToMarketLink = ({
           <Button
             disabled={invalid || typeof registered === "undefined"}
             onClick={onWalletButtonClick}
-            scale="lg"
+            scale="xl"
             style={{ cursor: invalid ? "not-allowed" : "pointer" }}
             scrambleProps={scrambleProps}
           >

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -299,9 +299,9 @@ const Liquidity: React.FC<LiquidityProps> = ({ market, geoblocked }) => {
           mb={{ _: "17px", tablet: "37px" }}
           position="relative"
         >
-          <ButtonWithConnectWalletFallback geoblocked={geoblocked}>
+          <ButtonWithConnectWalletFallback geoblocked={geoblocked} scale="xl">
             <Button
-              scale="lg"
+              scale="xl"
               disabled={!isActionPossible}
               style={{ cursor: isActionPossible ? "pointer" : "not-allowed" }}
               onClick={async () => {


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Buttons were found to be too small.

This PR defines a new button size standard: "xl" (in addition to "sm" and "lg" which were already present).

The new standard is used in core interaction buttons, like swap, provide liquidity, or launch market.

# Testing

See vercel.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
