### PR TITLE
[ECO-2369] Remove frontend console errors

### DIFF
--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -67,7 +67,7 @@ const configurationData: DatafeedConfiguration = {
  * @param props
  * @returns
  */
-export const Chart = async (props: ChartContainerProps) => {
+export const Chart = (props: ChartContainerProps) => {
   const tvWidget = useRef<IChartingLibraryWidget>();
   const ref = useRef<HTMLDivElement>(null);
   const router = useRouter();

--- a/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
+++ b/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
@@ -177,7 +177,7 @@ export default function EmojiPicker(
     }
   }, []);
 
-  const { drag, ...propsRest } = props;
+  const { drag, filterEmojis, ...propsRest } = props;
 
   return (
     <Suspense fallback={<div>Loading...</div>}>
@@ -200,7 +200,7 @@ export default function EmojiPicker(
             theme="dark"
             perLine={8}
             exceptEmojis={[]}
-            filterEmojis={props.filterEmojis}
+            filterEmojis={filterEmojis}
             onEmojiSelect={(v: EmojiSelectorData) => {
               const newEmoji = unifiedCodepointsToEmoji(v.unified as `${string}-${string}`);
               insertEmojiTextInput([newEmoji]);


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes a couple of frontend errors that appeared in the console and made it very annoying to actually read anything there:

- `Chart` (which is a client component) was `async`, now it's not.
- `filterEmojis` was accidentally passed to a `div` when it shouldn't have been, now it's not.

# Testing

See vercel, open console.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
