### PR TITLE
[ECO-2364] Fix double rendering issue on home page

### DIFF
--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
@@ -6,9 +6,8 @@ import { marketDataToProps } from "./utils";
 import { useGridRowLength } from "./hooks/use-grid-items-per-line";
 import { type MarketDataSortByHomePage } from "lib/queries/sorting/types";
 import { useEffect, useMemo, useRef } from "react";
-import "./module.css";
-import { useEmojiPicker } from "context/emoji-picker-context";
 import { type HomePageProps } from "app/home/HomePage";
+import "./module.css";
 
 export const ClientGrid = ({
   markets,

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/ClientGrid.tsx
@@ -20,11 +20,10 @@ export const ClientGrid = ({
   sortBy: MarketDataSortByHomePage;
 }) => {
   const rowLength = useGridRowLength();
-  const searchEmojis = useEmojiPicker((s) => s.emojis);
 
   const ordered = useMemo(() => {
-    return marketDataToProps(markets, searchEmojis);
-  }, [markets, searchEmojis]);
+    return marketDataToProps(markets);
+  }, [markets]);
 
   const initialRender = useRef(true);
 
@@ -41,7 +40,7 @@ export const ClientGrid = ({
       {ordered.map((v, i) => {
         return (
           <TableCard
-            key={`live-${v.marketID}-${v.searchEmojisKey}`}
+            key={`live-${v.marketID}`}
             index={i}
             pageOffset={(page - 1) * MARKETS_PER_PAGE}
             marketID={v.marketID}

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
@@ -18,9 +18,7 @@ export type WithTimeIndexAndPrev = PropsWithTimeAndIndex & {
 
 const toSearchEmojisKey = (searchEmojis: string[]) => `{${searchEmojis.join("")}}`;
 
-export const marketDataToProps = (
-  markets: HomePageProps["markets"],
-): PropsWithTime[] =>
+export const marketDataToProps = (markets: HomePageProps["markets"]): PropsWithTime[] =>
   markets.map((m) => ({
     time: Number(m.market.time),
     symbol: m.market.symbolData.symbol,

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
@@ -7,7 +7,6 @@ import { type SymbolEmoji } from "@sdk/emoji_data";
 
 export type PropsWithTime = Omit<TableCardProps, "index" | "rowLength"> & {
   time: number;
-  searchEmojisKey: string;
 };
 export type PropsWithTimeAndIndex = TableCardProps & {
   time: number;
@@ -21,7 +20,6 @@ const toSearchEmojisKey = (searchEmojis: string[]) => `{${searchEmojis.join("")}
 
 export const marketDataToProps = (
   markets: HomePageProps["markets"],
-  searchEmojis: string[]
 ): PropsWithTime[] =>
   markets.map((m) => ({
     time: Number(m.market.time),
@@ -30,7 +28,6 @@ export const marketDataToProps = (
     emojis: m.market.emojis,
     staticMarketCap: m.state.instantaneousStats.marketCap.toString(),
     staticVolume24H: m.dailyVolume.toString(),
-    searchEmojisKey: toSearchEmojisKey(searchEmojis),
   }));
 
 export const stateEventsToProps = (

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
@@ -98,7 +98,7 @@ export const constructOrdered = ({
   // We don't need to filter the fetched data because it's already filtered and sorted by the
   // server. We only need to filter event store state events.
   const searchEmojis = getSearchEmojis() as Array<SymbolEmoji>;
-  const initial = marketDataToProps(markets, searchEmojis);
+  const initial = marketDataToProps(markets);
 
   // If we're sorting by bump order, deduplicate and sort the events by bump order.
   const bumps = stateEventsToProps(stateFirehose, getMarket, searchEmojis);


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes a bug where the home page grid would double render when searching for something.

# Testing

Search, check no double animation.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
