### PR TITLE
[ECO-2224] Fix wrong separation character being used in header

### DIFF
--- a/src/typescript/sdk/src/indexer-v2/queries/client.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/client.ts
@@ -64,7 +64,7 @@ const localIndexer =
 
 const authHeaders =
   !localIndexer && process.env.EMOJICOIN_INDEXER_API_KEY
-    ? { "x-api-key": `${process.env.EMOJICOIN_INDEXER_API_KEY}`, Accept: "application-json" }
+    ? { "x-api-key": `${process.env.EMOJICOIN_INDEXER_API_KEY}`, Accept: "application/json" }
     : undefined;
 
 export const postgrest = new CustomClient(EMOJICOIN_INDEXER_URL, {


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes a small error with the header being sent to PostgREST (`-` being used instead of `/`).

