### PR TITLE
[ECO-2382] Fix non-breaking chat messages

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
@@ -53,7 +53,12 @@ const MessageContainer: React.FC<MessageContainerProps> = ({
       <StyledMessageContainer layout fromAnotherUser={fromAnotherUser}>
         <StyledMessageWrapper layout fromAnotherUser={fromAnotherUser}>
           <StyledMessageInner>
-            <span className="pt-[1ch] p-[0.25ch] text-xl tracking-widest">{message.text}</span>
+            <span
+              className="pt-[1ch] p-[0.25ch] text-xl tracking-widest"
+              style={{ wordBreak: "break-word" }}
+            >
+              {message.text}
+            </span>
             <Arrow />
           </StyledMessageInner>
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes emoji chat messages that did not break and overflowed the chat box.

# Testing

See `/market/infinity;TOP_arrow` chat history on vercel.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
