### PR TITLE
[ECO-2256] Fix line break on market with three emojis

### DIFF
--- a/src/typescript/frontend/src/app/global.css
+++ b/src/typescript/frontend/src/app/global.css
@@ -27,36 +27,6 @@
   --error: #f3263e;
 }
 
-.med-pixel-text {
-  font-size: 20px !important;
-  line-height: 25px;
-  font-family: var(--font-pixelar) !important;
-}
-
-@media screen and (min-width: 768px) {
-  .med-pixel-text {
-    font-size: 22px !important;
-    line-height: 27px;
-    font-family: var(--font-pixelar) !important;
-  }
-}
-
-@media screen and (min-width: 1024px) {
-  .med-pixel-text {
-    font-size: 24px !important;
-    line-height: 30px;
-    font-family: var(--font-pixelar) !important;
-  }
-}
-
-@media screen and (min-width: 1440px) {
-  .med-pixel-text {
-    font-size: 32px !important;
-    line-height: 40px;
-    font-family: var(--font-pixelar) !important;
-  }
-}
-
 .med-pixel-search {
   width: 18px;
 }

--- a/src/typescript/frontend/src/app/global.css
+++ b/src/typescript/frontend/src/app/global.css
@@ -30,14 +30,14 @@
 .med-pixel-text {
   font-size: 20px !important;
   line-height: 25px;
-  font-family: var(--font-pixelar);
+  font-family: var(--font-pixelar) !important;
 }
 
 @media screen and (min-width: 768px) {
   .med-pixel-text {
     font-size: 22px !important;
     line-height: 27px;
-    font-family: var(--font-pixelar);
+    font-family: var(--font-pixelar) !important;
   }
 }
 
@@ -45,7 +45,7 @@
   .med-pixel-text {
     font-size: 24px !important;
     line-height: 30px;
-    font-family: var(--font-pixelar);
+    font-family: var(--font-pixelar) !important;
   }
 }
 
@@ -53,7 +53,7 @@
   .med-pixel-text {
     font-size: 32px !important;
     line-height: 40px;
-    font-family: var(--font-pixelar);
+    font-family: var(--font-pixelar) !important;
   }
 }
 

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
@@ -215,7 +215,7 @@ const TableCard = ({
               <Arrow className="w-[21px] !fill-current text-dark-gray group-hover:text-ec-blue transition-all" />
             </Flex>
 
-            <Text textScale="pixelHeading1" textAlign="center" mb="22px">
+            <Text textScale="pixelHeading1" textAlign="center" mb="22px" className="text-nowrap">
               <span>{symbol}</span>
             </Text>
             <Text

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
@@ -30,6 +30,10 @@ import LinkOrAnimationTrigger from "./LinkOrAnimationTrigger";
 import { isMarketStateModel } from "@sdk/indexer-v2/types";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import "./module.css";
+import { type SymbolEmojiData } from "@sdk/emoji_data";
+
+const getFontSize = (emojis: SymbolEmojiData[]) =>
+  emojis.length <= 2 ? ("pixel-heading-1" as const) : ("pixel-heading-1b" as const);
 
 const TableCard = ({
   index,
@@ -215,9 +219,7 @@ const TableCard = ({
               <Arrow className="w-[21px] !fill-current text-dark-gray group-hover:text-ec-blue transition-all" />
             </Flex>
 
-            <div
-              className={`pixel-heading-${emojis.length <= 2 ? "1" : "1b"} text-center mb-[22px] text-nowrap`}
-            >
+            <div className={`${getFontSize(emojis)} text-center mb-[22px] text-nowrap`}>
               <span>{symbol}</span>
             </div>
             <Text

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
@@ -215,9 +215,11 @@ const TableCard = ({
               <Arrow className="w-[21px] !fill-current text-dark-gray group-hover:text-ec-blue transition-all" />
             </Flex>
 
-            <Text textScale="pixelHeading1" textAlign="center" mb="22px" className="text-nowrap">
+            <div
+              className={`pixel-heading-${emojis.length <= 2 ? "1" : "1b"} text-center mb-[22px] text-nowrap`}
+            >
               <span>{symbol}</span>
-            </Text>
+            </div>
             <Text
               textScale="display4"
               textTransform="uppercase"

--- a/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-header/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-header/index.tsx
@@ -70,7 +70,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({ item, isLast, onClick }) => {
           </Info>
         )}
         <Text
-          textScale={{ _: "bodySmall", tablet: "bodyLarge" }}
+          textScale="bodyLarge"
           textTransform="uppercase"
           color="econiaBlue"
           $fontWeight="regular"

--- a/src/typescript/frontend/src/components/selects/dropdown-menu/index.tsx
+++ b/src/typescript/frontend/src/components/selects/dropdown-menu/index.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-
 import { DropdownMenuWrapper } from "./styled";
 import { DropdownMenuItem } from "./components";
-
 import { type DropdownMenuProps } from "../types";
 import { DropdownMenuInner, StyledDropdownMenuClose } from "./components/dropdown-menu-item/styled";
+import "./module.css";
 
 export const DropdownMenu: React.FC<DropdownMenuProps> = ({
   onClick,

--- a/src/typescript/frontend/src/components/selects/dropdown-menu/module.css
+++ b/src/typescript/frontend/src/components/selects/dropdown-menu/module.css
@@ -1,0 +1,29 @@
+.med-pixel-text {
+  font-size: 20px !important;
+  line-height: 25px;
+  font-family: var(--font-pixelar) !important;
+}
+
+@media screen and (min-width: 768px) {
+  .med-pixel-text {
+    font-size: 22px !important;
+    line-height: 27px;
+    font-family: var(--font-pixelar) !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .med-pixel-text {
+    font-size: 24px !important;
+    line-height: 30px;
+    font-family: var(--font-pixelar) !important;
+  }
+}
+
+@media screen and (min-width: 1440px) {
+  .med-pixel-text {
+    font-size: 32px !important;
+    line-height: 40px;
+    font-family: var(--font-pixelar) !important;
+  }
+}

--- a/src/typescript/frontend/src/components/table/index.tsx
+++ b/src/typescript/frontend/src/components/table/index.tsx
@@ -60,6 +60,7 @@ export const Th = styled.td<TdProps>`
   z-index: 1;
   text-transform: uppercase;
   border-bottom: 1px solid ${({ theme }) => theme.colors.darkGray};
+  align-content: center;
 
   &:nth-child(1) {
     ${ThInner} {

--- a/src/typescript/frontend/src/components/text/index.tsx
+++ b/src/typescript/frontend/src/components/text/index.tsx
@@ -26,7 +26,6 @@ export const Text = styled.p.attrs<TextProps>(({ textScale = "display6" }) => ({
   textScale,
 }))`
   color: ${({ theme, color }) => (color ? theme.colors[color] : theme.colors.white)};
-  font-family: ${({ theme }) => theme.fonts.forma};
   text-transform: ${({ textTransform }) => textTransform};
 
   ${({ textScale }) => textScale && textStyles(textScale as keyof typeof scales)}
@@ -39,15 +38,6 @@ export const Text = styled.p.attrs<TextProps>(({ textScale = "display6" }) => ({
   ${layout}
   ${opacity}
   ${flexbox}
-
-  ${({ className }) =>
-    className &&
-    css`
-      &.${className} {
-        font-family: inherit;
-        font-size: inherit;
-      }
-    `}
 `;
 
 export default Text;

--- a/src/typescript/frontend/src/components/text/theme.ts
+++ b/src/typescript/frontend/src/components/text/theme.ts
@@ -46,6 +46,11 @@ export const textStyles = (k: keyof typeof scales) => {
       line-height: 48px;
       font-family: var(--font-pixelar);
     `,
+    [scales.pixelHeading1b]: `
+      font-size: 52px;
+      line-height: 48px;
+      font-family: var(--font-pixelar);
+    `,
     [scales.pixelHeading2]: `
       font-size: 40px;
       line-height: 50px;

--- a/src/typescript/frontend/src/components/text/theme.ts
+++ b/src/typescript/frontend/src/components/text/theme.ts
@@ -29,14 +29,17 @@ export const textStyles = (k: keyof typeof scales) => {
     [scales.display4]: `
       font-size: 28px;
       line-height: 48px;
+      font-family: var(--font-forma);
     `,
     [scales.display5]: `
       font-size: 20px;
       line-height: 48px;
+      font-family: var(--font-forma);
     `,
     [scales.display6]: `
       font-size: 15px;
       line-height: 20px;
+      font-family: var(--font-forma);
     `,
     [scales.pixelHeading1]: `
       font-size: 64px;
@@ -71,14 +74,17 @@ export const textStyles = (k: keyof typeof scales) => {
     [scales.bodyLarge]: `
       font-size: 16px;
       line-height: 18px;
+      font-family: var(--font-forma);
     `,
     [scales.bodySmall]: `
       font-size: 12px;
       line-height: 18px;
+      font-family: var(--font-forma);
     `,
     [scales.bodyXSmall]: `
       font-size: 10px;
       line-height: 18px;
+      font-family: var(--font-forma);
     `,
   };
 

--- a/src/typescript/frontend/src/components/text/types.ts
+++ b/src/typescript/frontend/src/components/text/types.ts
@@ -23,6 +23,7 @@ export const scales = {
   display5: "display5",
   display6: "display6",
   pixelHeading1: "pixelHeading1",
+  pixelHeading1b: "pixelHeading1b",
   pixelHeading2: "pixelHeading2",
   pixelHeading3: "pixelHeading3",
   pixelHeading4: "pixelHeading4",

--- a/src/typescript/frontend/tailwind.config.js
+++ b/src/typescript/frontend/tailwind.config.js
@@ -113,14 +113,17 @@ module.exports = {
           lineHeight: "65px",
         },
         ".display-4": {
+          fontFamily: "var(--font-forma)",
           fontSize: "28px",
           lineHeight: "48px",
         },
         ".display-5": {
+          fontFamily: "var(--font-forma)",
           fontSize: "20px",
           lineHeight: "48px",
         },
         ".display-6": {
+          fontFamily: "var(--font-forma)",
           fontSize: "15px",
           lineHeight: "20px",
         },
@@ -160,14 +163,17 @@ module.exports = {
           lineHeight: "18px",
         },
         ".body-lg": {
+          fontFamily: "var(--font-forma)",
           fontSize: "16px",
           lineHeight: "18px",
         },
         ".body-sm": {
+          fontFamily: "var(--font-forma)",
           fontSize: "12px",
           lineHeight: "18px",
         },
         ".body-xs": {
+          fontFamily: "var(--font-forma)",
           fontSize: "10px",
           lineHeight: "18px",
         },

--- a/src/typescript/frontend/tailwind.config.js
+++ b/src/typescript/frontend/tailwind.config.js
@@ -132,6 +132,11 @@ module.exports = {
           fontSize: "64px",
           lineHeight: "48px",
         },
+        ".pixel-heading-1b": {
+          fontFamily: "var(--font-pixelar)",
+          fontSize: "52px",
+          lineHeight: "48px",
+        },
         ".pixel-heading-2": {
           fontFamily: "var(--font-pixelar)",
           fontSize: "40px",

--- a/src/typescript/frontend/tailwind.config.js
+++ b/src/typescript/frontend/tailwind.config.js
@@ -10,10 +10,6 @@ import { fontFamily } from "tailwindcss/defaultTheme";
 
 module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
-  safelist: [
-    // Force tailwind to include `pixel-heading-1`, `pixel-heading-1b` in the build output.
-    /^pixel-heading-\d\w?$/
-  ],
   theme: {
     extend: {
       typography: {},

--- a/src/typescript/frontend/tailwind.config.js
+++ b/src/typescript/frontend/tailwind.config.js
@@ -10,6 +10,10 @@ import { fontFamily } from "tailwindcss/defaultTheme";
 
 module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
+  safelist: [
+    // Force tailwind to include `pixel-heading-1`, `pixel-heading-1b` in the build output.
+    /^pixel-heading-\d\w?$/
+  ],
   theme: {
     extend: {
       typography: {},


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes a bug where a line would break on the home page if a market had three emojis in its symbol.

This PR also adds the possibility to use `className` with the `Text` component and makes the `Text` component code more clear.

# Testing

See vercel (currently there is such a market on page 3 but this might change when you review).

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
