### PR TITLE
[ECO-2257] Patch event store to not pull from local storage because it's currently cached

### DIFF
--- a/src/typescript/frontend/src/lib/store/event/event-store.ts
+++ b/src/typescript/frontend/src/lib/store/event/event-store.ts
@@ -19,7 +19,7 @@ import {
   pushPeriodicStateEvents,
   toMappedMarketEvents,
 } from "./utils";
-import { addToLocalStorage, initialStateFromLocalStorage } from "./local-storage";
+import { initialStatePatch } from "./local-storage";
 import { periodEnumToRawDuration } from "@sdk/const";
 import { joinEmojis } from "@sdk/emoji_data";
 import { createWebSocketClientStore, type WebSocketClientStore } from "../websocket/store";
@@ -28,7 +28,7 @@ import { DEBUG_ASSERT, extractFilter } from "@sdk/utils";
 export const createEventStore = () => {
   return createStore<EventStore & WebSocketClientStore>()(
     immer((set, get) => ({
-      ...initialStateFromLocalStorage(),
+      ...initialStatePatch(),
       getMarket: (m) => get().markets.get(joinEmojis(m)),
       getRegisteredMarkets: () => {
         return get().markets;
@@ -51,7 +51,6 @@ export const createEventStore = () => {
             marketEvents.forEach((event) => market.stateEvents.push(event));
           });
         });
-        filtered.forEach(addToLocalStorage);
       },
       loadEventsFromServer: (eventsIn: Array<AnyEventModel>) => {
         const guids = get().guids;
@@ -77,7 +76,6 @@ export const createEventStore = () => {
             pushPeriodicStateEvents(market, extractFilter(marketEvents, isPeriodicStateEventModel));
             DEBUG_ASSERT(() => marketEvents.length === 0);
           });
-          events.forEach(addToLocalStorage);
         });
       },
       pushEventFromClient: (event: AnyEventModel) => {
@@ -108,7 +106,6 @@ export const createEventStore = () => {
             }
           }
         });
-        addToLocalStorage(event);
       },
       setLatestBars: ({ marketMetadata, latestBars }: SetLatestBarsArgs) => {
         set((state) => {

--- a/src/typescript/frontend/src/lib/store/event/local-storage.ts
+++ b/src/typescript/frontend/src/lib/store/event/local-storage.ts
@@ -56,6 +56,16 @@ type MarketEventTypes =
   | DatabaseModels["liquidity_events"]
   | DatabaseModels["periodic_state_events"];
 
+export const initialStatePatch = (): EventState => {
+  return {
+    guids: new Set<string>(),
+    stateFirehose: [],
+    marketRegistrations: [],
+    markets: new Map(),
+    globalStateEvents: [],
+  };
+};
+
 export const initialStateFromLocalStorage = (): EventState => {
   // Purge stale events then load up the remaining ones.
   const events = getEventsFromLocalStorage();


### PR DESCRIPTION
# Description

It's breaking production because it's trying to read from local storage, since there's values there. 

Removing the initial state to essentially reset it very quickly

# Testing

It has to be merged into production to see if it truly fixes it, but all tests should pass.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
