### PR TITLE
[ECO-2229] Fix the websocket client incoming event logic by using proper `immer` functionality

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -22,16 +22,14 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
   const setLatestBars = useEventStore((s) => s.setLatestBars);
 
   useEffect(() => {
-    if (props.data) {
-      const { chats, swaps, state, marketView } = props.data;
-      loadMarketStateFromServer([state]);
-      loadEventsFromServer([...chats, ...swaps]);
-      const latestBars = marketToLatestBars(marketView);
-      setLatestBars({ marketMetadata: state.market, latestBars });
-    }
+    const { chats, swaps, state, marketView } = props.data;
+    loadMarketStateFromServer([state]);
+    loadEventsFromServer([...chats, ...swaps]);
+    const latestBars = marketToLatestBars(marketView);
+    setLatestBars({ marketMetadata: state.market, latestBars });
 
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [props?.data]);
+  }, [props.data]);
 
   useReliableSubscribe({ eventTypes: EVENT_TYPES });
 

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/index.tsx
@@ -35,8 +35,7 @@ const ThWrapper = ({ className, children }: { className: string } & PropsWithChi
 );
 
 const TradeHistory = (props: TradeHistoryProps) => {
-  const swaps = useEventStore((s) => s.getMarket(props.data.symbolEmojis)?.swapEvents ?? []);
-
+  const swaps = useEventStore((s) => s.markets.get(props.data.symbol)?.swapEvents ?? []);
   const initialLoad = useRef(true);
   useEffect(() => {
     initialLoad.current = false;

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
@@ -27,6 +27,7 @@ export const LiveClientGrid = ({
   const getMarket = useEventStore((s) => s.getMarket);
   const getSearchEmojis = useEmojiPicker((s) => s.getEmojis);
   const stateFirehose = useEventStore((s) => s.stateFirehose);
+
   const latestOrdered = useRef(
     constructOrdered({
       markets,

--- a/src/typescript/frontend/src/context/ConnectToWebSockets.tsx
+++ b/src/typescript/frontend/src/context/ConnectToWebSockets.tsx
@@ -1,12 +1,10 @@
-import { useWebSocketClient } from "./event-store-context/hooks";
+import { useEventStore } from "./event-store-context/hooks";
 import { motion } from "framer-motion";
 import { hexToRgba } from "utils/hex-to-rgba";
 
 export const ConnectToWebSockets = () => {
-  const { connected, received } = useWebSocketClient((s) => ({
-    connected: s.connected,
-    received: s.received,
-  }));
+  const connected = useEventStore((s) => s.connected);
+  const received = useEventStore((s) => s.received);
 
   return (
     <>

--- a/src/typescript/frontend/src/context/event-store-context/StateStoreContextProviders.tsx
+++ b/src/typescript/frontend/src/context/event-store-context/StateStoreContextProviders.tsx
@@ -6,7 +6,7 @@ import { type NameStore, createNameStore } from "@/store/name-store";
 import createUserSettingsStore, { type UserSettingsStore } from "@/store/user-settings-store";
 import { createEventStore } from "@/store/event/event-store";
 import { type EventStore } from "@/store/event/types";
-import { createWebSocketClientStore, type WebSocketClientStore } from "@/store/websocket/store";
+import { type WebSocketClientStore } from "@/store/websocket/store";
 
 /**
  *
@@ -17,27 +17,28 @@ import { createWebSocketClientStore, type WebSocketClientStore } from "@/store/w
  */
 
 export const EventStoreContext = createContext<{
-  events: StoreApi<EventStore>;
+  events: StoreApi<EventStore & WebSocketClientStore>;
   names: StoreApi<NameStore>;
-  client: StoreApi<WebSocketClientStore>;
 } | null>(null);
 
 export interface EventStoreProviderProps {
   children: ReactNode;
 }
 
-const createStores = () => {
-  const events = createEventStore();
-  return {
-    events,
-    names: createNameStore(),
-    client: createWebSocketClientStore(events),
-  };
-};
-
 export const EventStoreProvider = ({ children }: EventStoreProviderProps) => {
-  const stores = useRef(createStores());
-  return <EventStoreContext.Provider value={stores.current}>{children}</EventStoreContext.Provider>;
+  const eventStore = useRef(createEventStore());
+  const nameStore = useRef(createNameStore());
+
+  return (
+    <EventStoreContext.Provider
+      value={{
+        events: eventStore.current,
+        names: nameStore.current,
+      }}
+    >
+      {children}
+    </EventStoreContext.Provider>
+  );
 };
 
 /**

--- a/src/typescript/frontend/src/context/event-store-context/hooks.tsx
+++ b/src/typescript/frontend/src/context/event-store-context/hooks.tsx
@@ -3,14 +3,14 @@ import { useStore } from "zustand";
 import type { NameStore } from "@/store/name-store";
 import { UserSettingsContext, EventStoreContext } from "./StateStoreContextProviders";
 import { type UserSettingsStore } from "@/store/user-settings-store";
-import { type WebSocketClientStore } from "@/store/websocket/store";
 import { type EventStore } from "@/store/event/types";
+import { type WebSocketClientStore } from "@/store/websocket/store";
 
-export const useEventStore = <T,>(selector: (store: EventStore) => T): T => {
+export const useEventStore = <T,>(selector: (store: EventStore & WebSocketClientStore) => T): T => {
   const eventStoreContext = useContext(EventStoreContext);
 
   if (eventStoreContext === null || eventStoreContext.events === null) {
-    throw new Error("useEventStore must be used within a WebSocketContextProvider");
+    throw new Error("useEventStore must be used within a EventStoreProvider");
   }
 
   return useStore(eventStoreContext.events, selector);
@@ -26,21 +26,11 @@ export const useNameStore = <T,>(selector: (store: NameStore) => T): T => {
   return useStore(nameStoreContext.names, selector);
 };
 
-export const useWebSocketClient = <T,>(selector: (store: WebSocketClientStore) => T): T => {
-  const eventStoreContext = useContext(EventStoreContext);
-
-  if (eventStoreContext === null || eventStoreContext.client === null) {
-    throw new Error("useWebSocketStore must be used within a WebSocketContextProvider");
-  }
-
-  return useStore(eventStoreContext.client, selector);
-};
-
 export const useUserSettings = <T,>(selector: (store: UserSettingsStore) => T): T => {
   const userSettingsContext = useContext(UserSettingsContext);
 
   if (userSettingsContext === null) {
-    throw new Error("useWebSocketStore must be used within a UserSettingsProvider");
+    throw new Error("useUserSettings must be used within a UserSettingsProvider");
   }
 
   return useStore(userSettingsContext, selector);

--- a/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
+++ b/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
@@ -1,5 +1,5 @@
 import { type BrokerEvent } from "@/broker/types";
-import { useWebSocketClient } from "context/event-store-context";
+import { useEventStore } from "context/event-store-context/hooks";
 import { useEffect } from "react";
 
 export type ReliableSubscribeArgs = {
@@ -13,8 +13,8 @@ export type ReliableSubscribeArgs = {
  */
 export const useReliableSubscribe = (args: ReliableSubscribeArgs) => {
   const { eventTypes } = args;
-  const subscribeEvents = useWebSocketClient((s) => s.subscribeEvents);
-  const unsubscribeEvents = useWebSocketClient((s) => s.unsubscribeEvents);
+  const subscribeEvents = useEventStore((s) => s.subscribeEvents);
+  const unsubscribeEvents = useEventStore((s) => s.unsubscribeEvents);
 
   useEffect(() => {
     // Don't subscribe right away, to let other components unmounting time to unsubscribe, that way

--- a/src/typescript/frontend/src/lib/store/event/event-store.ts
+++ b/src/typescript/frontend/src/lib/store/event/event-store.ts
@@ -1,7 +1,7 @@
 import {
   type AnyEventModel,
+  type EventModelWithMarket,
   isChatEventModel,
-  isEventModelWithMarket,
   isGlobalStateEventModel,
   isLiquidityEventModel,
   isMarketLatestStateEventModel,
@@ -17,13 +17,16 @@ import {
   handleLatestBarForPeriodicStateEvent,
   handleLatestBarForSwapEvent,
   pushPeriodicStateEvents,
+  toMappedMarketEvents,
 } from "./utils";
 import { addToLocalStorage, initialStateFromLocalStorage } from "./local-storage";
 import { periodEnumToRawDuration } from "@sdk/const";
 import { joinEmojis } from "@sdk/emoji_data";
+import { createWebSocketClientStore, type WebSocketClientStore } from "../websocket/store";
+import { DEBUG_ASSERT, extractFilter } from "@sdk/utils";
 
 export const createEventStore = () => {
-  return createStore<EventStore>()(
+  return createStore<EventStore & WebSocketClientStore>()(
     immer((set, get) => ({
       ...initialStateFromLocalStorage(),
       getMarket: (m) => get().markets.get(joinEmojis(m)),
@@ -31,23 +34,22 @@ export const createEventStore = () => {
         return get().markets;
       },
       loadMarketStateFromServer: (states) => {
-        const guids = get().guids;
         const filtered = states.filter((e) => {
           const marketEmojis = e.market.symbolEmojis;
           const symbol = joinEmojis(marketEmojis);
           const market = get().markets.get(symbol);
           // Filter by daily volume being undefined *or* the guid not already existing in `guids`.
-          return !market || typeof market.dailyVolume === "undefined" || !guids.has(symbol);
+          return !market || typeof market.dailyVolume === "undefined" || !get().guids.has(symbol);
         });
         filtered.forEach(addToLocalStorage);
         set((state) => {
-          state.guids = state.guids.union(new Set(...filtered.map((e) => e.guid)));
+          filtered.map(({ guid }) => state.guids.add(guid));
           state.stateFirehose.push(...filtered);
-          filtered.forEach(({ market: marketMetadata }) => {
-            const symbol = marketMetadata.symbolData.symbol;
-            ensureMarketInStore(state, marketMetadata);
-            const market = state.markets.get(symbol)!;
-            market.stateEvents.push(...filtered);
+          const map = toMappedMarketEvents(filtered);
+          Array.from(map.entries()).forEach(([marketSymbol, marketEvents]) => {
+            ensureMarketInStore(state, marketEvents[0].market);
+            const market = state.markets.get(marketSymbol)!;
+            marketEvents.forEach((event) => market.stateEvents.push(event));
           });
         });
       },
@@ -55,23 +57,27 @@ export const createEventStore = () => {
         const guids = get().guids;
         const events = eventsIn.filter((e) => !guids.has(e.guid));
         if (!events.length) return;
-        events.forEach(addToLocalStorage);
+        // Note the behavior of `extractFilter` below:
+        // It drains and returns the input array of the type filtered on in the filter function.
+        // The input array thus gets smaller each time `extractFilter` finds any matching events.
         set((state) => {
-          state.guids = state.guids.union(new Set(...events.map((e) => e.guid)));
+          events.map(({ guid }) => state.guids.add(guid));
           state.stateFirehose.push(...events.filter(isMarketLatestStateEventModel));
-          state.globalStateEvents.push(...events.filter(isGlobalStateEventModel));
-          state.marketRegistrations.push(...events.filter(isMarketRegistrationEventModel));
-          const uniqueMarkets = new Set([...events.filter(isEventModelWithMarket)]);
-          uniqueMarkets.forEach(({ market: marketMetadata }) => {
-            const symbol = marketMetadata.symbolData.symbol;
-            ensureMarketInStore(state, marketMetadata);
-            const market = state.markets.get(symbol)!;
-            market.swapEvents.push(...events.filter(isSwapEventModel));
-            market.chatEvents.push(...events.filter(isChatEventModel));
-            market.liquidityEvents.push(...events.filter(isLiquidityEventModel));
-            market.stateEvents.push(...events.filter(isMarketLatestStateEventModel));
-            pushPeriodicStateEvents(market, events.filter(isPeriodicStateEventModel));
+          state.globalStateEvents.push(...extractFilter(events, isGlobalStateEventModel));
+          state.marketRegistrations.push(...extractFilter(events, isMarketRegistrationEventModel));
+          DEBUG_ASSERT(() => !events.some(isGlobalStateEventModel));
+          const map = toMappedMarketEvents(events as Array<EventModelWithMarket>);
+          Array.from(map.entries()).forEach(([marketSymbol, marketEvents]) => {
+            ensureMarketInStore(state, marketEvents[0].market);
+            const market = state.markets.get(marketSymbol)!;
+            market.swapEvents.push(...extractFilter(marketEvents, isSwapEventModel));
+            market.chatEvents.push(...extractFilter(marketEvents, isChatEventModel));
+            market.liquidityEvents.push(...extractFilter(marketEvents, isLiquidityEventModel));
+            market.stateEvents.push(...extractFilter(marketEvents, isMarketLatestStateEventModel));
+            pushPeriodicStateEvents(market, extractFilter(marketEvents, isPeriodicStateEventModel));
+            DEBUG_ASSERT(() => marketEvents.length === 0);
           });
+          events.forEach(addToLocalStorage);
         });
       },
       pushEventFromClient: (event: AnyEventModel) => {
@@ -131,6 +137,7 @@ export const createEventStore = () => {
           market[period].callback = undefined;
         });
       },
+      ...createWebSocketClientStore(set, get),
     }))
   );
 };

--- a/src/typescript/frontend/src/lib/store/event/event-store.ts
+++ b/src/typescript/frontend/src/lib/store/event/event-store.ts
@@ -41,7 +41,6 @@ export const createEventStore = () => {
           // Filter by daily volume being undefined *or* the guid not already existing in `guids`.
           return !market || typeof market.dailyVolume === "undefined" || !get().guids.has(symbol);
         });
-        filtered.forEach(addToLocalStorage);
         set((state) => {
           filtered.map(({ guid }) => state.guids.add(guid));
           state.stateFirehose.push(...filtered);
@@ -52,6 +51,7 @@ export const createEventStore = () => {
             marketEvents.forEach((event) => market.stateEvents.push(event));
           });
         });
+        filtered.forEach(addToLocalStorage);
       },
       loadEventsFromServer: (eventsIn: Array<AnyEventModel>) => {
         const guids = get().guids;

--- a/src/typescript/frontend/src/lib/store/event/types.ts
+++ b/src/typescript/frontend/src/lib/store/event/types.ts
@@ -7,6 +7,8 @@ import {
 } from "@sdk/indexer-v2/types";
 import { type SubscribeBarsCallback } from "@static/charting_library/datafeed-api";
 import { type LatestBar } from "./candlestick-bars";
+import { type WritableDraft } from "immer";
+import { type ClientState, type ClientActions } from "../websocket/store";
 
 // Aliased to avoid repeating the type names over and over.
 type Swap = DatabaseModels["swap_events"];
@@ -73,3 +75,15 @@ export type EventActions = {
 };
 
 export type EventStore = EventState & EventActions;
+
+export type EventAndClientStore = EventState & EventActions & ClientState & ClientActions;
+
+export type ImmerSetEventAndClientStore = (
+  nextStateOrUpdater:
+    | EventAndClientStore
+    | Partial<EventAndClientStore>
+    | ((state: WritableDraft<EventAndClientStore>) => void),
+  shouldReplace?: boolean | undefined
+) => void;
+
+export type ImmerGetEventAndClientStore = () => EventAndClientStore;

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -7,6 +7,7 @@ import {
   type PeriodicStateEventModel,
   type SwapEventModel,
   type DatabaseModels,
+  type EventModelWithMarket,
 } from "@sdk/indexer-v2/types";
 import { getPeriodStartTimeFromTime } from "@sdk/utils";
 import { createBarFromPeriodicState, createBarFromSwap, type LatestBar } from "./candlestick-bars";
@@ -153,4 +154,11 @@ export const callbackClonedLatestBarIfSubscribed = (
       volume: latestBar.volume,
     });
   }
+};
+
+export const toMappedMarketEvents = <T extends EventModelWithMarket>(events: Array<T>) => {
+  const uniques = new Set(events.map(({ market }) => market.symbolData.symbol));
+  const map = new Map(Array.from(uniques).map((symbol) => [symbol, [] as Array<T>]));
+  events.forEach((event) => map.get(event.market.symbolData.symbol)!.push(event));
+  return map;
 };

--- a/src/typescript/frontend/src/lib/store/server-to-client/StoreOnClient.tsx
+++ b/src/typescript/frontend/src/lib/store/server-to-client/StoreOnClient.tsx
@@ -4,7 +4,7 @@ import { useWallet, type WalletName } from "@aptos-labs/wallet-adapter-react";
 
 import { ONE_APT } from "@sdk/const";
 import { CloseIconWithHover } from "components/svg";
-import { useEventStore, useWebSocketClient } from "context/event-store-context";
+import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -13,7 +13,7 @@ export const StoreOnClient = () => {
   const { account, connect, connected, wallet } = useWallet();
   const { aptos, forceRefetch } = useAptos();
   const storeMarkets = useEventStore((s) => s.markets);
-  const subscriptions = useWebSocketClient((s) => s.subscriptions);
+  const subscriptions = useEventStore((s) => s.subscriptions);
   const pathname = usePathname();
   const [showDebugger, setShowDebugger] = useState(false);
   const registeredMarkets = useEventStore((s) => s.markets);

--- a/src/typescript/frontend/src/lib/store/websocket/store.ts
+++ b/src/typescript/frontend/src/lib/store/websocket/store.ts
@@ -1,14 +1,18 @@
+// cspell:word immerable
 "use client";
 
-import { createStore, type StoreApi } from "zustand/vanilla";
 import { BROKER_URL } from "lib/env";
-import { type EventStore } from "@/store/event/types";
 import {
-  getSingletonClient,
-  type WebSocketClient,
+  type ImmerGetEventAndClientStore,
+  type ImmerSetEventAndClientStore,
+} from "@/store/event/types";
+import {
+  WebSocketClient,
+  type WebSocketClientArgs,
   type WebSocketSubscriptions,
 } from "@/broker/client";
 import { type BrokerEvent } from "@/broker/types";
+import { immerable } from "immer";
 
 export type ClientState = {
   client: WebSocketClient;
@@ -27,47 +31,69 @@ export type WebSocketClientStore = ClientState & ClientActions;
 
 const PERMANENTLY_SUBSCRIBE_REGISTRATIONS = true;
 
-export const createWebSocketClientStore = (eventStore: StoreApi<EventStore>) => {
-  return createStore<WebSocketClientStore>((set, get) => ({
-    subscriptions: {
-      marketIDs: new Set(),
-      eventTypes: new Set(),
-    },
-    received: 0,
-    client: getSingletonClient({
-      url: BROKER_URL,
-      listeners: {
-        onMessage: (e) => {
-          // eventStore.getState().pushEventFromClient(e);
-          eventStore.setState((state) => {
-            state.pushEventFromClient(e);
-            return state;
-          });
-          set((state) => ({
-            received: state.received + 1,
-          }));
-        },
-        onConnect: () => set({ connected: true }),
-        onClose: () => set({ connected: false }),
-        onError: (e) => console.error(e),
-      },
-      permanentlySubscribeToMarketRegistrations: PERMANENTLY_SUBSCRIBE_REGISTRATIONS,
-    }),
-    connected: false as boolean,
-    close: () => {
-      get().client.client.close();
-    },
-    subscribeEvents: (e) => {
-      set((state) => {
-        state.client.subscribeEvents(e);
-        return { subscriptions: state.client.subscriptions };
-      });
-    },
-    unsubscribeEvents: (e) => {
-      set((state) => {
-        state.client.unsubscribeEvents(e);
-        return { subscriptions: state.client.subscriptions };
-      });
-    },
-  }));
+export class ImmerableWebSocketClient extends WebSocketClient {
+  [immerable] = true;
+
+  constructor(args: WebSocketClientArgs) {
+    super(args);
+  }
+}
+
+let singletonClient: ImmerableWebSocketClient;
+
+export const getSingletonClient = (args: WebSocketClientArgs) => {
+  if (!singletonClient) {
+    singletonClient = new ImmerableWebSocketClient(args);
+  }
+  return singletonClient;
 };
+
+export const createWebSocketClientStore = (
+  set: ImmerSetEventAndClientStore,
+  get: ImmerGetEventAndClientStore
+): WebSocketClientStore => ({
+  subscriptions: {
+    marketIDs: new Set(),
+    eventTypes: new Set(),
+  },
+  received: 0,
+  client: getSingletonClient({
+    url: BROKER_URL,
+    listeners: {
+      onMessage: (e) => {
+        set((state) => {
+          state.received += 1;
+        });
+        get().pushEventFromClient(e);
+      },
+      onConnect: () => {
+        set((state) => {
+          state.connected = true;
+        });
+      },
+      onClose: () => {
+        set((state) => {
+          state.connected = false;
+        });
+      },
+      onError: (e) => console.error(e),
+    },
+    permanentlySubscribeToMarketRegistrations: PERMANENTLY_SUBSCRIBE_REGISTRATIONS,
+  }),
+  connected: false as boolean,
+  close: () => {
+    get().client.client.close();
+  },
+  subscribeEvents: (e) => {
+    set((state) => {
+      state.client.subscribeEvents(e);
+      state.subscriptions = state.client.subscriptions;
+    });
+  },
+  unsubscribeEvents: (e) => {
+    set((state) => {
+      state.client.unsubscribeEvents(e);
+      state.subscriptions = state.client.subscriptions;
+    });
+  },
+});

--- a/src/typescript/frontend/src/utils/index.ts
+++ b/src/typescript/frontend/src/utils/index.ts
@@ -13,10 +13,10 @@ export { getEmptyListTr } from "./get-empty-list-tr";
 export const stringifyJSON = (data: object) =>
   JSON.stringify(data, (_, value) => (typeof value === "bigint" ? value.toString() + "n" : value));
 
-export const parseJSON = (json: string) =>
+export const parseJSON = <T>(json: string): T =>
   JSON.parse(json, (_, value) => {
     if (typeof value === "string" && /^\d+n$/.test(value)) {
       return BigInt(value.substring(0, value.length - 1));
     }
-    return value;
+    return value as T;
   });

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -35,6 +35,7 @@
     "test": "pnpm run load-env -- dotenv -e ci.env -e ../docker/example.local.env -e ../docker/.env -- turbo run test --no-cache --force",
     "test:debug": "dotenv -v FETCH_DEBUG=true -- pnpm run test",
     "test:verbose": "pnpm run load-env -- dotenv -e ci.env -e ../docker/example.local.env -e ../docker/.env -v VERBOSE_TEST_LOGS=true -- turbo run test:verbose --force",
+    "unit-test": "pnpm run load-env -- turbo run unit-test",
     "up": "docker compose -f ../docker/compose.local.yaml up -d"
   },
   "version": "0.0.0",

--- a/src/typescript/sdk/src/broker-v2/client.ts
+++ b/src/typescript/sdk/src/broker-v2/client.ts
@@ -44,20 +44,11 @@ type WebSocketClientEventListeners = {
   onError?: (e: Event) => void;
 };
 
-type WebSocketClientArgs = {
+/* eslint-disable-next-line import/no-unused-modules */
+export type WebSocketClientArgs = {
   url: string | URL;
   listeners: WebSocketClientEventListeners;
   permanentlySubscribeToMarketRegistrations: boolean;
-};
-
-let singletonClient: WebSocketClient;
-
-/* eslint-disable-next-line import/no-unused-modules */
-export const getSingletonClient = (args: WebSocketClientArgs) => {
-  if (!singletonClient) {
-    singletonClient = new WebSocketClient(args);
-  }
-  return singletonClient;
 };
 
 /* eslint-disable-next-line import/no-unused-modules */

--- a/src/typescript/sdk/src/utils/misc.ts
+++ b/src/typescript/sdk/src/utils/misc.ts
@@ -1,5 +1,6 @@
 import { AccountAddress, type HexInput } from "@aptos-labs/ts-sdk";
 import Big from "big.js";
+import assert from "assert";
 import {
   type PeriodDuration,
   type Period,
@@ -284,3 +285,49 @@ export function zip<T>(a: T[], b: T[]): Array<[T, T]> {
   }
   return Array.from({ length: a.length }).map((_, i) => [a[i], b[i]]);
 }
+
+/**
+ * Extracts elements from an array based on a type predicate and a type guard filter function.
+ *
+ * This function mutates the original array, removing elements that match
+ * the filter and returning them in a new array. It effectively splits
+ * the input array into two based on the filter condition, returning the second array.
+ *
+ * @param arr - The input array to filter and extract from.
+ * @param filter - A type predicate function to determine which elements to extract.
+ * @returns A new array containing all elements that passed the filter, in their original order.
+ *
+ * @example
+ * const numbers = [1, 2, 3, 4, 5, 6];
+ * const isEven = (n: number): n is number => n % 2 === 0;
+ * const evenNumbers = extractFilter(numbers, isEven);
+ * console.log(evenNumbers); // [2, 4, 6]
+ * console.log(numbers); // [1, 3, 5]
+ */
+/* eslint-disable-next-line import/no-unused-modules */
+export const extractFilter = <T, U extends T>(
+  arr: Array<T>,
+  filter: (v: T) => v is U
+): Array<U> => {
+  const res1 = new Array<T>();
+  const res2 = new Array<U>();
+  while (arr.length) {
+    const val = arr.pop()!;
+    if (filter(val)) {
+      res2.push(val);
+    } else {
+      res1.push(val);
+    }
+  }
+  while (res1.length) {
+    const val = res1.pop()!;
+    arr.push(val);
+  }
+  return res2.reverse();
+};
+
+export const DEBUG_ASSERT = (fn: () => boolean) => {
+  if (process.env.NODE_ENV === "development") {
+    assert(fn());
+  }
+};

--- a/src/typescript/sdk/tests/unit/filter-extract.test.ts
+++ b/src/typescript/sdk/tests/unit/filter-extract.test.ts
@@ -1,0 +1,134 @@
+import { extractFilter } from "../../src/utils";
+
+describe("tests the extractFilter function", () => {
+  it("tests basic input", () => {
+    type Even = number;
+    const isEven = (n: number): n is Even => n % 2 === 0;
+    const input = [1, 2, 3, 4, 5, 6];
+    const evens = extractFilter(input, isEven);
+    expect(input).toEqual([1, 3, 5]);
+    expect(evens).toEqual([2, 4, 6]);
+  });
+
+  it("tests more complex input", () => {
+    type StuckInTheMiddle = `${string}stuck${string}`;
+    const isStuckInTheMiddle = (str: string): str is StuckInTheMiddle =>
+      !!str.match(/^.+stuck.+$/)?.at(0);
+    const input = [
+      ".stuck.",
+      "stuck.",
+      ".stuck",
+      "1stuck1",
+      "1stuck2",
+      "2stuck1",
+      "1stuck1",
+      "1stuck",
+    ];
+    const stuck = extractFilter(input, isStuckInTheMiddle);
+    expect(input).toEqual(["stuck.", ".stuck", "1stuck"]);
+    expect(stuck).toEqual([".stuck.", "1stuck1", "1stuck2", "2stuck1", "1stuck1"]);
+  });
+
+  it("handles an empty array", () => {
+    const input: number[] = [];
+    const result = extractFilter(input, (n): n is number => n > 0);
+    expect(input).toEqual([]);
+    expect(result).toEqual([]);
+  });
+
+  it("handles an array where all elements match the filter", () => {
+    const input = [2, 4, 6, 8, 10];
+    const result = extractFilter(input, (n): n is number => n % 2 === 0);
+    expect(input).toEqual([]);
+    expect(result).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it("handles an array where no elements match the filter", () => {
+    const input = [1, 3, 5, 7, 9];
+    const result = extractFilter(input, (n): n is number => n % 2 === 0);
+    expect(input).toEqual([1, 3, 5, 7, 9]);
+    expect(result).toEqual([]);
+  });
+
+  it("works with objects and preserves reference equality", () => {
+    type Person = { name: string; age: number };
+    const isAdult = (p: Person): p is Person & { age: number } => p.age >= 18;
+
+    const person1 = { name: "Alice", age: 25 };
+    const person2 = { name: "Bob", age: 17 };
+    const person3 = { name: "Charlie", age: 30 };
+
+    const input = [person1, person2, person3];
+    const adults = extractFilter(input, isAdult);
+
+    expect(input).toEqual([{ name: "Bob", age: 17 }]);
+    expect(adults).toEqual([
+      { name: "Alice", age: 25 },
+      { name: "Charlie", age: 30 },
+    ]);
+
+    expect(adults[0]).toBe(person1);
+    expect(adults[1]).toBe(person3);
+  });
+
+  it("handles large arrays", () => {
+    const largeArray = Array.from({ length: 100000000 }, (_, i) => i);
+    const isEven = (n: number): n is number => n % 2 === 0;
+    const evens = extractFilter(largeArray, isEven);
+    expect(largeArray.length).toBe(50000000);
+    expect(evens.length).toBe(50000000);
+    expect(largeArray[0]).toBe(1);
+    expect(evens[0]).toBe(0);
+    expect(largeArray.at(-1)).toEqual(100000000 - 1);
+    expect(evens.at(-1)).toEqual(100000000 - 2);
+  });
+
+  it("correctly handles first and last elements", () => {
+    const input = [1, 2, 3, 4, 5];
+    const isOdd = (n: number): n is number => n % 2 !== 0;
+    const result = extractFilter(input, isOdd);
+
+    expect(input).toEqual([2, 4]);
+    expect(result).toEqual([1, 3, 5]);
+    expect(input[0]).toBe(2); // First element of remaining array.
+    expect(result[0]).toBe(1); // First element of extracted array.
+    expect(input[input.length - 1]).toBe(4); // Last element of remaining array.
+    expect(result[result.length - 1]).toBe(5); // Last element of extracted array.
+  });
+
+  it("correctly handles array with only one element", () => {
+    const input = [42];
+    const isEven = (n: number): n is number => n % 2 === 0;
+    const result = extractFilter(input, isEven);
+
+    expect(input).toEqual([]);
+    expect(result).toEqual([42]);
+  });
+
+  it("correctly handles array where only first and last elements match filter", () => {
+    const input = [1, 2, 3, 4, 5];
+    const isOdd = (n: number): n is number => n % 2 !== 0;
+    const result = extractFilter(input, (n) => isOdd(n) && (n === 1 || n === 5));
+
+    expect(input).toEqual([2, 3, 4]);
+    expect(result).toEqual([1, 5]);
+  });
+
+  it("maintains correct order when all elements match filter", () => {
+    const input = [1, 3, 5, 7, 9];
+    const isOdd = (n: number): n is number => n % 2 !== 0;
+    const result = extractFilter(input, isOdd);
+
+    expect(input).toEqual([]);
+    expect(result).toEqual([1, 3, 5, 7, 9]);
+  });
+
+  it("maintains correct order when no elements match filter", () => {
+    const input = [2, 4, 6, 8, 10];
+    const isOdd = (n: number): n is number => n % 2 !== 0;
+    const result = extractFilter(input, isOdd);
+
+    expect(input).toEqual([2, 4, 6, 8, 10]);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/typescript/turbo.json
+++ b/src/typescript/turbo.json
@@ -64,6 +64,9 @@
     },
     "test:verbose": {
       "outputs": []
+    },
+    "unit-test": {
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
# Description

- [x] Fix the WebSocket client incoming event logic by using proper `immer `functions
- [x] Add unit test/function for extract filter function to simplify pushing aggregate events logic
- [x] Combine `WebSocketClientStore `into `EventStore`

# Testing

Manual testing, although some simple unit tests were added for function logic.

Ideally we'd add unit tests for this, but for now we just want to get it working. It's possibly within the scope of this PR to add unit tests for this- it would definitely be nice to have.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
