### PR TITLE
[ECO-2313] Fix input fields on market and pools pages

### DIFF
--- a/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
+++ b/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
@@ -1,5 +1,6 @@
 import Big from "big.js";
 import React, { useEffect, useState } from "react";
+import { isNumberInContstruction, numberOfDecimals, sanitizeNumber } from "@sdk/utils";
 
 const intToStr = (value: bigint, decimals?: number) =>
   (Number(value) / 10 ** (decimals ?? 0)).toString();
@@ -39,13 +40,13 @@ export const InputNumeric = ({
   }, [value, decimals]);
 
   const onChangeText = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/,/g, ".").replace(/^0+/, "0");
+    const value = sanitizeNumber(e.target.value);
 
-    if (!/^[0-9.]*$/.test(value)) {
+    if (!isNumberInContstruction(value)) {
       return;
     }
 
-    const decimalsInValue = /\./.test(value) ? value.split(".")[1].length : 0;
+    const decimalsInValue = numberOfDecimals(value);
     if (typeof decimals === "number" && decimalsInValue > decimals) {
       return;
     }

--- a/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
+++ b/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
@@ -1,6 +1,6 @@
 import Big from "big.js";
 import React, { useEffect, useState } from "react";
-import { isNumberInContstruction, numberOfDecimals, sanitizeNumber } from "@sdk/utils";
+import { isNumberInConstruction, numberOfDecimals, sanitizeNumber } from "@sdk/utils";
 
 const intToStr = (value: bigint, decimals?: number) =>
   (Number(value) / 10 ** (decimals ?? 0)).toString();
@@ -42,7 +42,7 @@ export const InputNumeric = ({
   const onChangeText = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = sanitizeNumber(e.target.value);
 
-    if (!isNumberInContstruction(value)) {
+    if (!isNumberInConstruction(value)) {
       return;
     }
 

--- a/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
+++ b/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
@@ -1,6 +1,6 @@
 import Big from "big.js";
 import React, { useEffect, useState } from "react";
-import { isNumberInConstruction, numberOfDecimals, sanitizeNumber } from "@sdk/utils";
+import { isNumberInConstruction, countDigitsAfterDecimal, sanitizeNumber } from "@sdk/utils";
 
 const intToStr = (value: bigint, decimals?: number) =>
   (Number(value) / 10 ** (decimals ?? 0)).toString();
@@ -46,7 +46,7 @@ export const InputNumeric = ({
       return;
     }
 
-    const decimalsInValue = numberOfDecimals(value);
+    const decimalsInValue = countDigitsAfterDecimal(value);
     if (typeof decimals === "number" && decimalsInValue > decimals) {
       return;
     }

--- a/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
+++ b/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
@@ -1,44 +1,71 @@
-import React from "react";
-import { Input } from "components/inputs/input";
-import { type InputProps } from "components/inputs/input/types";
+import Big from "big.js";
+import React, { useEffect, useState } from "react";
 
-const NUMBERS = new Set("0123456789");
+const intToStr = (value: bigint, decimals?: number) =>
+  (Number(value) / 10 ** (decimals ?? 0)).toString();
 
-export const InputNumeric = <E extends React.ElementType = "input">({
+const strToInt = (value: string, decimals?: number) => {
+  if (isNaN(parseFloat(value))) {
+    return 0n;
+  }
+  const res = Big(value.toString()).mul(Big(10 ** (decimals ?? 0)));
+  if (res < Big(1)) {
+    return 0n;
+  }
+  return BigInt(res.toString());
+};
+
+export const InputNumeric = ({
   onUserInput,
+  decimals,
+  value,
+  onSubmit,
   ...props
-}: InputProps<E> & { onUserInput: (value: string) => void }): JSX.Element => {
-  const [input, setInput] = React.useState("");
+}: {
+  className?: string;
+  onUserInput?: (value: bigint) => void;
+  onSubmit?: (value: bigint) => void;
+  decimals?: number;
+  disabled?: boolean;
+  value: bigint;
+}) => {
+  const [input, setInput] = useState(intToStr(value, decimals));
 
-  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value.replace(/,/g, ".").replace(/^0+/, "0");
+  useEffect(() => {
+    if (strToInt(input, decimals) != value) {
+      setInput(intToStr(value, decimals));
+    }
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [value, decimals]);
 
-    let hasDecimal = false;
-    let s = "";
-    for (const char of value) {
-      if (char === ".") {
-        if (!hasDecimal) {
-          s += char;
-        } else {
-          hasDecimal = true;
-        }
-      } else if (NUMBERS.has(char)) {
-        s += char;
-      }
+  const onChangeText = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/,/g, ".").replace(/^0+/, "0");
+
+    if (!/^[0-9.]*$/.test(value)) {
+      return;
     }
 
-    if (s === "" || !isNaN(Number(s))) {
-      setInput(s);
-      onUserInput(s);
+    const decimalsInValue = /\./.test(value) ? value.split(".")[1].length : 0;
+    if (typeof decimals === "number" && decimalsInValue > decimals) {
+      return;
+    }
+
+    setInput(value);
+    if (onUserInput) {
+      onUserInput(strToInt(value, decimals));
     }
   };
 
   return (
-    <Input
-      inputMode="decimal"
-      pattern="^\d*\.?\d*$"
-      onChange={(event) => onChangeText(event)}
+    <input
+      type="text"
+      onChange={(e) => onChangeText(e)}
       value={input}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && onSubmit) {
+          onSubmit(strToInt(input, decimals));
+        }
+      }}
       {...props}
     />
   );

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -166,7 +166,7 @@ export default function SwapComponent({
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     let value = e.target.value;
     value = value.replace(/^0*0\./, "0.");
-    let decimals = value.replace(/^.*\.(.*)/, "$1");
+    const decimals = value.replace(/^.*\.(.*)/, "$1");
     if (decimals.length > 8) {
       e.stopPropagation();
       return;

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -192,7 +192,7 @@ const Liquidity: React.FC<LiquidityProps> = ({ market, geoblocked }) => {
           onChange={(e) => {
             let value = e.target.value;
             value = value.replace(/^0*0\./, "0.");
-            let decimals = value.replace(/^.*\.(.*)/, "$1");
+            const decimals = value.replace(/^.*\.(.*)/, "$1");
             if (decimals.length > 8) {
               e.stopPropagation();
               return;
@@ -276,7 +276,7 @@ const Liquidity: React.FC<LiquidityProps> = ({ market, geoblocked }) => {
           onChange={(e) => {
             let value = e.target.value;
             value = value.replace(/^0*0\./, "0.");
-            let decimals = value.replace(/^.*\.(.*)/, "$1");
+            const decimals = value.replace(/^.*\.(.*)/, "$1");
             if (decimals.length > 8) {
               e.stopPropagation();
               return;

--- a/src/typescript/frontend/src/lib/utils/decimals.ts
+++ b/src/typescript/frontend/src/lib/utils/decimals.ts
@@ -24,7 +24,7 @@ const toActualCoinDecimals = ({ num }: { num: AnyNumberString }): bigint => {
   if (typeof num === "string" && isNaN(parseFloat(num))) {
     return 0n;
   }
-  let res = Big(num.toString()).mul(Big(10 ** DECIMALS));
+  const res = Big(num.toString()).mul(Big(10 ** DECIMALS));
   return BigInt(res.toString());
 };
 

--- a/src/typescript/frontend/src/lib/utils/decimals.ts
+++ b/src/typescript/frontend/src/lib/utils/decimals.ts
@@ -20,26 +20,12 @@ export const toCoinDecimalString = (num: AnyNumberString, displayDecimals?: numb
  * @example
  * 1 APT => 100000000
  */
-const toActualCoinDecimals = ({
-  num,
-  round,
-  decimals,
-}: {
-  num: AnyNumberString;
-  round?: number;
-  decimals?: number;
-}): string => {
+const toActualCoinDecimals = ({ num }: { num: AnyNumberString }): bigint => {
   if (typeof num === "string" && isNaN(parseFloat(num))) {
-    return "0";
+    return 0n;
   }
   let res = Big(num.toString()).mul(Big(10 ** DECIMALS));
-  if (typeof round !== "undefined") {
-    res = res.round(round);
-  }
-  if (typeof decimals !== "undefined") {
-    return res.toFixed(decimals).toString();
-  }
-  return res.toString();
+  return BigInt(res.toString());
 };
 
 /**
@@ -68,7 +54,10 @@ const toDisplayCoinDecimals = ({
     res = res.round(round);
   }
   if (typeof decimals !== "undefined") {
-    return res.toFixed(decimals).toString();
+    if (res < Big(1)) {
+      return res.toPrecision(decimals).replace(/\.?0+$/, "");
+    }
+    return res.toFixed(decimals).replace(/\.?0+$/, "");
   }
   return res.toString();
 };

--- a/src/typescript/frontend/tests/e2e/market-order.spec.ts
+++ b/src/typescript/frontend/tests/e2e/market-order.spec.ts
@@ -7,16 +7,16 @@ test("check sorting order", async ({ page }) => {
   const user = getFundedAccount("777");
   const rat = SYMBOL_EMOJI_DATA.byName("rat")!.emoji;
   const emojis = ["cat", "dog", "eagle", "sauropod"];
-  const markets = emojis.map(e => [rat, SYMBOL_EMOJI_DATA.byName(e)!.emoji])
+  const markets = emojis.map((e) => [rat, SYMBOL_EMOJI_DATA.byName(e)!.emoji]);
 
   const client = new EmojicoinClient();
 
   // Register markets.
   // They all start with rat to simplify the search.
   for (let i = 0; i < markets.length; i++) {
-    await client.register(user, markets[i]).then(res => res.handle);
-    const amount = 1n * ONE_APT_BIGINT / 100n * BigInt(10 ** (markets.length - i));
-    await client.buy(user, markets[i], amount).then(res => res.handle);
+    await client.register(user, markets[i]).then((res) => res.handle);
+    const amount = ((1n * ONE_APT_BIGINT) / 100n) * BigInt(10 ** (markets.length - i));
+    await client.buy(user, markets[i], amount).then((res) => res.handle);
   }
 
   await page.goto("/home");
@@ -51,14 +51,14 @@ test("check sorting order", async ({ page }) => {
   await filters.click();
 
   // Expect the sort by daily volume button to be visible.
-  const dailyVolume = page.locator('#emoji-grid-header').getByText('24h Volume');
+  const dailyVolume = page.locator("#emoji-grid-header").getByText("24h Volume");
   expect(dailyVolume).toBeVisible();
 
   // Sort by daily volume.
   await dailyVolume.click();
 
-  const names = emojis.map(e => `rat,${e}`);
-  const patterns = names.map(e => new RegExp(e));
+  const names = emojis.map((e) => `rat,${e}`);
+  const patterns = names.map((e) => new RegExp(e));
 
   // Expect the markets to be in order of daily volume.
   marketGridItems = page.locator("#emoji-grid a").getByTitle(/RAT,/, { exact: true });
@@ -68,7 +68,7 @@ test("check sorting order", async ({ page }) => {
   await filters.click();
 
   // Expect the sort by bump order button to be visible.
-  const bumpOrder = page.locator('#emoji-grid-header').getByText('Bump Order');
+  const bumpOrder = page.locator("#emoji-grid-header").getByText("Bump Order");
   expect(bumpOrder).toBeVisible();
 
   // Sort by bump order.

--- a/src/typescript/frontend/tests/e2e/search.spec.ts
+++ b/src/typescript/frontend/tests/e2e/search.spec.ts
@@ -6,7 +6,7 @@ import { sleep, SYMBOL_EMOJI_DATA } from "../../../sdk/src";
 test("check search results", async ({ page }) => {
   const user = getFundedAccount("666");
   const cat = SYMBOL_EMOJI_DATA.byName("cat")!.emoji;
-  const symbols = [cat,cat];
+  const symbols = [cat, cat];
 
   const client = new EmojicoinClient();
   await client.register(user, symbols).then((res) => res.handle);
@@ -32,11 +32,11 @@ test("check search results", async ({ page }) => {
   expect(emojiSearchCatButton).toBeVisible();
 
   // Search for the cat,cat market.
-  await emojiSearchCatButton.click({force: true});
+  await emojiSearchCatButton.click({ force: true });
 
   emojiSearchCatButton = picker.getByLabel(cat).first();
   expect(emojiSearchCatButton).toBeVisible();
-  await emojiSearchCatButton.click({force: true});
+  await emojiSearchCatButton.click({ force: true });
 
   // Click on the cat,cat market.
   const marketCard = page.getByText("cat,cat", { exact: true });

--- a/src/typescript/sdk/src/utils/index.ts
+++ b/src/typescript/sdk/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./hex";
 export * from "./misc";
 export * from "./type-tags";
 export * from "./compare-bigint";
+export * from "./validation";

--- a/src/typescript/sdk/src/utils/validation.ts
+++ b/src/typescript/sdk/src/utils/validation.ts
@@ -45,9 +45,9 @@ export const sanitizeNumber = (input: string) => {
 // It cannot be:
 // - 0.0.1
 //
-// Regex explenation:
+// Regex explanation:
 // n digits, then maybe (a dot, then maybe (m digits))
-export const isNumberInContstruction = (input: string) => /^[0-9]*(\.([0-9]*)?)?$/.test(input);
+export const isNumberInConstruction = (input: string) => /^[0-9]*(\.([0-9]*)?)?$/.test(input);
 
 // Return the number of decimals that input has.
 //

--- a/src/typescript/sdk/src/utils/validation.ts
+++ b/src/typescript/sdk/src/utils/validation.ts
@@ -1,6 +1,9 @@
-// Remove all useless leading zeros.
-//
-// In the case of 0.[0-9]+, the leading zero will not be removed.
+/**
+ * Removes all useless leading zeros.
+ * In the case of 0.[0-9]+, the leading zero will not be removed.
+ * @param {string} input - The string to process
+ * @returns {string} The processed string
+ */
 export const trimLeadingZeros = (input: string) => {
   // Replace all leading zeros with one zero
   input = input.replace(/^0+/, "0"); // The regex matches all leading 0s.
@@ -12,9 +15,12 @@ export const trimLeadingZeros = (input: string) => {
   return input;
 };
 
-// Remove all leading zeros and transform "," in ".".
-//
-// .[0-9]+ will be replaced with 0.[0-9]+
+/**
+ * Removes all leading zeros and transforms "," into ".".
+ * .[0-9]+ will be replaced with 0.[0-9]+
+ * @param {string} input - The string to process
+ * @returns {string} The processed string
+ */
 export const sanitizeNumber = (input: string) => {
   input = trimLeadingZeros(input.replace(/,/, "."));
   if (input.startsWith(".")) {
@@ -23,37 +29,34 @@ export const sanitizeNumber = (input: string) => {
   return input;
 };
 
-// Return true if input is a number in construction.
-//
-// This is used to allow the input of invalid numbers, if they are what needs
-// to be inputted to create a valid number.
-//
-// For example, in order to input 0.001, you first need to input 0, then 0. which
-// is an invalid number, but we do not want to forbid inputting that since it
-// will prevent the user from inputting 0.001.
-//
-// We define a number in construction as a number that leads to the construction
-// of a valid number.
-//
-// A number in construction can be:
-// - 0.1
-// - 0
-// - 0.000
-// - .0
-// - 0.
-//
-// It cannot be:
-// - 0.0.1
-//
-// Regex explanation:
-// n digits, then maybe (a dot, then maybe (m digits))
+/**
+ * Checks if the input is a number in construction.
+ *
+ * This facilitates using temporarily invalid numbers that will eventually be valid- aka, they are
+ * numbers in construction.
+ *
+ * For example, to input 0.001, you need to input "0", then "0." (invalid),
+ * which should be allowed to reach "0.001".
+ *
+ * Valid examples:
+ * - 0.1
+ * - 0
+ * - 0.000
+ * - .0
+ * - 0.
+ *
+ * Invalid examples:
+ * - 0.0.1
+ *
+ * @param {string} input - The string to test
+ * @returns {boolean} True if the input is a number in construction
+ */
 export const isNumberInConstruction = (input: string) => /^[0-9]*(\.([0-9]*)?)?$/.test(input);
 
-// Return the number of decimals that input has.
-//
-// If there is a dot, we count the number of elements past the dot, else we
-// return 0.
-//
-// The regex tests if there is a dot in the string.
-export const numberOfDecimals = (input: string) =>
+/**
+ * Counts the number of digits after the decimal point in a string number.
+ * @param {string} input - The numeric string to analyze (e.g., "123.456")
+ * @returns {number} The count of digits after the decimal point (e.g., "123.456" returns 3)
+ */
+export const countDigitsAfterDecimal = (input: string) =>
   /\./.test(input) ? input.split(".")[1].length : 0;

--- a/src/typescript/sdk/src/utils/validation.ts
+++ b/src/typescript/sdk/src/utils/validation.ts
@@ -1,0 +1,59 @@
+// Remove all useless leading zeros.
+//
+// In the case of 0.[0-9]+, the leading zero will not be removed.
+export const trimLeadingZeros = (input: string) => {
+   // Replace all leading zeros with one zero
+  input = input
+    .replace(/^0+/, "0"); // The regex matches all leading 0s.
+
+  if (input.startsWith("0") && !input.startsWith("0.") && input.length > 1) {
+    input = input.slice(1);
+  }
+
+  return input;
+}
+
+// Remove all leading zeros and transform "," in ".".
+//
+// .[0-9]+ will be replaced with 0.[0-9]+
+export const sanitizeNumber = (input: string) => {
+  input = trimLeadingZeros(input.replace(/,/, "."));
+  if (input.startsWith(".")) {
+    return `0${input}`;
+  }
+  return input;
+}
+
+// Return true if input is a number in construction.
+//
+// This is used to allow the input of invalid numbers, if they are what needs
+// to be inputted to create a valid number.
+//
+// For example, in order to input 0.001, you first need to input 0, then 0. which
+// is an invalid number, but we do not want to forbid inputting that since it
+// will prevent the user from inputting 0.001.
+//
+// We define a number in construction as a number that leads to the construction
+// of a valid number.
+//
+// A number in construction can be:
+// - 0.1
+// - 0
+// - 0.000
+// - .0
+// - 0.
+//
+// It cannot be:
+// - 0.0.1
+//
+// Regex explenation:
+// n digits, then maybe (a dot, then maybe (m digits))
+export const isNumberInContstruction = (input: string) => /^[0-9]*(\.([0-9]*)?)?$/.test(input);
+
+// Return the number of decimals that input has.
+//
+// If there is a dot, we count the number of elements past the dot, else we
+// return 0.
+//
+// The regex tests if there is a dot in the string.
+export const numberOfDecimals = (input: string) => /\./.test(input) ? input.split(".")[1].length : 0;

--- a/src/typescript/sdk/src/utils/validation.ts
+++ b/src/typescript/sdk/src/utils/validation.ts
@@ -2,16 +2,15 @@
 //
 // In the case of 0.[0-9]+, the leading zero will not be removed.
 export const trimLeadingZeros = (input: string) => {
-   // Replace all leading zeros with one zero
-  input = input
-    .replace(/^0+/, "0"); // The regex matches all leading 0s.
+  // Replace all leading zeros with one zero
+  input = input.replace(/^0+/, "0"); // The regex matches all leading 0s.
 
   if (input.startsWith("0") && !input.startsWith("0.") && input.length > 1) {
     input = input.slice(1);
   }
 
   return input;
-}
+};
 
 // Remove all leading zeros and transform "," in ".".
 //
@@ -22,7 +21,7 @@ export const sanitizeNumber = (input: string) => {
     return `0${input}`;
   }
   return input;
-}
+};
 
 // Return true if input is a number in construction.
 //
@@ -56,4 +55,5 @@ export const isNumberInContstruction = (input: string) => /^[0-9]*(\.([0-9]*)?)?
 // return 0.
 //
 // The regex tests if there is a dot in the string.
-export const numberOfDecimals = (input: string) => /\./.test(input) ? input.split(".")[1].length : 0;
+export const numberOfDecimals = (input: string) =>
+  /\./.test(input) ? input.split(".")[1].length : 0;

--- a/src/typescript/sdk/tests/unit/validation.test.ts
+++ b/src/typescript/sdk/tests/unit/validation.test.ts
@@ -40,7 +40,7 @@ describe("validation utility functions", () => {
     });
   });
 
-  it("should accurately test if number is in contruction", () => {
+  it("should accurately test if number is in construction", () => {
     const givenAndExpected: [string, boolean][] = [
       [".0", true],
       [".1", true],
@@ -58,7 +58,7 @@ describe("validation utility functions", () => {
     ];
 
     givenAndExpected.forEach(([given, expected]) => {
-      expect(validation.isNumberInContstruction(given)).toEqual(expected);
+      expect(validation.isNumberInConstruction(given)).toEqual(expected);
     });
   });
 

--- a/src/typescript/sdk/tests/unit/validation.test.ts
+++ b/src/typescript/sdk/tests/unit/validation.test.ts
@@ -1,0 +1,84 @@
+import * as validation from "../../src/utils/validation";
+
+describe("validation utility functions", () => {
+  it("should trim leading zeros", () => {
+    const givenAndExpected = [
+      ["00", "0"],
+      ["00000000", "0"],
+      ["01", "1"],
+      ["001", "1"],
+      ["000000001", "1"],
+      ["00.1", "0.1"],
+      ["00000000.1", "0.1"],
+      ["01.1", "1.1"],
+      ["001.1", "1.1"],
+      ["000000001.1", "1.1"],
+      ["0.1", "0.1"],
+      ["10", "10"],
+      ["100", "100"],
+    ];
+
+    givenAndExpected.forEach(([given, expected]) => {
+      expect(validation.trimLeadingZeros(given)).toEqual(expected);
+    });
+  });
+
+  it("should sanitize number", () => {
+    const givenAndExpected = [
+      [",1", "0.1"],
+      [",0", "0.0"],
+      ["0,1", "0.1"],
+      ["0,0", "0.0"],
+      [",100", "0.100"],
+      [",000", "0.000"],
+      ["0000,0", "0.0"],
+      ["0000,001", "0.001"],
+    ];
+
+    givenAndExpected.forEach(([given, expected]) => {
+      expect(validation.sanitizeNumber(given)).toEqual(expected);
+    });
+  });
+
+  it("should accurately test if number is in contruction", () => {
+    const givenAndExpected: [string, boolean][] = [
+      [".0", true],
+      [".1", true],
+      ["0.0", true],
+      ["0.1", true],
+      ["1.0", true],
+      ["1.1", true],
+      ["0", true],
+      ["0.000", true],
+      ["0.", true],
+      ["1.", true],
+      ["0.0.1", false],
+      ["0.abc", false],
+      ["abc.0", false],
+    ];
+
+    givenAndExpected.forEach(([given, expected]) => {
+      expect(validation.isNumberInContstruction(given)).toEqual(expected);
+    });
+  });
+
+  it("should accurately return the number of decimals", () => {
+    const givenAndExpected: [string, number][] = [
+      ["0", 0],
+      ["0.", 0],
+      [".0", 1],
+      ["0.0", 1],
+      ["0.00", 2],
+      ["00.00", 2],
+      ["000.00", 2],
+      ["0.0001", 4],
+      [".0001", 4],
+      ["54423536.23466245", 8],
+      [".23466245", 8],
+    ];
+
+    givenAndExpected.forEach(([given, expected]) => {
+      expect(validation.numberOfDecimals(given)).toEqual(expected);
+    });
+  });
+});

--- a/src/typescript/sdk/tests/unit/validation.test.ts
+++ b/src/typescript/sdk/tests/unit/validation.test.ts
@@ -78,7 +78,7 @@ describe("validation utility functions", () => {
     ];
 
     givenAndExpected.forEach(([given, expected]) => {
-      expect(validation.numberOfDecimals(given)).toEqual(expected);
+      expect(validation.countDigitsAfterDecimal(given)).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes input fields on the market and the pools pages.

Before, inputing small values would glitch the inputs.

Now, you can input values as small as 0.00000001, which is the smallest number you can trade.

# Testing

Input small values on the market and the pools pages in vercel.
