### PR TITLE
[ECO-2390] Fix flaky sdk e2e test due to period boundary cross miscalculation

### DIFF
--- a/src/typescript/sdk/src/client/emojicoin-client.ts
+++ b/src/typescript/sdk/src/client/emojicoin-client.ts
@@ -336,7 +336,7 @@ export class EmojicoinClient {
     const { marketNonce, marketID } = res.events.swapEvents[0];
     return {
       ...res,
-      sell: {
+      swap: {
         event: expect(res.events.swapEvents.at(0), Expect.Swap.Event),
         model: expect(res.models.swapEvents.at(0), Expect.Swap.Model),
       },

--- a/src/typescript/sdk/src/client/emojicoin-client.ts
+++ b/src/typescript/sdk/src/client/emojicoin-client.ts
@@ -336,7 +336,7 @@ export class EmojicoinClient {
     const { marketNonce, marketID } = res.events.swapEvents[0];
     return {
       ...res,
-      swap: {
+      sell: {
         event: expect(res.events.swapEvents.at(0), Expect.Swap.Event),
         model: expect(res.models.swapEvents.at(0), Expect.Swap.Model),
       },

--- a/src/typescript/sdk/src/utils/test/calculate-periodic-boundaries-crossed.ts
+++ b/src/typescript/sdk/src/utils/test/calculate-periodic-boundaries-crossed.ts
@@ -1,5 +1,5 @@
-import { Period, periodEnumToRawDuration, PERIODS } from "../../const";
-import { AnyNumberString } from "../../types";
+import { type Period, periodEnumToRawDuration, PERIODS } from "../../const";
+import { type AnyNumberString } from "../../types";
 import { getPeriodBoundary } from "../misc";
 
 /**

--- a/src/typescript/sdk/src/utils/test/calculate-periodic-boundaries-crossed.ts
+++ b/src/typescript/sdk/src/utils/test/calculate-periodic-boundaries-crossed.ts
@@ -1,0 +1,55 @@
+import { Period, periodEnumToRawDuration, PERIODS } from "../../const";
+import { AnyNumberString } from "../../types";
+import { getPeriodBoundary } from "../misc";
+
+/**
+ * Calculates the number of period boundaries crossed between two times. Since this will always
+ * be in ascending order of period boundary size, we just return the number of boundaries, not
+ * which specific ones.
+ *
+ * For example, (assume both times have the same date), 01:01:13 and 01:01:59 will cross 0 period
+ * boundaries.
+ *
+ * But 01:01:13 and 01:02:00 will cross 1 period boundary (a 1-minute period).
+ *
+ * 01:01:13 01:05:00 will cross a 1-minute and 5-minute period boundary.
+ *
+ * 01-01-2000 11:59:59 and 01-02-2000 12:00:00 will cross all period boundaries:
+ * 1m, 5m, 15m, 30m, 1h, 4h, and 1d.
+ *
+ * @param startMicroseconds the number/bigint/string start time in microseconds.
+ * @param endMicroseconds the number/bigint/string end time in microseconds.
+ * @returns the number of period boundaries crossed.
+ * @throws if the end time is later than the start time.
+ */
+export const calculatePeriodBoundariesCrossed = ({
+  startMicroseconds,
+  endMicroseconds,
+}: {
+  startMicroseconds: AnyNumberString;
+  endMicroseconds: AnyNumberString;
+}): number => {
+  const start = BigInt(startMicroseconds);
+  const end = BigInt(endMicroseconds);
+  if (start > end) {
+    throw new Error("End time cannot be later than start time.");
+  }
+  const periodsCrossed = PERIODS.reduce(
+    (acc, period) => {
+      // Get each period boundary of the start time; i.e., round it down to the nearest boundary.
+      const lowerPeriodBoundary = getPeriodBoundary(start, period);
+      // Add the time delta for one period boundary to the start time's lower period boundary to get
+      // the upper (next) period boundary.
+      const periodDuration = BigInt(periodEnumToRawDuration(period));
+      const upperPeriodBoundary = lowerPeriodBoundary + periodDuration;
+      // If the end time is greater than or equal to the start time's upper period boundary, that
+      // period boundary has been crossed.
+      if (end >= upperPeriodBoundary) {
+        acc.add(period);
+      }
+      return acc;
+    },
+    new Set([]) as Set<Period>
+  );
+  return periodsCrossed.size;
+};

--- a/src/typescript/sdk/src/utils/test/index.ts
+++ b/src/typescript/sdk/src/utils/test/index.ts
@@ -2,4 +2,4 @@ export * from "../aptos-client";
 export * from "./helpers";
 export * from "./publish";
 export * from "./load-priv-key";
-export * from "./calculate-num-periodic-events";
+export * from "./calculate-periodic-boundaries-crossed";

--- a/src/typescript/sdk/src/utils/test/index.ts
+++ b/src/typescript/sdk/src/utils/test/index.ts
@@ -2,3 +2,4 @@ export * from "../aptos-client";
 export * from "./helpers";
 export * from "./publish";
 export * from "./load-priv-key";
+export * from "./calculate-num-periodic-events";

--- a/src/typescript/sdk/tests/e2e/queries/client/submit.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/client/submit.test.ts
@@ -171,7 +171,6 @@ describe("all submission types for the emojicoin client", () => {
       emojicoin.sell(sender, emojis, inputAmount).then(({ response, events, swap: sell }) => {
         const { success } = response;
         const payload = response.payload as EntryFunctionPayloadResponse;
-        const endMicroseconds = events.swapEvents[0].time;
         expect(success).toBe(true);
         expect(payload.function).toEqual(functionNames.swap);
         expect(events.chatEvents.length).toEqual(0);

--- a/src/typescript/sdk/tests/unit/period-boundaries.test.ts
+++ b/src/typescript/sdk/tests/unit/period-boundaries.test.ts
@@ -1,4 +1,5 @@
-import { PeriodDuration, getPeriodStartTime } from "../../src";
+import { PERIODS, PeriodDuration, getPeriodStartTime } from "../../src";
+import { calculatePeriodBoundariesCrossed } from "../../src/utils/test";
 import { SAMPLE_STATE_EVENT, SAMPLE_SWAP_EVENT } from "../../src/utils/test/sample-data";
 
 const swap = SAMPLE_SWAP_EVENT;
@@ -121,5 +122,120 @@ describe("tests period boundaries", () => {
     expect(getPeriodStartTime(state, PERIOD_5M) === 2n * BigInt(PERIOD_5M)).toEqual(true);
     expect(getPeriodStartTime(state, PERIOD_15M) === 0n * BigInt(PERIOD_15M)).toEqual(true);
     expect(getPeriodStartTime(state, PERIOD_30M) === 0n * BigInt(PERIOD_30M)).toEqual(true);
+  });
+});
+
+describe("calculates period boundaries crossed", () => {
+  type TwoNumbers = `${number}${number}`;
+  type TimeFormat = `${TwoNumbers}:${TwoNumbers}:${TwoNumbers}`;
+  const defaultDate = "01-01-2000";
+  const getUTCDateFromHMS = (time: TimeFormat) => new Date(`${defaultDate} ${time}Z`);
+  // Converts hours:minutes:seconds to the number of microseconds since the Unix epoch using a
+  // default date for the day, month and year.
+  const getMicrosecondsFromHMS = (time: TimeFormat) =>
+    BigInt(getUTCDateFromHMS(time).getTime() * 1000);
+
+  it("uses the same date by default with the utility function", () => {
+    const times: Array<TimeFormat> = ["00:00:00", "11:59:59", "12:00:00", "23:59:59"];
+    times.forEach((time) => {
+      const utcDate = getUTCDateFromHMS(time);
+      expect(utcDate.getUTCDate()).toEqual(1);
+      expect(utcDate.getUTCMonth()).toEqual(0); // getUTCMonth() is offset by 0; December is 11.
+      expect(utcDate.getUTCFullYear()).toEqual(2000);
+      const micros = getMicrosecondsFromHMS(time);
+      expect(
+        calculatePeriodBoundariesCrossed({ startMicroseconds: micros, endMicroseconds: micros })
+      ).toEqual(0);
+      const date = new Date(Number(micros / 1000n));
+      expect(date.getUTCDate()).toEqual(1);
+      expect(date.getUTCMonth()).toEqual(0); // getUTCMonth() is offset by 0; December is 11.
+      expect(date.getUTCFullYear()).toEqual(2000);
+    });
+  });
+
+  it("calculates that no period boundaries are crossed", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("01:01:13");
+    const endMicroseconds = getMicrosecondsFromHMS("01:01:59");
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(0);
+  });
+
+  it("calculates that a 1 minute period boundary is crossed", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("01:01:13");
+    const endMicroseconds = getMicrosecondsFromHMS("01:02:00");
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(1);
+  });
+
+  it("calculates that 1m and 5m period boundaries are crossed", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("01:04:59");
+    const endMicroseconds = getMicrosecondsFromHMS("01:05:00");
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(2);
+  });
+
+  it("calculates that 1m, 5m, and 15m period boundaries are crossed", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("01:14:59");
+    const endMicroseconds = getMicrosecondsFromHMS("01:15:00");
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(3);
+  });
+
+  it("calculates that 1m, 5m, 15m, and 30m period boundaries are crossed", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("01:29:59");
+    const endMicroseconds = getMicrosecondsFromHMS("01:30:00");
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(4);
+  });
+
+  it("calculates that 1m, 5m, 15m, 30m, and 1h period boundaries are crossed", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("01:59:59");
+    const endMicroseconds = getMicrosecondsFromHMS("02:00:00");
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(5);
+  });
+
+  it("calculates that 1m, 5m, 15m, 30m, 1h, and 4h period boundaries are crossed", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("03:59:59");
+    const endMicroseconds = getMicrosecondsFromHMS("04:00:00");
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(6);
+  });
+
+  it("calculates that all period boundaries are crossed", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("23:59:59");
+    const oneDay = BigInt(PeriodDuration.PERIOD_1D);
+    const endMicroseconds = getMicrosecondsFromHMS("00:00:00") + oneDay;
+    const startDay = new Date(Number(startMicroseconds / 1000n)).getUTCDate();
+    const endDay = new Date(Number(endMicroseconds / 1000n)).getUTCDate();
+    expect(startDay + 1).toEqual(endDay);
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(PERIODS.length);
+  });
+
+  it("calculates that exactly only 1 period boundary is crossed over a 4m59s time period", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("01:00:00");
+    const endMicroseconds = getMicrosecondsFromHMS("01:04:59");
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(1);
+  });
+
+  it("calculates that exactly 7 period boundaries are crossed over multiple days", () => {
+    const startMicroseconds = getMicrosecondsFromHMS("01:01:13");
+    const threeDays = BigInt(PeriodDuration.PERIOD_1D) * 3n;
+    const endMicroseconds = getMicrosecondsFromHMS("01:02:00") + threeDays;
+    const startDay = new Date(Number(startMicroseconds / 1000n)).getUTCDate();
+    const endDay = new Date(Number(endMicroseconds / 1000n)).getUTCDate();
+    expect(startDay + 3).toEqual(endDay);
+    const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(numBoundaries).toEqual(7);
+    expect(numBoundaries).toEqual(PERIODS.length);
+  });
+
+  it("throws if the end time is later than the start time", () => {
+    const startMicroseconds = new Date("01-01-2000 00:00:01Z").getTime() * 1000;
+    const endMicroseconds = new Date("01-01-2000 00:00:00Z").getTime() * 1000;
+    const fn = () => calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
+    expect(fn).toThrow();
   });
 });

--- a/src/typescript/turbo.json
+++ b/src/typescript/turbo.json
@@ -71,6 +71,10 @@
     "test:sequential": {
       "cache": false,
       "outputs": []
+    },
+    "test:unit": {
+      "cache": false,
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
# Description

The `submit.test.ts` e2e test for the SDK would sometimes fail because it wasn't properly calculating the number of period boundaries crossed between two bump events.

To fix it, I added a function that calculates the number of period boundaries crossed between a start time and end time and calculate the number of period boundaries crossed between any two bump event start/end times.

# Testing

- [x] Added unit tests for the new `calculatePeriodicBoundariesCrossed` function
- [x] Update the e2e tests to use the new function

The tests will run in CI for this PR.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
