### PR TITLE
[ECO-2225] Remove check that renders local indexer testing with testnet impossible

### DIFF
--- a/src/typescript/frontend/src/lib/server-env.ts
+++ b/src/typescript/frontend/src/lib/server-env.ts
@@ -1,7 +1,5 @@
 import "server-only";
-import { APTOS_NETWORK, IS_ALLOWLIST_ENABLED } from "./env";
-import { Network } from "@aptos-labs/ts-sdk";
-import { EMOJICOIN_INDEXER_URL } from "@sdk/server-env";
+import { IS_ALLOWLIST_ENABLED } from "./env";
 
 if (typeof process.env.REVALIDATION_TIME === "undefined") {
   if (process.env.NODE) throw new Error("Environment variable REVALIDATION_TIME is undefined.");
@@ -41,9 +39,3 @@ export const GALXE_CAMPAIGN_ID: string | undefined = process.env.GALXE_CAMPAIGN_
 export const REVALIDATION_TIME: number = Number(process.env.REVALIDATION_TIME);
 export const HASH_SEED: string = process.env.HASH_SEED;
 export const VPNAPI_IO_API_KEY: string = process.env.VPNAPI_IO_API_KEY!;
-
-if (APTOS_NETWORK !== Network.LOCAL && EMOJICOIN_INDEXER_URL.includes("localhost")) {
-  throw new Error(
-    `APTOS_NETWORK is ${APTOS_NETWORK} but the indexer processor url is ${EMOJICOIN_INDEXER_URL}`
-  );
-}

--- a/src/typescript/frontend/src/lib/server-env.ts
+++ b/src/typescript/frontend/src/lib/server-env.ts
@@ -1,5 +1,7 @@
 import "server-only";
-import { IS_ALLOWLIST_ENABLED } from "./env";
+import { APTOS_NETWORK, IS_ALLOWLIST_ENABLED } from "./env";
+import { Network } from "@aptos-labs/ts-sdk";
+import { EMOJICOIN_INDEXER_URL } from "@sdk/server-env";
 
 if (typeof process.env.REVALIDATION_TIME === "undefined") {
   if (process.env.NODE) throw new Error("Environment variable REVALIDATION_TIME is undefined.");
@@ -39,3 +41,9 @@ export const GALXE_CAMPAIGN_ID: string | undefined = process.env.GALXE_CAMPAIGN_
 export const REVALIDATION_TIME: number = Number(process.env.REVALIDATION_TIME);
 export const HASH_SEED: string = process.env.HASH_SEED;
 export const VPNAPI_IO_API_KEY: string = process.env.VPNAPI_IO_API_KEY!;
+
+if (APTOS_NETWORK === Network.LOCAL && !EMOJICOIN_INDEXER_URL.includes("localhost")) {
+  throw new Error(
+    `APTOS_NETWORK is ${APTOS_NETWORK} but the indexer processor url is set to ${EMOJICOIN_INDEXER_URL}`
+  );
+}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The check removed made sure that the indexer isn't running on localhost when
the network is set on testnet. This makes it impossible to test something with
a local indexer against testnet. Since this is a workflow that is very used,
and the check does not seem to be very important, it is removed.
