### PR TITLE
[ECO-2333] Fix VPN banner styling

### DIFF
--- a/src/typescript/example.env
+++ b/src/typescript/example.env
@@ -55,7 +55,7 @@ GALXE_CAMPAIGN_ID="<CAMPAIGN_ID>"
 ALLOWLISTER3K_URL="http://localhost:3000"
 
 # A list of ISO 3166-2 codes of countries and regions to geoblock.
-GEOBLOCKED="{\"countries\":[],\"regions\":[]}"
+GEOBLOCKED='{"countries":[],"regions":[]}'
 
 # The vpnapi.io API key.
 # If GEOBLOCKED is set and non-empty, this needs to be set as well.

--- a/src/typescript/frontend/src/components/geoblocking/index.tsx
+++ b/src/typescript/frontend/src/components/geoblocking/index.tsx
@@ -8,8 +8,8 @@ export const GeoblockedBanner: React.FC = () => (
     <Carousel>
       <div className="flex items-center justify-center min-w-[fit-content] gap-[16px]">
         <Text
-          className="h-[2.4rem] whitespace-nowrap uppercase"
-          lineHeight="2.4rem"
+          className="h-[2.6rem] whitespace-nowrap uppercase"
+          lineHeight="2.6rem"
           textScale="display6"
           color="black"
           textAlign="center"


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds a little bit of height to the geoblocking banner so that it can completly hide the price feed
