### PR TITLE
[ECO-2222] Clean up the localnet setup process

### DIFF
--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -24,6 +24,17 @@ docker compose -f compose.yaml up
 
 ## Run a local Aptos fullnode as well
 
+Before you run the local testnet, ensure that your Docker Desktop settings are
+correct. In your Docker Desktop settings, you must have enabled:
+
+- Resources -> Enable host networking
+
+If you're using WSL 2, you must also enable both of these settings:
+
+- Use the WSL 2 based engine ... -> Add the *.docker.internal names ...
+
+Now your container can run the localnet on the host network:
+
 ```shell
 docker compose -f compose.local.yaml up
 ```

--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -31,7 +31,7 @@ correct. In your Docker Desktop settings, you must have enabled:
 
 If you're using WSL 2, you must also enable both of these settings:
 
-- Use the WSL 2 based engine ... -> Add the *.docker.internal names ...
+- Use the WSL 2 based engine ... -> Add the \*.docker.internal names ...
 
 Now your container can run the localnet on the host network:
 

--- a/src/docker/localnet/Dockerfile
+++ b/src/docker/localnet/Dockerfile
@@ -2,7 +2,8 @@
 
 FROM econialabs/aptos-cli:4.1.0
 
-RUN apt-get update && apt-get install --no-install-recommends -y bc
+RUN apt-get update && apt-get install --no-install-recommends -y bc=1.07* \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/src/docker/localnet/Dockerfile
+++ b/src/docker/localnet/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM econialabs/aptos-cli:4.1.0
 
+RUN apt-get update && apt-get install --no-install-recommends -y bc
+
 WORKDIR /app
 
 COPY src/docker/localnet/*.sh sh/

--- a/src/docker/localnet/check-if-stale.sh
+++ b/src/docker/localnet/check-if-stale.sh
@@ -47,6 +47,11 @@ function check_if_stale() {
 	rest_api_endpoint="http://localhost:8080/v1/transactions/by_version/1"
 	proposer2=$(curl -s "$rest_api_endpoint" | jq -r '.proposer')
 
+	if [[ -z "$proposer1" || -z "$proposer2" ]]; then
+		echo "ERROR: Failed to fetch the proposer from both endpoints."
+		exit 1
+	fi
+
 	if compare_addresses "$proposer1" "$proposer2"; then
 		echo "The indexer and the localnet are in sync, we're good to go!"
 		exit 0

--- a/src/docker/localnet/check-if-stale.sh
+++ b/src/docker/localnet/check-if-stale.sh
@@ -47,7 +47,7 @@ function check_if_stale() {
 	rest_api_endpoint="http://localhost:8080/v1/transactions/by_version/1"
 	proposer2=$(curl -s "$rest_api_endpoint" | jq -r '.proposer')
 
-	if [[ -z "$proposer1" || -z "$proposer2" ]]; then
+	if [[ -z $proposer1 || -z $proposer2 ]]; then
 		echo "ERROR: Failed to fetch the proposer from both endpoints."
 		exit 1
 	fi

--- a/src/docker/utils/prune.sh
+++ b/src/docker/utils/prune.sh
@@ -132,11 +132,12 @@ docker rm -f $api 2>/dev/null
 docker volume rm -f $postgres-data
 
 if [ -n "$reset_localnet" ]; then
-	if [ -n "$CI" ]; then
-		sudo rm -rf $docker_dir/localnet/.aptos || true
-	else
-		rm -rf $docker_dir/localnet/.aptos || true
-	fi
+	# In order to avoid having to run `sudo rm -rf src/docker/localnet/.aptos`,
+	# we can bind-mount a volume one directory above `localnet/.aptos`, aka
+	# `localnet`, effectively giving the ephemeral container ownership of
+	# everything in that directory. Then we delete the localnet data, aka
+	# `.aptos`, from within the ephemeral container.
+	docker run --rm -v "$docker_dir/localnet:/pwd" busybox rm -rf /pwd/.aptos
 	docker compose -f compose.local.yaml down --volumes
 else
 	docker compose -f compose.local.yaml down

--- a/src/docker/utils/prune.sh
+++ b/src/docker/utils/prune.sh
@@ -133,10 +133,9 @@ docker volume rm -f $postgres-data
 
 if [ -n "$reset_localnet" ]; then
 	# In order to avoid having to run `sudo rm -rf src/docker/localnet/.aptos`,
-	# we can bind-mount a volume one directory above `localnet/.aptos`, aka
-	# `localnet`, effectively giving the ephemeral container ownership of
-	# everything in that directory. Then we delete the localnet data, aka
-	# `.aptos`, from within the ephemeral container.
+	# we can run an ephemeral `docker` container that bind-mounts `localnet`.
+	# Bind-mounting the parent of `.aptos` gives the container the right to
+	# delete it.
 	docker run --rm -v "$docker_dir/localnet:/pwd" busybox rm -rf /pwd/.aptos
 	docker compose -f compose.local.yaml down --volumes
 else

--- a/src/typescript/pnpm-lock.yaml
+++ b/src/typescript/pnpm-lock.yaml
@@ -266,9 +266,6 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
     devDependencies:
-      '@aptos-labs/aptos-cli':
-        specifier: ^0.1.9
-        version: 0.1.9
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -16,7 +16,6 @@
   },
   "description": "TypeScript SDK for Econia's Emojicoin Dot Fun",
   "devDependencies": {
-    "@aptos-labs/aptos-cli": "^0.1.9",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/src/typescript/sdk/tests/utils/publish.ts
+++ b/src/typescript/sdk/tests/utils/publish.ts
@@ -42,12 +42,10 @@ export async function publishPackage(args: {
   } = args;
   const includedArtifacts = args.includedArtifacts || "none";
 
-  let aptosExecutableAvailable = true;
-  // Avoid using npx if aptos is installed globally already.
   try {
     execSync("aptos --version");
   } catch (e) {
-    aptosExecutableAvailable = false;
+    throw new Error("Please install the `aptos` executable before running these tests.");
   }
 
   const packageDir = path.join(getGitRoot(), packageDirRelative);
@@ -60,7 +58,7 @@ export async function publishPackage(args: {
   const privateKeyString = new Hex(privateKey.toUint8Array()).toStringWithoutPrefix();
 
   const shellArgs = [
-    aptosExecutableAvailable ? "npx @aptos-labs/aptos-cli" : "aptos",
+    "aptos",
     "move",
     "publish",
     ...["--named-addresses", namedAddressesString],
@@ -115,11 +113,9 @@ function extractJsonFromText(originalCommand: string, text: string): ResultJSON 
     }
   }
 
-  /* eslint-disable no-console */
-  console.error(`Command: ${originalCommand}`);
-  console.error("Result:");
-  console.error(text);
-  /* eslint-enable no-console */
+  console.debug(`Command: ${originalCommand}`);
+  console.debug("Result:");
+  console.debug(text);
   return null;
 }
 


### PR DESCRIPTION
# Description

- [x] Add `bc` to the `localnet` service so `check-if-stale.sh` actually works
- [x] Remove `@aptos-labs/aptos-cli` from the dev dependencies since it's fickle and we don't use it anymore anyway
- [x] Fix the need to use `sudo` to remove the localnet data directory: we can do this by removing the `src/docker/localnet/.aptos` folder by starting a docker service, bind-mounting it one directory above, then removing `.aptos`
- [x] Add instructions for setting the `localnet` up in a Docker Desktop on Windows Subsystem for Linux (WSL) environment

# Testing

Delete this sentence and provide a description of how to test the changes in
this PR.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
