### PR TITLE
[ECO-2286] Fix the incorrect chart bar times

### DIFF
--- a/src/typescript/frontend/src/lib/server-env.ts
+++ b/src/typescript/frontend/src/lib/server-env.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { APTOS_NETWORK, IS_ALLOWLIST_ENABLED } from "./env";
 import { Network } from "@aptos-labs/ts-sdk";
-import { EMOJICOIN_INDEXER_URL } from "@sdk/server-env";
+import { EMOJICOIN_INDEXER_URL } from "@sdk/server/env";
 
 if (typeof process.env.REVALIDATION_TIME === "undefined") {
   if (process.env.NODE) throw new Error("Environment variable REVALIDATION_TIME is undefined.");

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -75,7 +75,7 @@ export const handleLatestBarForSwapEvent = (
       throw new Error("This should never occur. It is a type guard/hint.");
     } else if (event.market.marketNonce >= data.latestBar.marketNonce) {
       const price = q64ToBig(event.swap.avgExecutionPriceQ64).toNumber();
-      data.latestBar.time = Number(getPeriodStartTimeFromTime(event.market.time, period));
+      data.latestBar.time = Number(getPeriodStartTimeFromTime(event.market.time, period) / 1000n);
       data.latestBar.close = price;
       data.latestBar.high = Math.max(data.latestBar.high, price);
       data.latestBar.low = Math.min(data.latestBar.low, price);

--- a/src/typescript/sdk/src/indexer-v2/queries/client.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/client.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { PostgrestClient } from "@supabase/postgrest-js";
 import { parseJSONWithBigInts, stringifyJSONWithBigInts } from "../json-bigint";
 import { type TableName } from "../types/json-types";
-import { EMOJICOIN_INDEXER_URL, FETCH_DEBUG, FETCH_DEBUG_VERBOSE } from "../../server-env";
+import { EMOJICOIN_INDEXER_URL, FETCH_DEBUG, FETCH_DEBUG_VERBOSE } from "../../server/env";
 
 /**
  * Fetch with BigInt support. This is necessary because the JSON returned by the indexer

--- a/src/typescript/sdk/src/server/env.ts
+++ b/src/typescript/sdk/src/server/env.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 if (typeof process.env.EMOJICOIN_INDEXER_URL === "undefined") {
   throw new Error("The indexer processor url must be defined.");
 } else {

--- a/src/typescript/sdk/tests/e2e/queries/testnet/simple.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/testnet/simple.test.ts
@@ -1,7 +1,7 @@
 import { sleep } from "../../../../src";
 import { getLatestProcessedEmojicoinVersion, postgrest } from "../../../../src/indexer-v2/queries";
 import { TableName } from "../../../../src/indexer-v2/types/json-types";
-import { EMOJICOIN_INDEXER_URL } from "../../../../src/server-env";
+import { EMOJICOIN_INDEXER_URL } from "../../../../src/server/env";
 
 const API_KEY = process.env.EMOJICOIN_INDEXER_API_KEY!;
 

--- a/src/typescript/sdk/tests/e2e/schema.test.ts
+++ b/src/typescript/sdk/tests/e2e/schema.test.ts
@@ -1,4 +1,4 @@
-import { EMOJICOIN_INDEXER_URL } from "../../src/server-env";
+import { EMOJICOIN_INDEXER_URL } from "../../src/server/env";
 import { type AnyColumnName, TableName } from "../../src/indexer-v2/types/json-types";
 import {
   floatColumns,


### PR DESCRIPTION
# Description

The chart is currently not dividing the time returned by a function that takes in a bigint of microseconds, so it thinks it's nearly the year 50,000.

During the big update for indexer v2, the `server-env.ts` file lost its `import "server-only"` directive at the top of the file. Currently it can be accidentally imported to client files. I've also fixed that

- [x] Fix the calculation in time error
- [x] Add the `server-only` import to the server environment variables file, move it to a folder for server actions that we may use later

# Testing

I'll add unit tests for some of this logic later, but for now we just have to visually ensure it's correct. It's extremely obviously wrong at the moment, so just check that the latest bar on the chart is `'24` and not the year 50447 (will display as `'47`) and that means it's working correctly.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
