### PR TITLE
[ECO-2311] Increase the max wait time for the frontend container being healthy and for the playwright setup timeout

### DIFF
--- a/src/typescript/frontend/tests/e2e/global.setup.ts
+++ b/src/typescript/frontend/tests/e2e/global.setup.ts
@@ -3,7 +3,7 @@ import { DockerTestHarness } from "../../../sdk/src/utils/test/docker/docker-tes
 
 setup("setup the Docker containers", async ({}) => {
   // Five minute timeout.
-  setup.setTimeout(300_000);
+  setup.setTimeout(600_000);
   const startDockerServices = process.env.APTOS_NETWORK === "local";
   if (startDockerServices) {
     await DockerTestHarness.run(true);

--- a/src/typescript/sdk/src/utils/test/docker/docker-test-harness.ts
+++ b/src/typescript/sdk/src/utils/test/docker/docker-test-harness.ts
@@ -23,7 +23,7 @@ const LOCAL_ENV_PATH = path.join(getGitRoot(), "src/docker", "example.local.env"
 const PRUNE_SCRIPT = path.join(getGitRoot(), "src/docker/utils", "prune.sh");
 
 const PING_STATE_INTERVAL = 200;
-const MAX_WAIT_TIME_SECONDS = 300;
+const MAX_WAIT_TIME_SECONDS = 600;
 const TMP_PID_FILE_PATH = path.join(os.tmpdir(), "emojicoin-e2e-process-id");
 
 async function isPrimaryContainerReady(name: ContainerName): Promise<boolean> {


### PR DESCRIPTION
# Description

Change it in both places, in playwright config setTimeout and in the `docker-test-harness.ts` file as well.

- [x] Change it in the Playwright set timeout function
- [x] Change it in the SDK `docker-test-harness.ts` function

# Testing

Tests will run in CI.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

