### PR TITLE
[ECO-2307] Fix rewards probability calculations 

### DIFF
--- a/src/move/rewards/Move.toml
+++ b/src/move/rewards/Move.toml
@@ -15,4 +15,4 @@ rewards = "0xddd"
 authors = ["Econia Labs (developers@econialabs.com)"]
 name = "EmojicoinDotFunRewards"
 upgrade_policy = "compatible"
-version = "1.0.0"
+version = "1.0.1"

--- a/src/move/rewards/sources/emojicoin_dot_fun_rewards.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_rewards.move
@@ -138,8 +138,7 @@ module rewards::emojicoin_dot_fun_rewards {
             // `probability_per_octa_q64` is less than 1 in nominal probability, hence less than
             // `MAX_U64` when represented as a Q64-style `u128`. Since `integrator_fee_in_octas` is
             // also significantly less than `MAX_U64`, the product is less than `MAX_U128`.
-            let reward_threshold_q64 =
-                (probability_per_octa_q64) * (integrator_fee_in_octas as u128);
+            let reward_threshold_q64 = probability_per_octa_q64 * (integrator_fee_in_octas as u128);
 
             // Check if user is eligible for reward at current tier by checking if tier still has
             // rewards remaining, then compare random number to probability threshold. Since the


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Remove an erroneous shift when multiplying a `Q64` by a scalar.
1. Add clarifying comment about rewards probability per octa of fees paid.
1. Bump patch version.

# Testing

Published on testnet for further integration testing.
