### PR TITLE
[ECO-2361] Add test page `/verify_status` for checking Galxe campaign, allowlisted, and geoblocked status

### DIFF
--- a/src/typescript/frontend/src/app/verify_status/page.tsx
+++ b/src/typescript/frontend/src/app/verify_status/page.tsx
@@ -1,0 +1,12 @@
+import VerifyStatusPage from "components/pages/verify_status/VerifyStatusPage";
+import { headers } from "next/headers";
+import { isUserGeoblocked } from "utils/geolocation";
+
+export const dynamic = "force-dynamic";
+
+const Verify = async () => {
+  const geoblocked = await isUserGeoblocked(headers().get("x-real-ip"));
+  return <VerifyStatusPage geoblocked={geoblocked} />;
+};
+
+export default Verify;

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -69,7 +69,7 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
                 </div>
                 <div>Galxe: {checkmarkOrX(galxe)}</div>
                 <div>Custom allowlist: {checkmarkOrX(customAllowlisted)}</div>
-                <div>Not geoblocked: {checkmarkOrX(geoblocked)}</div>
+                <div>Passes geoblocking: {checkmarkOrX(geoblocked)}</div>
                 <a
                   className="underline text-ec-blue"
                   href={process.env.NEXT_PUBLIC_GALXE_CAMPAIGN_REDIRECT}

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -9,6 +9,10 @@ import { standardizeAddress, truncateAddress } from "@sdk/utils";
 import { getVerificationStatus } from "./get-verification-status";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 
+const checkmarkOrX = (bool: boolean) => {
+  return <span className="text-lg">{bool ? "✅" : "❌"} </span>;
+};
+
 export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked }) => {
   const { account } = useAptos();
   const { connected, disconnect } = useWallet();
@@ -63,9 +67,9 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
                     {account && <span>`0x${truncateAddress(account.address).substring(2)}`</span>}
                   </span>
                 </div>
-                <div>Galxe: {galxe ? "✅" : "❌"}</div>
-                <div>Custom allowlist: {customAllowlisted ? "✅" : "❌"}</div>
-                <div>Not geoblocked: {geoblocked ? "✅" : "❌"}</div>
+                <div>Galxe: {checkmarkOrX(galxe)}</div>
+                <div>Custom allowlist: {checkmarkOrX(customAllowlisted)}</div>
+                <div>Not geoblocked: {checkmarkOrX(geoblocked)}</div>
                 <a
                   className="underline text-ec-blue"
                   href="NEXT_PUBLIC_GALXE_CAMPAIGN_REDIRECT"

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
+import { useAptos } from "context/wallet-context/AptosContextProvider";
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { isInGalxeCampaign, isOnCustomAllowlist } from "lib/utils/allowlist";
+import { standardizeAddress } from "@sdk/utils";
+
+export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked }) => {
+  const { account } = useAptos();
+  const { connected, disconnect } = useWallet();
+  const [galxe, setGalxe] = useState(false);
+  const [customAllowlisted, setCustomAllowlisted] = useState(false);
+
+  useEffect(() => {
+    if (!account || !connected) {
+      setGalxe(false);
+      setCustomAllowlisted(false);
+    } else {
+      const address = standardizeAddress(account.address);
+      isInGalxeCampaign(address).then((r) => setGalxe(r));
+      isOnCustomAllowlist(address).then((r) => setCustomAllowlisted(r));
+    }
+  }, [account, connected]);
+
+  return (
+    <>
+      <div
+        className="absolute top-0 left-0 w-[100dvw] h-[100dvh] bg-black z-50 overflow-hidden grid"
+        style={{
+          gridTemplateRows: "19fr 1fr",
+        }}
+      >
+        <div className="flex items-center justify-center w-full h-full">
+          <div className="flex flex-col justify-begin uppercase text-ec-blue gap-4 text-2xl">
+            {connected && (
+              <motion.div
+                animate={{ x: 0, y: -60 }}
+                initial={{ x: 2000, y: -60 }}
+                className="absolute flex flex-row px-2.5 hover:cursor-pointer min-w-[12ch] top-[50%]"
+                onClick={() => {
+                  disconnect();
+                }}
+                transition={{
+                  type: "just",
+                  duration: 0.3,
+                }}
+              >
+                <span>{"<<"}&nbsp;</span>
+                <span>Disconnect Wallet</span>
+              </motion.div>
+            )}
+            <ButtonWithConnectWalletFallback geoblocked={false} arrow={false}>
+              <div className="flex flex-col uppercase mt-[8ch] gap-1">
+                <div>Galxe: {galxe ? "✅" : "❌"}</div>
+                <div>Custom allowlist: {customAllowlisted ? "✅" : "❌"}</div>
+                <div>Not geoblocked: {geoblocked ? "✅" : "❌"}</div>
+              </div>
+            </ButtonWithConnectWalletFallback>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ClientVerifyPage;

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { standardizeAddress, truncateAddress } from "@sdk/utils";
 import { getVerificationStatus } from "./get-verification-status";
+import { EXTERNAL_LINK_PROPS } from "components/link";
 
 export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked }) => {
   const { account } = useAptos();
@@ -60,6 +61,13 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
                 <div>Galxe: {galxe ? "✅" : "❌"}</div>
                 <div>Custom allowlist: {customAllowlisted ? "✅" : "❌"}</div>
                 <div>Not geoblocked: {geoblocked ? "✅" : "❌"}</div>
+                <a
+                  className="underline text-ec-blue"
+                  href="NEXT_PUBLIC_GALXE_CAMPAIGN_REDIRECT"
+                  {...EXTERNAL_LINK_PROPS}
+                >
+                  Galxe Campaign
+                </a>
               </div>
             </ButtonWithConnectWalletFallback>
           </div>

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -5,8 +5,8 @@ import ButtonWithConnectWalletFallback from "components/header/wallet-button/Con
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { isInGalxeCampaign, isOnCustomAllowlist } from "lib/utils/allowlist";
 import { standardizeAddress } from "@sdk/utils";
+import { getVerificationStatus } from "./get-verification-status";
 
 export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked }) => {
   const { account } = useAptos();
@@ -20,8 +20,10 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
       setCustomAllowlisted(false);
     } else {
       const address = standardizeAddress(account.address);
-      isInGalxeCampaign(address).then((r) => setGalxe(r));
-      isOnCustomAllowlist(address).then((r) => setCustomAllowlisted(r));
+      getVerificationStatus(address).then(({ galxe, customAllowlisted }) => {
+        setGalxe(galxe);
+        setCustomAllowlisted(customAllowlisted);
+      });
     }
   }, [account, connected]);
 

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -64,7 +64,7 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
                 <div>
                   Wallet address:{" "}
                   <span className="text-warning">
-                    {account && <span>`0x${truncateAddress(account.address).substring(2)}`</span>}
+                    {account && <span>{`0x${truncateAddress(account.address).substring(2)}`}</span>}
                   </span>
                 </div>
                 <div>Galxe: {checkmarkOrX(galxe)}</div>
@@ -72,7 +72,7 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
                 <div>Not geoblocked: {checkmarkOrX(geoblocked)}</div>
                 <a
                   className="underline text-ec-blue"
-                  href="NEXT_PUBLIC_GALXE_CAMPAIGN_REDIRECT"
+                  href={process.env.NEXT_PUBLIC_GALXE_CAMPAIGN_REDIRECT}
                   {...EXTERNAL_LINK_PROPS}
                 >
                   Galxe Campaign

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -56,8 +56,13 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
               </motion.div>
             )}
             <ButtonWithConnectWalletFallback geoblocked={false} arrow={false}>
-              <div className="flex flex-col uppercase mt-[16ch] gap-1">
-                <div>Wallet address: {account && truncateAddress(account.address)}</div>
+              <div className="flex flex-col uppercase mt-[20ch] gap-1">
+                <div>
+                  Wallet address:{" "}
+                  <span className="text-warning">
+                    {account && <span>`0x${truncateAddress(account.address).substring(2)}`</span>}
+                  </span>
+                </div>
                 <div>Galxe: {galxe ? "✅" : "❌"}</div>
                 <div>Custom allowlist: {customAllowlisted ? "✅" : "❌"}</div>
                 <div>Not geoblocked: {geoblocked ? "✅" : "❌"}</div>

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -5,7 +5,7 @@ import ButtonWithConnectWalletFallback from "components/header/wallet-button/Con
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { standardizeAddress } from "@sdk/utils";
+import { standardizeAddress, truncateAddress } from "@sdk/utils";
 import { getVerificationStatus } from "./get-verification-status";
 
 export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked }) => {
@@ -55,7 +55,8 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
               </motion.div>
             )}
             <ButtonWithConnectWalletFallback geoblocked={false} arrow={false}>
-              <div className="flex flex-col uppercase mt-[8ch] gap-1">
+              <div className="flex flex-col uppercase mt-[16ch] gap-1">
+                <div>Wallet address: {account && truncateAddress(account.address)}</div>
                 <div>Galxe: {galxe ? "✅" : "❌"}</div>
                 <div>Custom allowlist: {customAllowlisted ? "✅" : "❌"}</div>
                 <div>Not geoblocked: {geoblocked ? "✅" : "❌"}</div>

--- a/src/typescript/frontend/src/components/pages/verify_status/get-verification-status.ts
+++ b/src/typescript/frontend/src/components/pages/verify_status/get-verification-status.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { isInGalxeCampaign, isOnCustomAllowlist } from "lib/utils/allowlist";
+
+export async function getVerificationStatus(address: `0x${string}`) {
+  const [galxe, customAllowlisted] = await Promise.all([
+    isInGalxeCampaign(address),
+    isOnCustomAllowlist(address),
+  ]);
+  return {
+    galxe,
+    customAllowlisted,
+  };
+}

--- a/src/typescript/frontend/src/lib/utils/allowlist.ts
+++ b/src/typescript/frontend/src/lib/utils/allowlist.ts
@@ -10,24 +10,19 @@ export const GALXE_URL = "https://graphigo.prd.galaxy.eco/query";
 // If IS_ALLOWLIST_ENABLED is not truthy, the function returns true.
 //
 // The address can be provided either as "0xabc" or directly "abc".
-export async function isAllowListed(address: string): Promise<boolean> {
+export async function isAllowListed(addressIn: string): Promise<boolean> {
   if (!IS_ALLOWLIST_ENABLED) {
     return true;
   }
 
-  if (!address.startsWith("0x")) {
-    address = `0x${address}`;
-  }
+  const address = addressIn.startsWith("0x")
+    ? (addressIn as `0x${string}`)
+    : (`0x${addressIn}` as const);
 
-  if (ALLOWLISTER3K_URL !== undefined) {
-    const condition = await fetch(`${ALLOWLISTER3K_URL}/${address}`)
-      .then((r) => r.text())
-      .then((data) => data === "true");
-    if (condition) {
-      return true;
-    }
-  }
+  return isInGalxeCampaign(address) || isOnCustomAllowlist(address);
+}
 
+export const isInGalxeCampaign = async (address: `0x${string}`): Promise<boolean> => {
   if (GALXE_CAMPAIGN_ID !== undefined) {
     const condition = await fetch(GALXE_URL, {
       method: "POST",
@@ -57,4 +52,17 @@ export async function isAllowListed(address: string): Promise<boolean> {
   }
 
   return false;
-}
+};
+
+export const isOnCustomAllowlist = async (address: `0x${string}`): Promise<boolean> => {
+  if (ALLOWLISTER3K_URL !== undefined) {
+    const condition = await fetch(`${ALLOWLISTER3K_URL}/${address}`)
+      .then((r) => r.text())
+      .then((data) => data === "true");
+    if (condition) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -16,7 +16,7 @@ export default async function middleware(request: NextRequest) {
     pathname === "/icon.png" ||
     pathname === "/test" ||
     pathname === "/geolocation" ||
-    pathname === "verify_status"
+    pathname === "/verify_status"
   ) {
     return NextResponse.next();
   }

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -15,7 +15,8 @@ export default async function middleware(request: NextRequest) {
     pathname === "/webclip.png" ||
     pathname === "/icon.png" ||
     pathname === "/test" ||
-    pathname === "/geolocation"
+    pathname === "/geolocation" ||
+    pathname === "verify_status"
   ) {
     return NextResponse.next();
   }


### PR DESCRIPTION
# Description

To easily test the verification status of individual allowlists (galxe campaign, allowlister3000, geoblocked), we need a custom page that displays the value of all three depending on the wallet account address and user's IP address.

- [x] Check galxe campaign status
- [x] Check allowlister3000 status
- [x] Check geoblocked status


Example:
![image](https://github.com/user-attachments/assets/0383c417-7b14-426b-9572-9c7c83a394f2)

# Testing

Manual testing.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
