### PR TITLE
[ECO-2372] Fix candlestick chart issues

### DIFF
--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -20,7 +20,7 @@ import {
   type Timezone,
   widget,
 } from "@static/charting_library";
-import { getClientTimezone } from "lib/chart-utils";
+import { getClientTimezone, hasTradingActivity } from "lib/chart-utils";
 import { type ChartContainerProps } from "./types";
 import { useRouter } from "next/navigation";
 import { ROUTES } from "router/routes";
@@ -179,12 +179,13 @@ export const Chart = (props: ChartContainerProps) => {
             // Convert the market view data to `latestBar[]` and set the latest bars in our EventStore to those values.
             const latestBars = marketToLatestBars(marketResource);
             const marketEmojiData = toMarketEmojiData(marketResource.metadata.emojiBytes);
+            const symbolEmojis = marketEmojiData.emojis.map((e) => e.emoji);
             const marketMetadata: MarketMetadataModel = {
               marketID: marketResource.metadata.marketID,
               time: 0n,
               marketNonce: marketResource.sequenceInfo.nonce,
               trigger: Trigger.PackagePublication, // Make up some bunk trigger, since it should be clear it's made up.
-              symbolEmojis: marketEmojiData.emojis.map((e) => e.emoji),
+              symbolEmojis,
               marketAddress: marketResource.metadata.marketAddress,
               ...marketEmojiData,
             };
@@ -209,9 +210,11 @@ export const Chart = (props: ChartContainerProps) => {
           // some visual inconsistencies in the chart.
           const bars: Bar[] = data.reduce((acc: Bar[], event) => {
             const bar = toBar(event);
-            if (bar.time >= from * 1000 && bar.time <= to * 1000) {
-              if (acc.at(-1)) {
-                bar.open = acc.at(-1)!.close;
+            const inTimeRange = bar.time >= from * 1000 && bar.time <= to * 1000;
+            if (inTimeRange && hasTradingActivity(bar)) {
+              const prev = acc.at(-1);
+              if (prev) {
+                bar.open = prev.close;
               }
               acc.push(bar);
             }
@@ -220,9 +223,23 @@ export const Chart = (props: ChartContainerProps) => {
 
           // Push the latest bar to the bars array if it exists and update its `open` value to be the previous bar's
           // `close` if it's not the first/only bar.
+          // This logic mirrors what we use in `createBarFrom[Swap|PeriodicState]` but we need it here because we
+          // update the latest bar based on the market view every time we fetch with `getBars`, not just when a new
+          // event comes in.
           if (latestBar) {
-            if (bars.at(-1)) {
-              latestBar.open = bars.at(-1)!.close;
+            const secondLatestBar = bars.at(-1);
+            if (secondLatestBar) {
+              // If the latest bar has no trading activity, set all of its fields to the previous bar's close.
+              if (!hasTradingActivity(latestBar)) {
+                latestBar.high = secondLatestBar.close;
+                latestBar.low = secondLatestBar.close;
+                latestBar.close = secondLatestBar.close;
+              }
+              if (secondLatestBar.close !== 0) {
+                latestBar.open = secondLatestBar.close;
+              } else {
+                latestBar.open = latestBar.close;
+              }
             }
             bars.push(latestBar);
           }

--- a/src/typescript/frontend/src/lib/chart-utils/index.ts
+++ b/src/typescript/frontend/src/lib/chart-utils/index.ts
@@ -1,5 +1,8 @@
 // cspell:word Kolkata
 // cspell:word Fakaofo
+
+import { type Bar } from "@static/charting_library/datafeed-api";
+
 /**
  * Retrieves the client's timezone based on the current system time offset.
  *
@@ -70,3 +73,6 @@ export function getClientTimezone() {
   }
   return "Etc/UTC";
 }
+
+export const hasTradingActivity = (bar: Bar) =>
+  [bar.open, bar.high, bar.low, bar.close].some((price) => price !== 0);

--- a/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
+++ b/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
@@ -75,9 +75,8 @@ export const createBarFromSwap = (
   const periodStartTime = getPeriodStartTimeFromTime(market.time, period);
   return {
     time: Number(periodStartTime / 1000n),
-    // Only use previousClose if it's a truthy value. Without this contingency, any time a new bar
-    // is created and the previous bar has no activity, the new bar will be a huge green candlestick
-    // starting with an open price of `0`.
+    // Only use previousClose if it's a truthy value, otherwise, new bars that follow bars with no
+    // trading activity will appear as a huge green candlestick because their open price is `0`.
     open: previousClose ? previousClose : price,
     high: price,
     low: price,
@@ -97,9 +96,8 @@ export const createBarFromPeriodicState = (
   const price = q64ToBig(periodicState.closePriceQ64).toNumber();
   return {
     time: periodEnumToRawDuration(period) / 1000,
-    // Only use previousClose if it's a truthy value. Without this contingency, any time a new bar
-    // is created and the previous bar has no activity, the new bar will be a huge green candlestick
-    // starting with an open price of `0`.
+    // Only use previousClose if it's a truthy value, otherwise, new bars that follow bars with no
+    // trading activity will appear as a huge green candlestick because their open price is `0`.
     open: previousClose ? previousClose : price,
     high: price,
     low: price,

--- a/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
+++ b/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
@@ -59,7 +59,7 @@ export const toBar = (event: PeriodicStateEventModel): Bar => ({
   high: q64ToBig(event.periodicState.highPriceQ64).toNumber(),
   low: q64ToBig(event.periodicState.lowPriceQ64).toNumber(),
   close: q64ToBig(event.periodicState.closePriceQ64).toNumber(),
-  volume: Number(event.periodicState.volumeQuote),
+  volume: Number(event.periodicState.volumeBase),
 });
 
 export const toBars = (events: PeriodicStateEventModel | PeriodicStateEventModel[]) =>
@@ -75,7 +75,10 @@ export const createBarFromSwap = (
   const periodStartTime = getPeriodStartTimeFromTime(market.time, period);
   return {
     time: Number(periodStartTime / 1000n),
-    open: previousClose ?? price,
+    // Only use previousClose if it's a truthy value. Without this contingency, any time a new bar
+    // is created and the previous bar has no activity, the new bar will be a huge green candlestick
+    // starting with an open price of `0`.
+    open: previousClose ? previousClose : price,
     high: price,
     low: price,
     close: price,
@@ -94,7 +97,10 @@ export const createBarFromPeriodicState = (
   const price = q64ToBig(periodicState.closePriceQ64).toNumber();
   return {
     time: periodEnumToRawDuration(period) / 1000,
-    open: previousClose ?? price,
+    // Only use previousClose if it's a truthy value. Without this contingency, any time a new bar
+    // is created and the previous bar has no activity, the new bar will be a huge green candlestick
+    // starting with an open price of `0`.
+    open: previousClose ? previousClose : price,
     high: price,
     low: price,
     close: price,

--- a/src/typescript/frontend/src/lib/store/event/event-store.ts
+++ b/src/typescript/frontend/src/lib/store/event/event-store.ts
@@ -113,6 +113,16 @@ export const createEventStore = () => {
           const market = state.markets.get(symbol)!;
           latestBars.forEach((bar) => {
             const period = bar.period;
+            // A bar's open should never be zero, so use the previous bar if it exists and isn't 0,
+            // otherwise, use the existing current bar's close.
+            if (bar.open === 0) {
+              const prevLatestBarClose = market[period].latestBar?.close;
+              if (prevLatestBarClose) {
+                bar.open = prevLatestBarClose;
+              } else {
+                bar.open = bar.close;
+              }
+            }
             market[period].latestBar = bar;
           });
         });


### PR DESCRIPTION
# Description

OLD:
![image](https://github.com/user-attachments/assets/b4c04bde-a36d-45af-8b81-2221a3b3b2bf)

NEW:
![image](https://github.com/user-attachments/assets/b3cb21c2-3ded-41a4-b2f3-d4296fc8c786)

- [x] Fixed the non-latest bar candlesticks using quote volume instead of base volume (meaning the latest bar always looked like it had huge volume)
- [x] Remove empty trading activity candlestick bars to make chart and bar logic cleaner
- [x] Fix the issue where some interim bars/candlesticks had a open price of zero
- [x] Fix the issue where a new (live update) bar when the previous bar has no activity resulted in a new bar/candlestick that started at an open price of zero (even after fixing the previous bullet point)

# Testing

Lots of visual and manual testing.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
