### PR TITLE
[ECO-2371] Fix CI task name

### DIFF
--- a/.github/workflows/sdk-tests.yaml
+++ b/.github/workflows/sdk-tests.yaml
@@ -24,7 +24,7 @@ jobs:
           0xf000d910b99722d201c6cf88eb7d1112b43475b9765b118f289b5d65d919000d
         PUBLISHER_PRIVATE_KEY: >-
           0xeaa964d1353b075ac63b0c5a0c1e92aa93355be1402f6077581e37e2a846105e
-      name: 'Run Playwright tests'
+      name: 'Run SDK tests'
       run: 'pnpm run test:sdk'
     - if: 'failure()'
       name: 'Print local testnet logs on failure'


### PR DESCRIPTION
# Description

This PR fixes a copy pasta error in the CI task names.

