### PR TITLE
[ECO-2227] Add chat box input preview if wallet isn't connected

### DIFF
--- a/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
@@ -31,7 +31,9 @@ const ChatInputBox = ({
       <ButtonWithConnectWalletFallback geoblocked={geoblocked} className="mt-[6px]">
         {children}
       </ButtonWithConnectWalletFallback>
-      {!connected && <div className="flex justify-center absolute w-full opacity-20 z-[-1]">{children}</div>}
+      {!connected && (
+        <div className="flex justify-center absolute w-full opacity-20 z-[-1]">{children}</div>
+      )}
     </>
   );
 };

--- a/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
@@ -16,6 +16,25 @@ import { getEmojisInString } from "@sdk/emoji_data";
 import "./triangle.css";
 import { createPortal } from "react-dom";
 import { type EmojiMartData } from "components/pages/emoji-picker/types";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+
+const ChatInputBox = ({
+  children,
+  geoblocked,
+}: {
+  children: React.ReactNode;
+  geoblocked: boolean;
+}) => {
+  const { connected } = useWallet();
+  return (
+    <>
+      <ButtonWithConnectWalletFallback geoblocked={geoblocked} className="mt-[6px]">
+        {children}
+      </ButtonWithConnectWalletFallback>
+      {!connected && <div className="flex justify-center absolute w-full opacity-20 z-[-1]">{children}</div>}
+    </>
+  );
+};
 
 /**
  * The wrapper for the input box, depending on whether or not we're using this as a chat input
@@ -31,9 +50,7 @@ const ConditionalWrapper = ({
   geoblocked: boolean;
 }) => {
   return mode === "chat" ? (
-    <ButtonWithConnectWalletFallback geoblocked={geoblocked} className="mt-2">
-      {children}
-    </ButtonWithConnectWalletFallback>
+    <ChatInputBox geoblocked={geoblocked}>{children}</ChatInputBox>
   ) : (
     <>{children}</>
   );

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from "react";
 
 import { FlexGap } from "@containers";
-import { Text } from "components/text";
-
 import {
   Arrow,
   StyledMessageContainer,
@@ -10,7 +8,6 @@ import {
   StyledMessageWrapper,
   StyledUserNameWrapper,
 } from "./styled";
-
 import { type MessageContainerProps } from "./types";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 import { toExplorerLink } from "lib/utils/explorer-link";
@@ -66,14 +63,11 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
                 {...EXTERNAL_LINK_PROPS}
                 href={toExplorerLink({ value: message.version, linkType: "version" })}
               >
-                <Text textScale="pixelHeading4" color="lightGray" textTransform="uppercase">
+                <span className="pixel-heading-4 text-light-gray uppercase hover:underline">
                   {formatDisplayName(message.sender)}
-                </Text>
+                </span>
               </a>
-
-              <Text textScale="pixelHeading4" color="lightGray" textTransform="uppercase">
-                {message.senderRank}
-              </Text>
+              <span className="pixel-heading-4 text-light-gray uppercase">{message.senderRank}</span>
             </FlexGap>
           </StyledUserNameWrapper>
         </StyledMessageWrapper>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
@@ -67,7 +67,9 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
                   {formatDisplayName(message.sender)}
                 </span>
               </a>
-              <span className="pixel-heading-4 text-light-gray uppercase">{message.senderRank}</span>
+              <span className="pixel-heading-4 text-light-gray uppercase">
+                {message.senderRank}
+              </span>
             </FlexGap>
           </StyledUserNameWrapper>
         </StyledMessageWrapper>


### PR DESCRIPTION
# Description

- [x] Add a transparent input box if the user's wallet isn't connected
- [x] Convert some old components to using `tailwind` instead of `styled-components`

Before: <img width="337" alt="image" src="https://github.com/user-attachments/assets/e316449d-3609-45d4-a5fc-8748e613254f">

After: <img width="332" alt="image" src="https://github.com/user-attachments/assets/dd3c39cc-7d96-4695-9497-1164670b121e">

The chat box input looks a little off without a preview, since it's just at the bottom with no grid lines or anything. I've added a very transparent preview of the input box if the user's wallet isn't connected.

# Testing

Check the preview, plus manual testing!

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
