### PR TITLE
[ECO-2379] Add log environment variables for PostgREST

### DIFF
--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -56,6 +56,10 @@ services:
       PGRST_DB_URI: 'postgres://emojicoin:emojicoin@postgres:5432/emojicoin'
       PGRST_DB_ANON_ROLE: 'web_anon'
       PGRST_DB_MAX_ROWS: '${POSTGREST_MAX_ROWS}'
+      PGRST_LOG_LEVEL: 'info'
+      PGRST_SERVER_TIMING_ENABLED: 'true'
+      PGRST_DB_PLAN_ENABLED: 'true'
+      PGRST_SERVER_TRACE_HEADER: 'X-Request-Id'
     image: 'postgrest/postgrest'
     container_name: 'postgrest'
     ports:


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds useful logging variables to PostgREST.

- Timing is now returned in header.
- You can pass `Accept: application/vnd.pgrst.plan` to get the query plan, to check index usage.
- You can pass an `X-Request-Id` header to trace requests.
- All requests are logged.

# Testing

Run docker compose.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
