### PR TITLE
[ECO-2241] Attempt to fix wallet adapter issues with a version bump and config update

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -12,8 +12,9 @@
     ]
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "1.22.2",
-    "@aptos-labs/wallet-adapter-react": "3.4.3",
+    "@aptos-labs/ts-sdk": "1.27.1",
+    "@aptos-labs/wallet-adapter-core": "^4.17.0",
+    "@aptos-labs/wallet-adapter-react": "3.7.0",
     "@econia-labs/emojicoin-sdk": "workspace:*",
     "@emoji-mart/data": "https://github.com/econia-labs/emoji-mart/raw/emojicoin-dot-fun/packages/emoji-mart-data/emoji-mart-data-v1.2.1.tgz",
     "@emoji-mart/react": "https://github.com/econia-labs/emoji-mart/raw/emojicoin-dot-fun/packages/emoji-mart-react/emoji-mart-react-v1.1.1.tgz",
@@ -40,7 +41,6 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.400.0",
     "next": "^14.2.4",
-    "petra-plugin-wallet-adapter": "^0.4.5",
     "react": "^18.3.1",
     "react-confetti": "^6.1.0",
     "react-device-detect": "^2.2.3",

--- a/src/typescript/frontend/src/components/pages/verify/session-info.ts
+++ b/src/typescript/frontend/src/components/pages/verify/session-info.ts
@@ -1,7 +1,6 @@
 // cspell:word emojicoindotfun
 
-import { UNIT_OF_TIME_MULTIPLIERS, UnitOfTime } from "@sdk/utils/misc";
-
+// One week.
+export const COOKIE_LENGTH = 1000 * 60 * 60 * 24 * 7;
 export const COOKIE_FOR_HASHED_ADDRESS = "emojicoindotfun-account-hashed-address";
 export const COOKIE_FOR_ACCOUNT_ADDRESS = "emojicoindotfun-account-address";
-export const COOKIE_LENGTH = UNIT_OF_TIME_MULTIPLIERS[UnitOfTime.Weeks] * 1;

--- a/src/typescript/frontend/src/components/pages/verify/verify.ts
+++ b/src/typescript/frontend/src/components/pages/verify/verify.ts
@@ -1,9 +1,15 @@
 "use server";
 import { sha3_256 } from "@noble/hashes/sha3";
 import { normalizeHex } from "@sdk/utils";
-import { HASH_SEED } from "lib/server-env";
 
 export const hashAddress = async (address: string) => {
+  // Ensure the HASH_SEED is valid, since we don't import it.
+  if (!process.env.HASH_SEED || process.env.HASH_SEED.length < 8) {
+    throw new Error("Environment variable HASH_SEED must be set and at least 8 characters.");
+  }
+  const HASH_SEED = process.env.HASH_SEED;
+  // Use `process.env.HASH_SEED` here to avoid polluting the namespace with @aptos-labs/ts-sdk`
+  // imports that import functions that aren't supported in the Edge Runtime middleware.
   const buffer = Buffer.from(`${address}::${HASH_SEED}`, "utf-8");
   const hash = sha3_256(new Uint8Array(buffer));
   return normalizeHex(hash);

--- a/src/typescript/frontend/src/context/providers.tsx
+++ b/src/typescript/frontend/src/context/providers.tsx
@@ -41,18 +41,7 @@ const ThemedApp: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = 
 
   const isMobileMenuOpen = isOpen && !isDesktop;
 
-  const wallets = useMemo(
-    () => [
-      new PontemWallet(),
-      new RiseWallet(),
-      new MartianWallet(),
-      // new AptosConnectWalletPlugin({ network: APTOS_NETWORK }),
-    ],
-    []
-  );
-  // TODO: Make fetch queries here and pass the data to the event store..?
-  // It's possible we can also pass a promise down from the server components
-  // to the clients and then add those to the store as they stream in.
+  const wallets = useMemo(() => [new PontemWallet(), new RiseWallet(), new MartianWallet()], []);
 
   const queryClient = new QueryClient();
 
@@ -63,8 +52,7 @@ const ThemedApp: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = 
           <UserSettingsProvider>
             <AptosWalletAdapterProvider
               plugins={wallets}
-              autoConnect={true}
-              optInWallets={["Petra"]}
+              autoConnect={false}
               dappConfig={{ network: APTOS_NETWORK }}
             >
               <WalletModalContextProvider>

--- a/src/typescript/frontend/src/lib/server-env.ts
+++ b/src/typescript/frontend/src/lib/server-env.ts
@@ -7,8 +7,10 @@ if (typeof process.env.REVALIDATION_TIME === "undefined") {
   if (process.env.NODE) throw new Error("Environment variable REVALIDATION_TIME is undefined.");
 }
 
-if (typeof process.env.HASH_SEED === "undefined") {
-  throw new Error("Environment variable HASH_SEED is undefined.");
+// We don't export `HASH_SEED` here since it would pollute the Edge Runtime namespace with
+// incompatible node.js functions. Instead, just verify that it is valid.
+if (!process.env.HASH_SEED || process.env.HASH_SEED.length < 8) {
+  throw new Error("Environment variable HASH_SEED must be set and at least 8 characters.");
 }
 
 if (
@@ -39,7 +41,6 @@ if (GEOBLOCKING_ENABLED) {
 export const ALLOWLISTER3K_URL: string | undefined = process.env.ALLOWLISTER3K_URL;
 export const GALXE_CAMPAIGN_ID: string | undefined = process.env.GALXE_CAMPAIGN_ID;
 export const REVALIDATION_TIME: number = Number(process.env.REVALIDATION_TIME);
-export const HASH_SEED: string = process.env.HASH_SEED;
 export const VPNAPI_IO_API_KEY: string = process.env.VPNAPI_IO_API_KEY!;
 
 if (APTOS_NETWORK === Network.LOCAL && !EMOJICOIN_INDEXER_URL.includes("localhost")) {

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@aptos-labs/ts-sdk": "1.22.2",
     "@types/node": "^20.14.9"
   },
   "devDependencies": {

--- a/src/typescript/pnpm-lock.yaml
+++ b/src/typescript/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
 
   .:
     dependencies:
-      '@aptos-labs/ts-sdk':
-        specifier: 1.22.2
-        version: 1.22.2
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.10
@@ -351,10 +348,6 @@ packages:
       '@aptos-labs/wallet-standard': ^0.1.0
       aptos: ^1.20.0
 
-  '@aptos-labs/aptos-cli@0.1.9':
-    resolution: {integrity: sha512-76uPNZ6JrpruN9H8bEU37GVhAHwdhmvp7ZXpMTFnlFOJnBYt0LHCxR3x+HCk4WZ1CRrPQ57lmO+5A58PiGuweA==}
-    hasBin: true
-
   '@aptos-labs/aptos-cli@0.2.0':
     resolution: {integrity: sha512-6kljJFRsTLXCvgkNhBoOLhVyo7rmih+8+XAtdeciIXkZYwzwVS3TFPLMqBUO2HcY6gYtQQRmTG52R5ihyi/bXA==}
     hasBin: true
@@ -366,10 +359,6 @@ packages:
   '@aptos-labs/aptos-client@0.1.1':
     resolution: {integrity: sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==}
     engines: {node: '>=15.10.0'}
-
-  '@aptos-labs/ts-sdk@1.22.2':
-    resolution: {integrity: sha512-EUGFT6Emyrc8xqBxZB7fO6Xha98+Q3WWJNw56IOVbiMYaga5w7Dzj8rTYYHxvxyBfEbnNQHn4QcQfaciU2N4qA==}
-    engines: {node: '>=11.0.0'}
 
   '@aptos-labs/ts-sdk@1.27.1':
     resolution: {integrity: sha512-QS4BlivXQy/uJgXcNOfXNjv8l+MSd+qQ256mY/Jc6iaWbfn69nRYh6chjSyLot4fHA49QxlZlWh1mJLlfNdtow==}
@@ -4796,8 +4785,6 @@ snapshots:
       aptos: 1.21.0
       uuid: 9.0.1
 
-  '@aptos-labs/aptos-cli@0.1.9': {}
-
   '@aptos-labs/aptos-cli@0.2.0': {}
 
   '@aptos-labs/aptos-client@0.1.0':
@@ -4811,22 +4798,6 @@ snapshots:
     dependencies:
       axios: 1.7.4
       got: 11.8.6
-    transitivePeerDependencies:
-      - debug
-
-  '@aptos-labs/ts-sdk@1.22.2':
-    dependencies:
-      '@aptos-labs/aptos-cli': 0.1.9
-      '@aptos-labs/aptos-client': 0.1.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.3.0
-      eventemitter3: 5.0.1
-      form-data: 4.0.0
-      js-base64: 3.7.7
-      jwt-decode: 4.0.0
-      poseidon-lite: 0.2.0
     transitivePeerDependencies:
       - debug
 

--- a/src/typescript/pnpm-lock.yaml
+++ b/src/typescript/pnpm-lock.yaml
@@ -34,11 +34,14 @@ importers:
   frontend:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: 1.22.2
-        version: 1.22.2
+        specifier: 1.27.1
+        version: 1.27.1
+      '@aptos-labs/wallet-adapter-core':
+        specifier: ^4.17.0
+        version: 4.17.0(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.3.2(@aptos-labs/ts-sdk@1.27.1)(graphql-request@7.1.0(graphql@16.9.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
       '@aptos-labs/wallet-adapter-react':
-        specifier: 3.4.3
-        version: 3.4.3(@aptos-labs/ts-sdk@1.22.2)(@types/react@18.3.3)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.3.1)
+        specifier: 3.7.0
+        version: 3.7.0(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.3.2(@aptos-labs/ts-sdk@1.27.1)(graphql-request@7.1.0(graphql@16.9.0)))(@mizuwallet-sdk/protocol@0.0.1)(@types/react@18.3.3)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.3.1)
       '@econia-labs/emojicoin-sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -117,9 +120,6 @@ importers:
       next:
         specifier: ^14.2.4
         version: 14.2.4(@playwright/test@1.45.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      petra-plugin-wallet-adapter:
-        specifier: ^0.4.5
-        version: 0.4.5(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -227,8 +227,8 @@ importers:
   sdk:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: 1.22.2
-        version: 1.22.2
+        specifier: 1.27.1
+        version: 1.27.1
       '@keyvhq/core':
         specifier: ^2.1.1
         version: 2.1.1
@@ -331,17 +331,16 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@aptos-connect/wallet-adapter-plugin@1.0.1':
-    resolution: {integrity: sha512-yrnzO9gWMPqhgV0hz3Qv9XP98hefX/V7Pcj911SLM3NWktc+mL/5CW6BKz4VKcqnhewotd2Tek43VDZTSHKoeQ==}
+  '@aptos-connect/wallet-adapter-plugin@2.0.2':
+    resolution: {integrity: sha512-Gcftitx8UeqGBo2c7DvfDVMPMaSCDLfi/ffFLh3qf9Gd7J2wyi8Nx7x/Dxvjq9r5eTX4Iy6JoiQlA9+uuLRhwg==}
     peerDependencies:
-      '@aptos-labs/ts-sdk': 1.18.1
-      '@aptos-labs/wallet-standard': ^0.1.0
-      aptos: ^1.21.0
+      '@aptos-labs/ts-sdk': 1.26.0
+      '@aptos-labs/wallet-standard': 0.2.0
 
-  '@aptos-connect/wallet-api@0.1.1':
-    resolution: {integrity: sha512-If666Wz7m+ZK/RzDhm5Wy3oDkhnv14wKHW0jEVtXtHwTzYEgaOdC92RhZHqzPAqysipKSatBJJNVk58PzJLAUQ==}
+  '@aptos-connect/wallet-api@0.1.3':
+    resolution: {integrity: sha512-AJhKAdbUXL5dIaO49DWH8QVGWVNEBpTzObgjXLK1Sx4zRlesiW9PP/V73naPgxyCFt2xWolqIauzogXElR60mw==}
     peerDependencies:
-      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/ts-sdk': 1.26.0
       '@aptos-labs/wallet-standard': ^0.1.0
       aptos: ^1.20.0
 
@@ -356,12 +355,24 @@ packages:
     resolution: {integrity: sha512-76uPNZ6JrpruN9H8bEU37GVhAHwdhmvp7ZXpMTFnlFOJnBYt0LHCxR3x+HCk4WZ1CRrPQ57lmO+5A58PiGuweA==}
     hasBin: true
 
+  '@aptos-labs/aptos-cli@0.2.0':
+    resolution: {integrity: sha512-6kljJFRsTLXCvgkNhBoOLhVyo7rmih+8+XAtdeciIXkZYwzwVS3TFPLMqBUO2HcY6gYtQQRmTG52R5ihyi/bXA==}
+    hasBin: true
+
   '@aptos-labs/aptos-client@0.1.0':
     resolution: {integrity: sha512-q3s6pPq8H2buGp+tPuIRInWsYOuhSEwuNJPwd2YnsiID3YSLihn2ug39ktDJAcSOprUcp7Nid8WK7hKqnUmSdA==}
     engines: {node: '>=15.10.0'}
 
+  '@aptos-labs/aptos-client@0.1.1':
+    resolution: {integrity: sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==}
+    engines: {node: '>=15.10.0'}
+
   '@aptos-labs/ts-sdk@1.22.2':
     resolution: {integrity: sha512-EUGFT6Emyrc8xqBxZB7fO6Xha98+Q3WWJNw56IOVbiMYaga5w7Dzj8rTYYHxvxyBfEbnNQHn4QcQfaciU2N4qA==}
+    engines: {node: '>=11.0.0'}
+
+  '@aptos-labs/ts-sdk@1.27.1':
+    resolution: {integrity: sha512-QS4BlivXQy/uJgXcNOfXNjv8l+MSd+qQ256mY/Jc6iaWbfn69nRYh6chjSyLot4fHA49QxlZlWh1mJLlfNdtow==}
     engines: {node: '>=11.0.0'}
 
   '@aptos-labs/wallet-adapter-core@0.1.7':
@@ -373,43 +384,43 @@ packages:
   '@aptos-labs/wallet-adapter-core@2.2.0':
     resolution: {integrity: sha512-JL0zTXXoSQba1EDGqY5yTJxZVKMKwgMKZNA1JyV54s5loWzE2tinwg002EB+ONodkVmMhKbWnajCFFOgvgk+NQ==}
 
-  '@aptos-labs/wallet-adapter-core@3.16.0':
-    resolution: {integrity: sha512-4pBNoDLzuIOxdNwJEO770bkxROuEIQis0H0lFOVVCL33jK8/MWLlQo8hFgc71ovN1vWfdERDEgPLbAtVChploQ==}
+  '@aptos-labs/wallet-adapter-core@4.17.0':
+    resolution: {integrity: sha512-YzTZTVnySAXyyQl94o8Al5/MHfsy4XAAyelqn9kSwTkz4j2vp/8C4qNa77k6fm4HcaTDvw+VWdyKuYl7DIN39Q==}
     peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.13.2
+      '@aptos-labs/ts-sdk': ^1.27.1
       aptos: ^1.21.0
 
-  '@aptos-labs/wallet-adapter-core@4.8.2':
-    resolution: {integrity: sha512-sbAJcBvXCtE/4hBBdG1zviwmaYVusstDLiCE1gzdGI8Fa4BoqykHhpkWTEJtsCrxKMNZc08A6ZszkkxaOaG/tw==}
-    peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.18.1
-      aptos: ^1.21.0
-
-  '@aptos-labs/wallet-adapter-react@3.4.3':
-    resolution: {integrity: sha512-AFJC1gQLG1Kku939fFlWcKw1LskbPQ8HkSdF5kCqBD2W++jOI59LlsYbgOVUmXsIK8YmLoDtDZ4Jwxf5SAjDCw==}
+  '@aptos-labs/wallet-adapter-react@3.7.0':
+    resolution: {integrity: sha512-drb13Pk0HMwfMnP/u0W6Qj9VNEPbSMOYGuXpKvLEcuTcIpbXJKYGGeVJRutZBCQ/8VY1uI8MjzA1MgrfuI+W1A==}
     peerDependencies:
       react: ^18
 
   '@aptos-labs/wallet-standard@0.0.11':
     resolution: {integrity: sha512-8dygyPBby7TaMJjUSyeVP4R1WC9D/FPpX9gVMMLaqTKCXrSbkzhGDxcuwbMZ3ziEwRmx3zz+d6BIJbDhd0hm5g==}
 
-  '@aptos-labs/wallet-standard@0.1.0':
-    resolution: {integrity: sha512-DC4cWuvgXKBVQC+seGQc/nwIZoggZmGOIoN8EtEKHBSBMijwVfgRjD6cXPx8xWaXANyr5d32BGnWvYfMyWk3Pg==}
+  '@aptos-labs/wallet-standard@0.1.0-ms.1':
+    resolution: {integrity: sha512-3aWEmdqMcll8D2lzhBZuYUW1o49TDpqw4QRAkHk00tSC3SwAkuukoW8g/M9lB5nHFxaX7UzuxeaYv8l6/mhJVQ==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.17.0
       '@wallet-standard/core': ^1.0.3
 
-  '@atomrigslab/aptos-wallet-adapter@0.1.12':
-    resolution: {integrity: sha512-fxkinFLitXaq7UDtfA4BgFMW4DL9dg/tHI14Du7a+tGHUL2cCmUhRIS29X6gsAiPUNHE/gsrDODvcU1QdE1dWQ==}
+  '@aptos-labs/wallet-standard@0.2.0':
+    resolution: {integrity: sha512-4aoO4MlqzrW+CtO83MwbHMMtu91DL5B7YKRvhJbRnVB4R+QCOwBI/aQTkNZbKBDfOplLlqWTTl6Li0l6e02YLQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.17.0
+      '@wallet-standard/core': ^1.0.3
+
+  '@atomrigslab/aptos-wallet-adapter@0.1.21':
+    resolution: {integrity: sha512-LwT0OTOaGglctggMcihXLd4mzBFwRoJsR0aeFBHQRfTxZV1agNTgN/PxJl6N13+WYAvzc00j/WByxAmWgonorA==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.9.0
 
-  '@atomrigslab/dekey-web-wallet-provider@1.2.0':
-    resolution: {integrity: sha512-y9Jd/fzcEaZTXj/hAvt4eKuAHD9AEMeeeVL5fgEFoJKkAyevoxPmsH2CwCgc6AZbgXNw6YUTk8KyDIjWL/XBEA==}
+  '@atomrigslab/dekey-web-wallet-provider@1.2.1':
+    resolution: {integrity: sha512-GMEGjARgle9lIRopvxm4uis+sRr/ih26HzBgFbnLsk8+G94Z5dE87EclAIGFQUSAxYj7SmSk6xpx7//qUJDW/A==}
     engines: {node: '>=12.0.0'}
 
-  '@atomrigslab/providers@1.0.1':
-    resolution: {integrity: sha512-gaJZgbT3NlEP+RrU/38hAvmM0xmzpEV/I+g4wCqMjTkYY0S8c7khTB0WdrieIjldD5YPKfPr3dKdmPhibdY8JA==}
+  '@atomrigslab/providers@1.1.0':
+    resolution: {integrity: sha512-QLYxSCVrxwlN1oZ7vLnZbKZxkbZ6QG77Bj4pmTEowIpTcq7qZdBtU9pn+vqJAso1nnA3+AkmPuE9Jnx7+Jo1zQ==}
     engines: {node: '>=12.0.0'}
 
   '@babel/code-frame@7.24.6':
@@ -582,6 +593,14 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@blocto/sdk@0.10.3':
+    resolution: {integrity: sha512-9Ot5R3YULaX8IIRGyVYXhoGC01H+kaXCqwfLWzUSKciNYT2GxiF547LEAnT1a7e5HMrJdqjQ+94OsS32fHmq9A==}
+    peerDependencies:
+      aptos: ^1.3.14
+    peerDependenciesMeta:
+      aptos:
+        optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -791,6 +810,11 @@ packages:
   '@floating-ui/utils@0.2.2':
     resolution: {integrity: sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==}
 
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@headlessui/react@2.1.2':
     resolution: {integrity: sha512-Kb3hgk9gRNRcTZktBrKdHhF3xFhYkca1Rk6e1/im2ENf83dgN54orMW0uSKTXFnUpZOUFZ+wcY05LlipwgZIFQ==}
     engines: {node: '>=10'}
@@ -817,18 +841,18 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@identity-connect/api@0.6.1':
-    resolution: {integrity: sha512-CBeff9UZtQWhJBPEuwFCOcies2rFkn14BTLyyYLpI+Tlxv1XTCWSZKRx/Ewvexb4U/5OWWMY1s263gZBaOAiPQ==}
+  '@identity-connect/api@0.7.0':
+    resolution: {integrity: sha512-mn/LZGeb3xgBD644p67tYOjvYSSdZpwxiO4/ZjwjsJZ8eYvGha5FiZg+pqVH73lg1S36qikwbkA3HUQOAE5GKA==}
 
   '@identity-connect/crypto@0.2.3':
     resolution: {integrity: sha512-HJmsNz4YeJg/BFgu94x9cbNUrlKTmk50yVuoF2Ry1+SwC2c6Vhy2CeaZa1SeevjHsk9hjSrqk42q+EZMZAuaJA==}
     peerDependencies:
       '@aptos-labs/ts-sdk': 1.18.1
 
-  '@identity-connect/dapp-sdk@0.9.0':
-    resolution: {integrity: sha512-EYB9PMyEagt3PCjJTwX3V34vyXi/asj7dAD22rvUJarlx+TIRPYODxTWoUR2jc7F9Q83cZbU7Iv/EL77diqYYQ==}
+  '@identity-connect/dapp-sdk@0.9.5':
+    resolution: {integrity: sha512-LGPPmOtesrFCUtxe0OmMhDk8S02qp7sMlCoeqfnV8xvmRW++6eH4bfTnM0L7NL95xBdNiLMd1rwR6QC5NByHmQ==}
     peerDependencies:
-      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/ts-sdk': 1.26.0
       '@aptos-labs/wallet-standard': ^0.1.0
 
   '@identity-connect/wallet-api@0.1.1':
@@ -1049,6 +1073,18 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@json-rpc-tools/provider@1.7.6':
+    resolution: {integrity: sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@json-rpc-tools/types@1.7.6':
+    resolution: {integrity: sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  '@json-rpc-tools/utils@1.7.6':
+    resolution: {integrity: sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   '@keyvhq/core@2.1.1':
     resolution: {integrity: sha512-wVnnVFWmtAvQP8v/Ugm8KSl4glrVZjb5uqVc1n5tbGzj45lZhG7F/YxCJ6qHGDfBtDEw5cp1nJ2qImdmaG/JEQ==}
     engines: {node: '>= 16'}
@@ -1062,6 +1098,33 @@ packages:
 
   '@metamask/safe-event-emitter@2.0.0':
     resolution: {integrity: sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==}
+
+  '@microsoft/fetch-event-source@2.0.1':
+    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
+
+  '@mizuwallet-sdk/aptos-wallet-adapter@0.2.5':
+    resolution: {integrity: sha512-D4/kCV5qNRFaatEdVUOFNPPl7zicFfc/813vgo5LmvVwa4jHWK0GiPK5lIKL99jKnDRicR28ftbIIvPecaPv3g==}
+    peerDependencies:
+      '@mizuwallet-sdk/core': '>=1.3.2'
+      '@mizuwallet-sdk/protocol': 0.0.1
+
+  '@mizuwallet-sdk/core@1.3.2':
+    resolution: {integrity: sha512-pe4YLMUBBYKDggKPT+U4gn7s6MpJ4qnENOlNwvlUQRY+Q9/zUs+PIQljRlDA9aGM8Y8ZwsRZmuIHTmeirWw7yg==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': '>=1.14.0'
+      graphql-request: '>=7.0.1'
+
+  '@mizuwallet-sdk/protocol@0.0.1':
+    resolution: {integrity: sha512-LTkygWdCL4ao7XvmrUq570waMMA9EKDWV/GH7/NbTndLUQqJDp5hIM08E99FdplpI02mdA89/o6uTtfmd/Pstg==}
+
+  '@molt/command@0.9.0':
+    resolution: {integrity: sha512-1JI8dAlpqlZoXyKWVQggX7geFNPxBpocHIXQCsnxDjKy+3WX4SGyZVJXuLlqRRrX7FmQCuuMAfx642ovXmPA9g==}
+
+  '@molt/types@0.2.0':
+    resolution: {integrity: sha512-p6ChnEZDGjg9PYPec9BK6Yp5/DdSrYQvXTBAtgrnqX6N36cZy37ql1c8Tc5LclfIYBNG7EZp8NBcRTYJwyi84g==}
+
+  '@msafe/aptos-wallet@6.1.1':
+    resolution: {integrity: sha512-g/2TPRqyChciaw/S69EBr7CgzYJBT1LJulU0nMNnkehJc+ZX/fNN+5JXEuea+a0rXsk/flcbCSfvT2JtS0+/mQ==}
 
   '@next/bundle-analyzer@14.2.4':
     resolution: {integrity: sha512-ydSDikSgGhYmBlnvzS4tgdGyn40SCFI9uWDldbkRSwXS60tg4WBJR4qJoTSERTmdAFb1PeUYCyFdfC80i2WL1w==}
@@ -1148,6 +1211,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@pedrouid/environment@1.0.1':
+    resolution: {integrity: sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1868,6 +1934,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  alge@0.8.1:
+    resolution: {integrity: sha512-kiV9nTt+XIauAXsowVygDxMZLplZxDWt0W8plE/nB32/V2ziM/P/TxDbSVK7FYIUt2Xo16h3/htDh199LNPCKQ==}
+
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -1985,11 +2054,17 @@ packages:
     resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
     engines: {node: '>=4'}
 
+  axios@0.21.4:
+    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
+
   axios@1.6.2:
     resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
 
   axios@1.7.2:
     resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
+
+  axios@1.7.4:
+    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
 
   axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
@@ -2111,6 +2186,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -2374,6 +2453,10 @@ packages:
 
   ed2curve@0.3.0:
     resolution: {integrity: sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==}
+
+  eip1193-provider@1.0.1:
+    resolution: {integrity: sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   electron-to-chromium@1.4.783:
     resolution: {integrity: sha512-bT0jEz/Xz1fahQpbZ1D7LgmPYZ3iHVY39NcWWro1+hA2IvjiPeaXtfSqrQ+nXjApMvQRE2ASt1itSLRrebHMRQ==}
@@ -2843,6 +2926,26 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql-request@7.1.0:
+    resolution: {integrity: sha512-Ouu/lYVFhARS1aXeZoVJWnGT6grFJXTLwXJuK4mUGGRo0EUk1JkyYp43mdGmRgUVezpRm6V5Sq3t8jBDQcajng==}
+    hasBin: true
+    peerDependencies:
+      '@dprint/formatter': ^0.3.0
+      '@dprint/typescript': ^0.91.1
+      dprint: ^0.46.2
+      graphql: 14 - 16
+    peerDependenciesMeta:
+      '@dprint/formatter':
+        optional: true
+      '@dprint/typescript':
+        optional: true
+      dprint:
+        optional: true
+
+  graphql@16.9.0:
+    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
@@ -3245,6 +3348,9 @@ packages:
   js-sdsl@4.3.0:
     resolution: {integrity: sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==}
 
+  js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3277,6 +3383,10 @@ packages:
   json-rpc-middleware-stream@3.0.0:
     resolution: {integrity: sha512-JmZmlehE0xF3swwORpLHny/GvW3MZxCsb2uFNBrn8TOqMqivzCfz232NSDLLOtIQlrPlgyEjiYpyzyOPFOzClw==}
 
+  json-rpc-protocol@0.13.2:
+    resolution: {integrity: sha512-2InSi+c7wGESmvYcEVS0clctpJCodV7gLqLN1BIIPNK07wokXIwhOL8RQWU4O7oX5adChn6HJGtIU6JaUQ1P/A==}
+    engines: {node: '>=4'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -3299,6 +3409,9 @@ packages:
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
+
+  keyvaluestorage-interface@1.0.0:
+    resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3341,11 +3454,20 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.ismatch@4.4.0:
+    resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -3619,12 +3741,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  petra-plugin-wallet-adapter@0.4.5:
-    resolution: {integrity: sha512-x2S2xRAIz/5ytbB2wHCTJhqLBDsgWPEVmj7X2aril1BUplIGPJHTstgo8hqOngb2rtYbBY+wviyS9Di4IDCGRA==}
-    peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.3.0
-      aptos: ^1.21.0
-
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
@@ -3713,6 +3829,9 @@ packages:
   postgres@3.4.4:
     resolution: {integrity: sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A==}
     engines: {node: '>=12'}
+
+  postmate@1.5.2:
+    resolution: {integrity: sha512-EHLlEmrUA/hALls49oBrtE7BzDXXjB9EiO4MZpsoO3R/jRuBmD+2WKQuYAbeuVEpTzrPpUTT79z2cz4qaFgPRg==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3867,6 +3986,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readline-sync@1.4.10:
+    resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
+    engines: {node: '>= 0.8.0'}
+
   reflect.getprototypeof@1.0.6:
     resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
     engines: {node: '>= 0.4'}
@@ -3880,6 +4003,9 @@ packages:
 
   reinterval@1.1.0:
     resolution: {integrity: sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==}
+
+  remeda@1.61.0:
+    resolution: {integrity: sha512-caKfSz9rDeSKBQQnlJnVW3mbVdFgxgGWQKq1XlFokqjf+hQD5gxutLGTTY2A/x24UxVyJe9gH5fAkFI63ULw4A==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3948,6 +4074,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-json-utils@1.1.1:
+    resolution: {integrity: sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ==}
 
   safe-regex-test@1.0.3:
     resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
@@ -4077,6 +4206,10 @@ packages:
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
+
+  string-length@6.0.0:
+    resolution: {integrity: sha512-1U361pxZHEQ+FeSjzqRpV+cu2vTzYeWeafXFLykiFlv4Vc0n3njgU8HrMbyik5uwm77naWMuVG8fhEF+Ovb1Kg==}
+    engines: {node: '>=16'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4292,6 +4425,9 @@ packages:
       '@swc/wasm':
         optional: true
 
+  ts-toolbelt@9.6.0:
+    resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -4343,6 +4479,9 @@ packages:
   tween-functions@1.2.0:
     resolution: {integrity: sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==}
 
+  tweetnacl-util@0.15.1:
+    resolution: {integrity: sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==}
+
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
@@ -4365,6 +4504,10 @@ packages:
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
+
+  type-fest@4.26.1:
+    resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.2:
     resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
@@ -4600,6 +4743,9 @@ packages:
   yup@1.4.0:
     resolution: {integrity: sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==}
 
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
   zustand@4.5.4:
     resolution: {integrity: sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==}
     engines: {node: '>=12.7.0'}
@@ -4624,34 +4770,35 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@aptos-connect/wallet-adapter-plugin@1.0.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+  '@aptos-connect/wallet-adapter-plugin@2.0.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.22.2
-      '@aptos-labs/wallet-adapter-core': 3.16.0(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)
-      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
-      '@identity-connect/crypto': 0.2.3(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@identity-connect/dapp-sdk': 0.9.0(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      aptos: 1.21.0
+      '@aptos-connect/wallet-api': 0.1.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/crypto': 0.2.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@identity-connect/dapp-sdk': 0.9.5(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
     transitivePeerDependencies:
+      - aptos
       - debug
 
-  '@aptos-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+  '@aptos-connect/wallet-api@0.1.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.22.2
-      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
-      '@identity-connect/api': 0.6.1
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.7.0
       aptos: 1.21.0
 
-  '@aptos-connect/web-transport@0.0.7(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+  '@aptos-connect/web-transport@0.0.7(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.22.2
-      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
+      '@aptos-connect/wallet-api': 0.1.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
       aptos: 1.21.0
       uuid: 9.0.1
 
   '@aptos-labs/aptos-cli@0.1.9': {}
+
+  '@aptos-labs/aptos-cli@0.2.0': {}
 
   '@aptos-labs/aptos-client@0.1.0':
     dependencies:
@@ -4660,10 +4807,33 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@aptos-labs/aptos-client@0.1.1':
+    dependencies:
+      axios: 1.7.4
+      got: 11.8.6
+    transitivePeerDependencies:
+      - debug
+
   '@aptos-labs/ts-sdk@1.22.2':
     dependencies:
       '@aptos-labs/aptos-cli': 0.1.9
       '@aptos-labs/aptos-client': 0.1.0
+      '@noble/curves': 1.4.0
+      '@noble/hashes': 1.4.0
+      '@scure/bip32': 1.4.0
+      '@scure/bip39': 1.3.0
+      eventemitter3: 5.0.1
+      form-data: 4.0.0
+      js-base64: 3.7.7
+      jwt-decode: 4.0.0
+      poseidon-lite: 0.2.0
+    transitivePeerDependencies:
+      - debug
+
+  '@aptos-labs/ts-sdk@1.27.1':
+    dependencies:
+      '@aptos-labs/aptos-cli': 0.2.0
+      '@aptos-labs/aptos-client': 0.1.1
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
@@ -4701,69 +4871,71 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@aptos-labs/wallet-adapter-core@3.16.0(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)':
+  '@aptos-labs/wallet-adapter-core@4.17.0(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.3.2(@aptos-labs/ts-sdk@1.27.1)(graphql-request@7.1.0(graphql@16.9.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.22.2
-      '@aptos-labs/wallet-standard': 0.0.11
-      '@atomrigslab/aptos-wallet-adapter': 0.1.12(@aptos-labs/ts-sdk@1.22.2)
+      '@aptos-connect/wallet-adapter-plugin': 2.0.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.27.1)
+      '@mizuwallet-sdk/aptos-wallet-adapter': 0.2.5(@mizuwallet-sdk/core@1.3.2(@aptos-labs/ts-sdk@1.27.1)(graphql-request@7.1.0(graphql@16.9.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
       aptos: 1.21.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
     transitivePeerDependencies:
-      - debug
-
-  '@aptos-labs/wallet-adapter-core@4.8.2(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)(aptos@1.21.0)':
-    dependencies:
-      '@aptos-connect/wallet-adapter-plugin': 1.0.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.22.2
-      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
-      '@atomrigslab/aptos-wallet-adapter': 0.1.12(@aptos-labs/ts-sdk@1.22.2)
-      aptos: 1.21.0
-      buffer: 6.0.3
-      eventemitter3: 4.0.7
-      tweetnacl: 1.0.3
-    transitivePeerDependencies:
+      - '@mizuwallet-sdk/core'
+      - '@mizuwallet-sdk/protocol'
       - '@wallet-standard/core'
+      - bufferutil
       - debug
+      - utf-8-validate
 
-  '@aptos-labs/wallet-adapter-react@3.4.3(@aptos-labs/ts-sdk@1.22.2)(@types/react@18.3.3)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.3.1)':
+  '@aptos-labs/wallet-adapter-react@3.7.0(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.3.2(@aptos-labs/ts-sdk@1.27.1)(graphql-request@7.1.0(graphql@16.9.0)))(@mizuwallet-sdk/protocol@0.0.1)(@types/react@18.3.3)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(react@18.3.1)':
     dependencies:
-      '@aptos-labs/wallet-adapter-core': 4.8.2(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@aptos-labs/wallet-adapter-core': 4.17.0(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.3.2(@aptos-labs/ts-sdk@1.27.1)(graphql-request@7.1.0(graphql@16.9.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
     transitivePeerDependencies:
       - '@aptos-labs/ts-sdk'
+      - '@mizuwallet-sdk/core'
+      - '@mizuwallet-sdk/protocol'
       - '@types/react'
       - '@wallet-standard/core'
       - aptos
+      - bufferutil
       - debug
+      - utf-8-validate
 
   '@aptos-labs/wallet-standard@0.0.11':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.22.2
+      '@aptos-labs/ts-sdk': 1.27.1
       '@wallet-standard/core': 1.0.3
     transitivePeerDependencies:
       - debug
 
-  '@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)':
+  '@aptos-labs/wallet-standard@0.1.0-ms.1(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.22.2
+      '@aptos-labs/ts-sdk': 1.27.1
       '@wallet-standard/core': 1.0.3
 
-  '@atomrigslab/aptos-wallet-adapter@0.1.12(@aptos-labs/ts-sdk@1.22.2)':
+  '@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.22.2
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@wallet-standard/core': 1.0.3
+
+  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.27.1)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.1
       '@aptos-labs/wallet-standard': 0.0.11
-      '@atomrigslab/dekey-web-wallet-provider': 1.2.0
+      '@atomrigslab/dekey-web-wallet-provider': 1.2.1
     transitivePeerDependencies:
       - debug
 
-  '@atomrigslab/dekey-web-wallet-provider@1.2.0':
+  '@atomrigslab/dekey-web-wallet-provider@1.2.1':
     dependencies:
-      '@atomrigslab/providers': 1.0.1
+      '@atomrigslab/providers': 1.1.0
 
-  '@atomrigslab/providers@1.0.1':
+  '@atomrigslab/providers@1.1.0':
     dependencies:
       '@metamask/object-multiplex': 1.3.0
       '@metamask/safe-event-emitter': 2.0.0
@@ -4979,6 +5151,18 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@blocto/sdk@0.10.3(aptos@1.21.0)':
+    dependencies:
+      buffer: 6.0.3
+      eip1193-provider: 1.0.1
+      js-sha3: 0.8.0
+    optionalDependencies:
+      aptos: 1.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -5122,6 +5306,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.2': {}
 
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.9.0)':
+    dependencies:
+      graphql: 16.9.0
+
   '@headlessui/react@2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react': 0.26.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5147,12 +5335,12 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@identity-connect/api@0.6.1': {}
+  '@identity-connect/api@0.7.0': {}
 
-  '@identity-connect/crypto@0.2.3(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+  '@identity-connect/crypto@0.2.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.22.2
+      '@aptos-connect/wallet-api': 0.1.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
       '@noble/hashes': 1.4.0
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
@@ -5160,24 +5348,24 @@ snapshots:
       - '@aptos-labs/wallet-standard'
       - aptos
 
-  '@identity-connect/dapp-sdk@0.9.0(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+  '@identity-connect/dapp-sdk@0.9.5(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-connect/web-transport': 0.0.7(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.22.2
-      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3)
-      '@identity-connect/api': 0.6.1
-      '@identity-connect/crypto': 0.2.3(@aptos-labs/ts-sdk@1.22.2)(@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.22.2)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@identity-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)
+      '@aptos-connect/wallet-api': 0.1.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-connect/web-transport': 0.0.7(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.7.0
+      '@identity-connect/crypto': 0.2.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
+      '@identity-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.1)(aptos@1.21.0)
       axios: 1.7.2
       uuid: 9.0.1
     transitivePeerDependencies:
       - aptos
       - debug
 
-  '@identity-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)':
+  '@identity-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.27.1)(aptos@1.21.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.22.2
+      '@aptos-labs/ts-sdk': 1.27.1
       aptos: 1.21.0
 
   '@img/sharp-darwin-arm64@0.33.4':
@@ -5458,6 +5646,26 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  '@json-rpc-tools/provider@1.7.6':
+    dependencies:
+      '@json-rpc-tools/utils': 1.7.6
+      axios: 0.21.4
+      safe-json-utils: 1.1.1
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@json-rpc-tools/types@1.7.6':
+    dependencies:
+      keyvaluestorage-interface: 1.0.0
+
+  '@json-rpc-tools/utils@1.7.6':
+    dependencies:
+      '@json-rpc-tools/types': 1.7.6
+      '@pedrouid/environment': 1.0.1
+
   '@keyvhq/core@2.1.1':
     dependencies:
       json-buffer: 3.0.1
@@ -5476,6 +5684,61 @@ snapshots:
       readable-stream: 2.3.8
 
   '@metamask/safe-event-emitter@2.0.0': {}
+
+  '@microsoft/fetch-event-source@2.0.1': {}
+
+  '@mizuwallet-sdk/aptos-wallet-adapter@0.2.5(@mizuwallet-sdk/core@1.3.2(@aptos-labs/ts-sdk@1.27.1)(graphql-request@7.1.0(graphql@16.9.0)))(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.1.0-ms.1(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@blocto/sdk': 0.10.3(aptos@1.21.0)
+      '@mizuwallet-sdk/core': 1.3.2(@aptos-labs/ts-sdk@1.27.1)(graphql-request@7.1.0(graphql@16.9.0))
+      '@mizuwallet-sdk/protocol': 0.0.1
+      '@msafe/aptos-wallet': 6.1.1
+      buffer: 6.0.3
+      postmate: 1.5.2
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
+      - aptos
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@mizuwallet-sdk/core@1.3.2(@aptos-labs/ts-sdk@1.27.1)(graphql-request@7.1.0(graphql@16.9.0))':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.1
+      buffer: 6.0.3
+      graphql-request: 7.1.0(graphql@16.9.0)
+      jwt-decode: 4.0.0
+
+  '@mizuwallet-sdk/protocol@0.0.1':
+    dependencies:
+      '@microsoft/fetch-event-source': 2.0.1
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.15.1
+
+  '@molt/command@0.9.0':
+    dependencies:
+      '@molt/types': 0.2.0
+      alge: 0.8.1
+      chalk: 5.3.0
+      lodash.camelcase: 4.3.0
+      lodash.snakecase: 4.1.1
+      readline-sync: 1.4.10
+      string-length: 6.0.0
+      strip-ansi: 7.1.0
+      ts-toolbelt: 9.6.0
+      type-fest: 4.26.1
+      zod: 3.23.8
+
+  '@molt/types@0.2.0':
+    dependencies:
+      ts-toolbelt: 9.6.0
+
+  '@msafe/aptos-wallet@6.1.1':
+    dependencies:
+      buffer: 6.0.3
+      json-rpc-protocol: 0.13.2
 
   '@next/bundle-analyzer@14.2.4':
     dependencies:
@@ -5536,6 +5799,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@pedrouid/environment@1.0.1': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6323,6 +6588,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  alge@0.8.1:
+    dependencies:
+      lodash.ismatch: 4.4.0
+      remeda: 1.61.0
+      ts-toolbelt: 9.6.0
+      zod: 3.23.8
+
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -6473,6 +6745,12 @@ snapshots:
 
   axe-core@4.7.0: {}
 
+  axios@0.21.4:
+    dependencies:
+      follow-redirects: 1.15.6
+    transitivePeerDependencies:
+      - debug
+
   axios@1.6.2:
     dependencies:
       follow-redirects: 1.15.6
@@ -6482,6 +6760,14 @@ snapshots:
       - debug
 
   axios@1.7.2:
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.7.4:
     dependencies:
       follow-redirects: 1.15.6
       form-data: 4.0.0
@@ -6643,6 +6929,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.3.0: {}
 
   char-regex@1.0.2: {}
 
@@ -6881,6 +7169,14 @@ snapshots:
   ed2curve@0.3.0:
     dependencies:
       tweetnacl: 1.0.3
+
+  eip1193-provider@1.0.1:
+    dependencies:
+      '@json-rpc-tools/provider': 1.7.6
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
 
   electron-to-chromium@1.4.783: {}
 
@@ -7571,6 +7867,15 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql-request@7.1.0(graphql@16.9.0):
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@molt/command': 0.9.0
+      graphql: 16.9.0
+      zod: 3.23.8
+
+  graphql@16.9.0: {}
+
   gzip-size@6.0.0:
     dependencies:
       duplexer: 0.1.2
@@ -8137,6 +8442,8 @@ snapshots:
 
   js-sdsl@4.3.0: {}
 
+  js-sha3@0.8.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -8168,6 +8475,10 @@ snapshots:
       '@metamask/safe-event-emitter': 2.0.0
       readable-stream: 2.3.8
 
+  json-rpc-protocol@0.13.2:
+    dependencies:
+      make-error: 1.3.6
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -8186,6 +8497,8 @@ snapshots:
       object.values: 1.2.0
 
   jwt-decode@4.0.0: {}
+
+  keyvaluestorage-interface@1.0.0: {}
 
   kleur@3.0.3: {}
 
@@ -8218,9 +8531,15 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.camelcase@4.3.0: {}
+
+  lodash.ismatch@4.4.0: {}
+
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.snakecase@4.1.1: {}
 
   lodash@4.17.21: {}
 
@@ -8507,14 +8826,6 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  petra-plugin-wallet-adapter@0.4.5(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0):
-    dependencies:
-      '@aptos-labs/ts-sdk': 1.22.2
-      '@aptos-labs/wallet-adapter-core': 3.16.0(@aptos-labs/ts-sdk@1.22.2)(aptos@1.21.0)
-      aptos: 1.21.0
-    transitivePeerDependencies:
-      - debug
-
   picocolors@1.0.1: {}
 
   picomatch@2.3.1: {}
@@ -8590,6 +8901,8 @@ snapshots:
       source-map-js: 1.2.0
 
   postgres@3.4.4: {}
+
+  postmate@1.5.2: {}
 
   prelude-ls@1.2.1: {}
 
@@ -8758,6 +9071,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  readline-sync@1.4.10: {}
+
   reflect.getprototypeof@1.0.6:
     dependencies:
       call-bind: 1.0.7
@@ -8778,6 +9093,8 @@ snapshots:
       set-function-name: 2.0.2
 
   reinterval@1.1.0: {}
+
+  remeda@1.61.0: {}
 
   require-directory@2.1.1: {}
 
@@ -8839,6 +9156,8 @@ snapshots:
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
+
+  safe-json-utils@1.1.1: {}
 
   safe-regex-test@1.0.3:
     dependencies:
@@ -8995,6 +9314,10 @@ snapshots:
     dependencies:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
+
+  string-length@6.0.0:
+    dependencies:
+      strip-ansi: 7.1.0
 
   string-width@4.2.3:
     dependencies:
@@ -9242,6 +9565,8 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-toolbelt@9.6.0: {}
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -9289,6 +9614,8 @@ snapshots:
 
   tween-functions@1.2.0: {}
 
+  tweetnacl-util@0.15.1: {}
+
   tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
@@ -9302,6 +9629,8 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@2.19.0: {}
+
+  type-fest@4.26.1: {}
 
   typed-array-buffer@1.0.2:
     dependencies:
@@ -9556,6 +9885,8 @@ snapshots:
       tiny-case: 1.0.3
       toposort: 2.0.2
       type-fest: 2.19.0
+
+  zod@3.23.8: {}
 
   zustand@4.5.4(@types/react@18.3.3)(immer@10.1.1)(react@18.3.1):
     dependencies:

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@aptos-labs/ts-sdk": "1.22.2",
+    "@aptos-labs/ts-sdk": "1.27.1",
     "@keyvhq/core": "^2.1.1",
     "@noble/hashes": "^1.4.0",
     "@supabase/postgrest-js": "^1.15.7",

--- a/src/typescript/sdk/src/emojicoin_dot_fun/emojicoin-dot-fun.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/emojicoin-dot-fun.ts
@@ -18,7 +18,7 @@ import {
   type UserTransactionResponse,
   type LedgerVersionArg,
   SimpleTransaction,
-  Ed25519PublicKey,
+  type Ed25519PublicKey,
 } from "@aptos-labs/ts-sdk";
 import {
   type Option,

--- a/src/typescript/sdk/src/emojicoin_dot_fun/emojicoin-dot-fun.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/emojicoin-dot-fun.ts
@@ -17,8 +17,8 @@ import {
   type WaitForTransactionOptions,
   type UserTransactionResponse,
   type LedgerVersionArg,
-  type PublicKey,
   SimpleTransaction,
+  Ed25519PublicKey,
 } from "@aptos-labs/ts-sdk";
 import {
   type Option,
@@ -302,7 +302,7 @@ export class RegisterMarket extends EntryFunctionPayloadBuilder {
   static async getGasCost(args: {
     aptosConfig: AptosConfig;
     registrant: AccountAddressInput; // &signer
-    registrantPubKey: PublicKey;
+    registrantPubKey: Ed25519PublicKey;
     emojis: Array<HexInput>; // vector<vector<u8>>
   }): Promise<{ data: { amount: number; unitPrice: number }; error: boolean }> {
     const { aptosConfig } = args;


### PR DESCRIPTION
# Description

- [x] Update the `@aptos-labs/wallet-adapter-react` to the latest possible version
- [x] Remove unused `petra-plugin-wallet-adapter` to reduce chances of aberrant behavior
- [x] Update the `@aptos-labs/ts-sdk` to the latest compatible version
- [x] Remove `Petra` from `optInWallets`, since it's behavior was unnecessary
- [x] Fix incompatibilities with our middleware with the `Edge Runtime` after the new `@aptos-labs/ts-sdk` update, since `axios` was updated, and it now uses `setImmediate` which isn't available in the Edge Runtime.
  - [x] This was done by removing the `HASH_SEED` import from `server-env` and just validating/importing it directly in `authenticate.ts`
  - [x] We also removed imports in `session-info.ts` and now calculate the length of a week without using helper utilities.
  - [x] Note we still validate the `HASH_SEED` entry is valid at build time by leaving it in `server-env.ts`.
- [x] Ensure register market function still works
- [x] Disable `autoconnect` for now to see if we can isolate the problem with not being able to connect to `Petra`
- [x] Remove `@aptos-labs/ts-sdk` package from the monorepo, since we no longer need it. We used to use it to resolve imports not being found when the frontend didn't use the SDK, but now it does, so we can remove it from the `typescript` directory.

# Testing

Register a market  with the preview deployment and see if the transaction succeeds!

- [x] https://explorer.aptoslabs.com/txn/6081559927?network=testnet

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

