### PR TITLE
[ECO-2391] Ignore lint/type errors when building the frontend Docker container

### DIFF
--- a/src/docker/frontend/Dockerfile
+++ b/src/docker/frontend/Dockerfile
@@ -31,6 +31,6 @@ ENV HASH_SEED=$HASH_SEED \
     REVALIDATION_TIME=$REVALIDATION_TIME \
     EMOJICOIN_INDEXER_URL=$EMOJICOIN_INDEXER_URL
 
-RUN ["bash", "-c", "pnpm install && pnpm run build"]
+RUN ["bash", "-c", "pnpm install && pnpm run build:no-checks"]
 
 CMD ["bash", "-c", "pnpm run start -- -H 0.0.0.0"]

--- a/src/typescript/frontend/next.config.mjs
+++ b/src/typescript/frontend/next.config.mjs
@@ -38,6 +38,7 @@ const nextConfig = {
   crossOrigin: "use-credentials",
   typescript: {
     tsconfigPath: "tsconfig.json",
+    ignoreBuildErrors: process.env.IGNORE_BUILD_ERRORS === "true",
   },
   compiler: {
     styledComponents: DEBUG ? styledComponentsConfig : true,

--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -90,6 +90,7 @@
   "scripts": {
     "_format": "prettier './**/*.{js,jsx,ts,tsx,css,md}' --config ./.prettierrc.js",
     "build": "next build",
+    "build:no-checks": "IGNORE_BUILD_ERRORS=true next build --no-lint",
     "build:debug": "BUILD_DEBUG=true next build --no-lint --no-mangling --debug",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
     "dev": "NODE_OPTIONS='--inspect' next dev --turbo --port 3001",

--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -90,8 +90,8 @@
   "scripts": {
     "_format": "prettier './**/*.{js,jsx,ts,tsx,css,md}' --config ./.prettierrc.js",
     "build": "next build",
-    "build:no-checks": "IGNORE_BUILD_ERRORS=true next build --no-lint",
     "build:debug": "BUILD_DEBUG=true next build --no-lint --no-mangling --debug",
+    "build:no-checks": "IGNORE_BUILD_ERRORS=true next build --no-lint",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
     "dev": "NODE_OPTIONS='--inspect' next dev --turbo --port 3001",
     "format": "pnpm _format --write",

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build": "pnpm i && pnpm load-env:test -- turbo run build",
     "build:debug": "pnpm i && pnpm load-env:test -- turbo run build:debug",
+    "build:no-checks": "pnpm i && pnpm load-env:test -- turbo run build:no-checks",
     "check": "turbo run check",
     "clean": "turbo run clean --no-cache --force && rm -rf .turbo",
     "clean:full": "pnpm run clean && rm -rf node_modules && rm -rf sdk/node_modules && rm -rf frontend/node_modules",

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -56,6 +56,7 @@
     "_format": "prettier 'src/**/*.ts' 'tests/**/*.ts' '.eslintrc.js'",
     "build": "tsc",
     "build:debug": "BUILD_DEBUG=true pnpm run build",
+    "build:no-checks": "tsc --skipLibCheck",
     "check": "tsc -p tests/tsconfig.json --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "e2e:testnet": "pnpm load-test-env -v NO_TEST_SETUP=true -- pnpm jest tests/e2e/queries/testnet",

--- a/src/typescript/turbo.json
+++ b/src/typescript/turbo.json
@@ -53,9 +53,6 @@
       "outputs": []
     },
     "start": {
-      "dependsOn": [
-        "build"
-      ],
       "outputs": [],
       "persistent": true
     },

--- a/src/typescript/turbo.json
+++ b/src/typescript/turbo.json
@@ -16,10 +16,16 @@
       ]
     },
     "build:debug": {
-      "dependsOn": [
-        "build"
-      ],
-      "outputs": []
+      "outputs": [
+        "dist/**",
+        ".next/**"
+      ]
+    },
+    "build:no-checks": {
+      "outputs": [
+        "dist/**",
+        ".next/**"
+      ]
     },
     "check": {
       "outputs": []


### PR DESCRIPTION
# Description

Have the docker container, when built, ignore linting/typescript type errors so that playwright doesn't show up as failing when it's merely a linting/type issue

This is okay because we check this in CI in other actions anyway, and we rebuild the frontend container in all tests.

# Testing

Tested locally with another PR that's currently failing linting/type checks.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
