### PR TITLE
[ECO-2280] Replace 00 on home page

### DIFF
--- a/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
@@ -13,6 +13,7 @@ import planetHome from "../../../../../../public/images/planet-home.png";
 import { emojiNamesToPath } from "utils/pathname-helpers";
 import { type HomePageProps } from "app/home/HomePage";
 import "./module.css";
+import { SYMBOL_DATA } from "@sdk/emoji_data";
 
 export interface MainCardProps {
   featured?: HomePageProps["featured"];
@@ -96,7 +97,7 @@ const MainCard = (props: MainCardProps) => {
         </Link>
 
         <Column maxWidth="100%" ellipsis>
-          <div className="pixel-heading-1 text-medium-gray pixel-heading-text">00</div>
+          <div className="flex flex-row"><span className="pixel-heading-1 text-medium-gray pixel-heading-text">HOT</span><span className="pixel-heading-2 pixel-heading-text mt-[.2rem]">{SYMBOL_DATA.byName("fire")?.emoji}</span></div>
           <div
             className="display-font-text ellipses font-forma-bold"
             title={(featured ? featured.market.symbolData.name : "BLACK HEART").toUpperCase()}

--- a/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
@@ -97,7 +97,7 @@ const MainCard = (props: MainCardProps) => {
         </Link>
 
         <Column maxWidth="100%" ellipsis>
-          <div className="flex flex-row"><span className="pixel-heading-1 text-medium-gray pixel-heading-text">HOT</span><span className="pixel-heading-2 pixel-heading-text mt-[.2rem]">{SYMBOL_DATA.byName("fire")?.emoji}</span></div>
+          <div className="flex flex-row"><span className="pixel-heading-1 text-medium-gray pixel-heading-text">HOT</span><span>&nbsp;</span><span className="pixel-heading-2 pixel-heading-text mt-[.2rem]">{SYMBOL_DATA.byName("fire")?.emoji}</span></div>
           <div
             className="display-font-text ellipses font-forma-bold"
             title={(featured ? featured.market.symbolData.name : "BLACK HEART").toUpperCase()}

--- a/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
@@ -97,7 +97,13 @@ const MainCard = (props: MainCardProps) => {
         </Link>
 
         <Column maxWidth="100%" ellipsis>
-          <div className="flex flex-row"><span className="pixel-heading-1 text-medium-gray pixel-heading-text">HOT</span><span>&nbsp;</span><span className="pixel-heading-2 pixel-heading-text mt-[.2rem]">{SYMBOL_DATA.byName("fire")?.emoji}</span></div>
+          <div className="flex flex-row">
+            <span className="pixel-heading-1 text-medium-gray pixel-heading-text">HOT</span>
+            <span>&nbsp;</span>
+            <span className="pixel-heading-2 pixel-heading-text mt-[.2rem]">
+              {SYMBOL_DATA.byName("fire")?.emoji}
+            </span>
+          </div>
           <div
             className="display-font-text ellipses font-forma-bold"
             title={(featured ? featured.market.symbolData.name : "BLACK HEART").toUpperCase()}

--- a/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
@@ -13,7 +13,7 @@ import planetHome from "../../../../../../public/images/planet-home.png";
 import { emojiNamesToPath } from "utils/pathname-helpers";
 import { type HomePageProps } from "app/home/HomePage";
 import "./module.css";
-import { SYMBOL_DATA } from "@sdk/emoji_data";
+import { SYMBOL_EMOJI_DATA } from "@sdk/emoji_data";
 
 export interface MainCardProps {
   featured?: HomePageProps["featured"];
@@ -101,7 +101,7 @@ const MainCard = (props: MainCardProps) => {
             <span className="pixel-heading-1 text-medium-gray pixel-heading-text">HOT</span>
             <span>&nbsp;</span>
             <span className="pixel-heading-2 pixel-heading-text mt-[.2rem]">
-              {SYMBOL_DATA.byName("fire")?.emoji}
+              {SYMBOL_EMOJI_DATA.byName("fire")?.emoji}
             </span>
           </div>
           <div


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR aims to replace the confusing `00` on the home page.

Here are some options:

## Option A0 - 🔥

![image](https://github.com/user-attachments/assets/2b4305b1-8551-4ebe-8316-da3252d4a4f2)

Personal opinion: this one feels the most confusing to me. It seems like it's the market name to me.

## Option A1 - HOT 🔥

![image](https://github.com/user-attachments/assets/0aabaaf9-bcfc-4569-bf62-5577b37ecea9)

Personal opition: not a fan of the emoji, but this is the best compromise between having and emoji and clarity.

## Option A2 - HOT RIGHT NOW 🔥

![image](https://github.com/user-attachments/assets/4d695f02-b08e-4950-b37d-5539c7189d8f)

Personal opinion: maybe a bit too much.

## Option A3 - FEATURED 🔥

![image](https://github.com/user-attachments/assets/93cd80fb-1601-4b00-a2eb-ed051bbc1011)

Personal opition: just like option A1, but "featured" might give the false idea that the market is somehow officially endorsed.

## Option B1 - HOT

![image](https://github.com/user-attachments/assets/363c59e5-a39a-4f40-9d0c-8da59ac2755a)

Personal opinion: I like the look, very clean, but not very visible.

## Option B2 - HOT RIGHT NOW

![image](https://github.com/user-attachments/assets/63774649-ccae-4967-8a80-5f1887daf2a2)

Personal opinion: sometimes, you don't need a reason to hate something.

## Option B3 - FEATURED

![image](https://github.com/user-attachments/assets/9dd24b98-b674-4dfa-a438-7af76609d926)

Personal opinion: Looks the cleanest out of them all, but has the endorsement issue.
