### PR TITLE
[ECO-2394] Remove `geoblocked` prop drilling and use the hook instead

### DIFF
--- a/src/typescript/frontend/src/app/home/HomePage.tsx
+++ b/src/typescript/frontend/src/app/home/HomePage.tsx
@@ -13,7 +13,6 @@ export interface HomePageProps {
   sortBy: MarketDataSortByHomePage;
   searchBytes?: string;
   children?: React.ReactNode;
-  geoblocked: boolean;
   priceFeed: Array<DatabaseModels["price_feed"]>;
 }
 
@@ -25,7 +24,6 @@ export default async function HomePageComponent({
   sortBy,
   searchBytes,
   children,
-  geoblocked,
   priceFeed,
 }: HomePageProps) {
   return (
@@ -46,7 +44,6 @@ export default async function HomePageComponent({
           page={page}
           sortBy={sortBy}
           searchBytes={searchBytes}
-          geoblocked={geoblocked}
         />
       </div>
     </>

--- a/src/typescript/frontend/src/app/home/page.tsx
+++ b/src/typescript/frontend/src/app/home/page.tsx
@@ -1,7 +1,5 @@
 import { type HomePageParams, toHomePageParamsWithDefault } from "lib/routes/home-page-params";
 import HomePageComponent from "./HomePage";
-import { isUserGeoblocked } from "utils/geolocation";
-import { headers } from "next/headers";
 import {
   fetchFeaturedMarket,
   fetchMarkets,

--- a/src/typescript/frontend/src/app/home/page.tsx
+++ b/src/typescript/frontend/src/app/home/page.tsx
@@ -46,8 +46,6 @@ export default async function Home({ searchParams }: HomePageParams) {
 
   const priceFeed = await fetchPriceFeed({});
 
-  // Call this last because `headers()` is a dynamic API and all fetches after this aren't cached.
-  const geoblocked = await isUserGeoblocked(headers().get("x-real-ip"));
   return (
     <HomePageComponent
       featured={featured}
@@ -56,7 +54,6 @@ export default async function Home({ searchParams }: HomePageParams) {
       page={page}
       sortBy={sortBy}
       searchBytes={q}
-      geoblocked={geoblocked}
       priceFeed={priceFeed}
     />
   );

--- a/src/typescript/frontend/src/app/layout.tsx
+++ b/src/typescript/frontend/src/app/layout.tsx
@@ -11,8 +11,6 @@ import {
 } from "styles/fonts";
 import "../app/global.css";
 import DisplayDebugData from "@/store/server-to-client/FetchFromServer";
-import { isUserGeoblocked } from "utils/geolocation";
-import { headers } from "next/headers";
 
 export const metadata: Metadata = getDefaultMetadata();
 export const viewport: Viewport = {
@@ -23,12 +21,11 @@ const fonts = [pixelar, formaDJRMicro, formaDJRDisplayMedium, formaDJRDisplayReg
 const fontsClassName = fonts.map((font) => font.variable).join(" ");
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const geoblocked = await isUserGeoblocked(headers().get("x-real-ip"));
   return (
     <html>
       <body className={fontsClassName}>
         <StyledComponentsRegistry>
-          <Providers geoblocked={geoblocked}>
+          <Providers>
             <DisplayDebugData />
             {children}
           </Providers>

--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -3,8 +3,6 @@ import EmojiNotFoundPage from "./not-found";
 import { fetchContractMarketView } from "lib/queries/aptos-client/market-view";
 import { SYMBOL_EMOJI_DATA } from "@sdk/emoji_data";
 import { pathToEmojiNames } from "utils/pathname-helpers";
-import { isUserGeoblocked } from "utils/geolocation";
-import { headers } from "next/headers";
 import { fetchChatEvents, fetchMarketState, fetchSwapEvents } from "@/queries/market";
 import { deriveEmojicoinPublisherAddress } from "@sdk/emojicoin_dot_fun";
 import { type Metadata } from "next";
@@ -77,8 +75,6 @@ const EmojicoinPage = async (params: EmojicoinPageProps) => {
     const swaps = await fetchSwapEvents({ marketID });
     const marketView = await fetchContractMarketView(marketAddress.toString());
 
-    // Call this last because `headers()` is a dynamic API and all fetches after this aren't cached.
-    const geoblocked = await isUserGeoblocked(headers().get("x-real-ip"));
     return (
       <ClientEmojicoinPage
         data={{
@@ -89,7 +85,6 @@ const EmojicoinPage = async (params: EmojicoinPageProps) => {
           marketView,
           ...state.market,
         }}
-        geoblocked={geoblocked}
       />
     );
   }

--- a/src/typescript/frontend/src/app/pools/page.tsx
+++ b/src/typescript/frontend/src/app/pools/page.tsx
@@ -1,6 +1,4 @@
 import ClientPoolsPage, { type PoolsData } from "components/pages/pools/ClientPoolsPage";
-import { headers } from "next/headers";
-import { isUserGeoblocked } from "utils/geolocation";
 import { getPoolData } from "./api/getPoolDataQuery";
 import { SortMarketsBy } from "@sdk/indexer-v2/types/common";
 import { symbolBytesToEmojis } from "@sdk/emoji_data/utils";
@@ -26,7 +24,5 @@ export default async function PoolsPage({ searchParams }: { searchParams: { pool
     )
   );
 
-  // Call this last because `headers()` is a dynamic API and all fetches after this aren't cached.
-  const geoblocked = await isUserGeoblocked(headers().get("x-real-ip"));
-  return <ClientPoolsPage geoblocked={geoblocked} initialData={initialData} />;
+  return <ClientPoolsPage initialData={initialData} />;
 }

--- a/src/typescript/frontend/src/app/verify/page.tsx
+++ b/src/typescript/frontend/src/app/verify/page.tsx
@@ -7,18 +7,16 @@ import { authenticate } from "components/pages/verify/verify";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { ROUTES } from "router/routes";
-import { isUserGeoblocked } from "utils/geolocation";
 
 export const dynamic = "force-dynamic";
 
 const Verify = async () => {
   const hashed = cookies().get(COOKIE_FOR_HASHED_ADDRESS)?.value;
   const address = cookies().get(COOKIE_FOR_ACCOUNT_ADDRESS)?.value;
-  const geoblocked = await isUserGeoblocked(headers().get("x-real-ip"));
 
   let authenticated = false;
   if (!hashed || !address) {
-    return <VerifyPage geoblocked={geoblocked} />;
+    return <VerifyPage />;
   } else {
     authenticated = await authenticate({
       address,
@@ -30,7 +28,7 @@ const Verify = async () => {
     }
   }
 
-  return <VerifyPage geoblocked={geoblocked} />;
+  return <VerifyPage />;
 };
 
 export default Verify;

--- a/src/typescript/frontend/src/app/verify/page.tsx
+++ b/src/typescript/frontend/src/app/verify/page.tsx
@@ -4,7 +4,7 @@ import {
   COOKIE_FOR_HASHED_ADDRESS,
 } from "components/pages/verify/session-info";
 import { authenticate } from "components/pages/verify/verify";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { ROUTES } from "router/routes";
 

--- a/src/typescript/frontend/src/app/verify_status/page.tsx
+++ b/src/typescript/frontend/src/app/verify_status/page.tsx
@@ -1,12 +1,7 @@
 import VerifyStatusPage from "components/pages/verify_status/VerifyStatusPage";
-import { headers } from "next/headers";
-import { isUserGeoblocked } from "utils/geolocation";
-
-export const dynamic = "force-dynamic";
 
 const Verify = async () => {
-  const geoblocked = await isUserGeoblocked(headers().get("x-real-ip"));
-  return <VerifyStatusPage geoblocked={geoblocked} />;
+  return <VerifyStatusPage />;
 };
 
 export default Verify;

--- a/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
@@ -23,11 +23,7 @@ const EMOJI_FONT_FAMILY =
   '"Segoe UI", "Apple Color Emoji", "Twemoji Mozilla", "Noto Color Emoji", ' +
   '"Android Emoji"';
 
-const ChatInputBox = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
+const ChatInputBox = ({ children }: { children: React.ReactNode }) => {
   const { connected } = useWallet();
   return (
     <>
@@ -52,11 +48,7 @@ const ConditionalWrapper = ({
   children: React.ReactNode;
   mode: "chat" | "register" | "search";
 }) => {
-  return mode === "chat" ? (
-    <ChatInputBox>{children}</ChatInputBox>
-  ) : (
-    <>{children}</>
-  );
+  return mode === "chat" ? <ChatInputBox>{children}</ChatInputBox> : <>{children}</>;
 };
 
 export const EmojiPickerWithInput = ({

--- a/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
@@ -13,10 +13,10 @@ import { MarketValidityIndicator } from "./ColoredBytesIndicator";
 import { variants } from "./animation-variants";
 import { checkTargetAndStopDefaultPropagation } from "./utils";
 import { getEmojisInString } from "@sdk/emoji_data";
-import "./triangle.css";
 import { createPortal } from "react-dom";
 import { type EmojiMartData } from "components/pages/emoji-picker/types";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import "./triangle.css";
 
 const EMOJI_FONT_FAMILY =
   '"EmojiMart", "Segoe UI Emoji", "Segoe UI Symbol", ' +
@@ -25,15 +25,13 @@ const EMOJI_FONT_FAMILY =
 
 const ChatInputBox = ({
   children,
-  geoblocked,
 }: {
   children: React.ReactNode;
-  geoblocked: boolean;
 }) => {
   const { connected } = useWallet();
   return (
     <>
-      <ButtonWithConnectWalletFallback geoblocked={geoblocked} className="mt-[6px]">
+      <ButtonWithConnectWalletFallback className="mt-[6px]">
         {children}
       </ButtonWithConnectWalletFallback>
       {!connected && (
@@ -50,14 +48,12 @@ const ChatInputBox = ({
 const ConditionalWrapper = ({
   children,
   mode,
-  geoblocked,
 }: {
   children: React.ReactNode;
   mode: "chat" | "register" | "search";
-  geoblocked: boolean;
 }) => {
   return mode === "chat" ? (
-    <ChatInputBox geoblocked={geoblocked}>{children}</ChatInputBox>
+    <ChatInputBox>{children}</ChatInputBox>
   ) : (
     <>{children}</>
   );
@@ -68,14 +64,12 @@ export const EmojiPickerWithInput = ({
   pickerButtonClassName,
   inputGroupProps,
   inputClassName = "",
-  geoblocked,
   filterEmojis,
 }: {
   handleClick: (message: string) => Promise<void>;
   pickerButtonClassName?: string;
   inputGroupProps?: Partial<React.ComponentProps<typeof InputGroup>>;
   inputClassName?: string;
-  geoblocked: boolean;
   filterEmojis?: (e: EmojiMartData["emojis"][string]) => boolean;
 }) => {
   const inputRef = useRef<HTMLDivElement | null>(null);
@@ -216,7 +210,7 @@ export const EmojiPickerWithInput = ({
       className="justify-center"
       ref={inputRef}
     >
-      <ConditionalWrapper geoblocked={geoblocked} mode={mode}>
+      <ConditionalWrapper mode={mode}>
         <InputGroup isShowError={false} {...inputGroupProps}>
           <div className="flex-row relative items-center justify-center">
             <div className="relative h-[45px]">

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -1,12 +1,9 @@
 import React, { useCallback, useEffect, useState } from "react";
-
 import { MobileMenuInner, MobileMenuWrapper, StyledMotion } from "./styled";
 import { EXTERNAL_LINK_PROPS, Link } from "components/link";
 import { MobileSocialLinks } from "./components/mobile-social-links";
 import { MobileMenuItem } from "../index";
-
 import { type MobileMenuProps } from "./types";
-
 import { slideVariants } from "./animations";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
@@ -26,7 +23,6 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
   isOpen,
   setIsOpen,
   linksForCurrentPage,
-  geoblocked,
 }) => {
   const { wallet, account, disconnect } = useWallet();
   const { copyAddress } = useAptos();
@@ -96,7 +92,6 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
       <MobileMenuWrapper>
         <MobileMenuInner>
           <ButtonWithConnectWalletFallback
-            geoblocked={geoblocked}
             className="w-full"
             mobile={true}
             onClick={subMenuOnClick}

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/types.ts
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/types.ts
@@ -4,5 +4,4 @@ export interface MobileMenuProps {
   isOpen: boolean;
   setIsOpen: (arg: boolean) => void;
   linksForCurrentPage: (typeof NAVIGATE_LINKS)[number][];
-  geoblocked: boolean;
 }

--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -21,7 +21,7 @@ import Link, { type LinkProps } from "next/link";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { GeoblockedBanner } from "components/geoblocking";
 
-const Header: React.FC<HeaderProps> = ({ isOpen, setIsOpen, geoblocked }) => {
+const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
   const { isDesktop } = useMatchBreakpoints();
   const { t } = translationFunction();
   const searchParams = useSearchParams();

--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -20,6 +20,7 @@ import { useSearchParams } from "next/navigation";
 import Link, { type LinkProps } from "next/link";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { GeoblockedBanner } from "components/geoblocking";
+import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
   const { isDesktop } = useMatchBreakpoints();
@@ -27,6 +28,7 @@ const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
   const searchParams = useSearchParams();
   const linksForCurrentPage = NAVIGATE_LINKS;
   const clear = useEmojiPicker((s) => s.clear);
+  const geoblocked = useIsUserGeoblocked();
 
   const [offsetHeight, setOffsetHeight] = useState(0);
 
@@ -96,7 +98,7 @@ const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
                   </Link>
                 );
               })}
-              <ButtonWithConnectWalletFallback geoblocked={geoblocked}>
+              <ButtonWithConnectWalletFallback>
                 <WalletDropdownMenu />
               </ButtonWithConnectWalletFallback>
             </FlexGap>
@@ -109,12 +111,7 @@ const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
           )}
         </Flex>
       </Container>
-      <MobileMenu
-        geoblocked={geoblocked}
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        linksForCurrentPage={linksForCurrentPage}
-      />
+      <MobileMenu isOpen={isOpen} setIsOpen={setIsOpen} linksForCurrentPage={linksForCurrentPage} />
       {geoblocked && <GeoblockedBanner />}
     </StyledContainer>
   );

--- a/src/typescript/frontend/src/components/header/types.ts
+++ b/src/typescript/frontend/src/components/header/types.ts
@@ -1,5 +1,4 @@
 export type HeaderProps = {
   isOpen: boolean;
   setIsOpen: (arg: boolean) => void;
-  geoblocked: boolean;
 };

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -34,11 +34,11 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
   const { t } = translationFunction();
   const _geoblocked = useIsUserGeoblocked();
   const geoblocked = useMemo(() => {
-  // For letting the user connect on the `/verify_status` page when `forceAllowConnect` is `true`,
-  // by only returning `geoblocked = true` if we're not force allow connecting and they're
-  // geoblocked.
+    // For letting the user connect on the `/verify_status` page when `forceAllowConnect` is `true`,
+    // by only returning `geoblocked = true` if we're not force allow connecting and they're
+    // geoblocked.
     return !forceAllowConnect && _geoblocked;
-  }, [_geoblocked]);
+  }, [forceAllowConnect, _geoblocked]);
 
   const [enabled, setEnabled] = useState(false);
 

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -10,11 +10,11 @@ import Arrow from "@icons/Arrow";
 import { useNameStore } from "context/event-store-context";
 import Popup from "components/popup";
 import Text from "components/text";
+import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 export interface ConnectWalletProps extends PropsWithChildren<{ className?: string }> {
   mobile?: boolean;
   onClick?: () => void;
-  geoblocked: boolean;
   arrow?: boolean;
 }
 
@@ -25,12 +25,12 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
   children,
   className,
   onClick,
-  geoblocked,
   arrow = true,
 }) => {
   const { connected, account } = useWallet();
   const { openWalletModal } = useWalletModal();
   const { t } = translationFunction();
+  const geoblocked = useIsUserGeoblocked();
 
   const [enabled, setEnabled] = useState(false);
 

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -16,6 +16,7 @@ export interface ConnectWalletProps extends PropsWithChildren<{ className?: stri
   mobile?: boolean;
   onClick?: () => void;
   arrow?: boolean;
+  forceAllowConnect?: boolean;
 }
 
 const CONNECT_WALLET = "Connect Wallet";
@@ -26,11 +27,18 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
   className,
   onClick,
   arrow = true,
+  forceAllowConnect,
 }) => {
   const { connected, account } = useWallet();
   const { openWalletModal } = useWalletModal();
   const { t } = translationFunction();
-  const geoblocked = useIsUserGeoblocked();
+  const _geoblocked = useIsUserGeoblocked();
+  const geoblocked = useMemo(() => {
+  // For letting the user connect on the `/verify_status` page when `forceAllowConnect` is `true`,
+  // by only returning `geoblocked = true` if we're not force allow connecting and they're
+  // geoblocked.
+    return !forceAllowConnect && _geoblocked;
+  }, [_geoblocked]);
 
   const [enabled, setEnabled] = useState(false);
 

--- a/src/typescript/frontend/src/components/inputs/search-bar.tsx
+++ b/src/typescript/frontend/src/components/inputs/search-bar.tsx
@@ -36,7 +36,7 @@ export const Border = styled(Flex)`
   }
 `;
 
-export const SearchBar: React.FC<{ geoblocked: boolean }> = ({ geoblocked }) => {
+export const SearchBar = () => {
   const setMode = useEmojiPicker((state) => state.setMode);
   useEffect(() => {
     setMode("search");
@@ -63,7 +63,6 @@ export const SearchBar: React.FC<{ geoblocked: boolean }> = ({ geoblocked }) => 
               <EmojiPickerWithInput
                 handleClick={async () => {}}
                 inputClassName="search-picker border-none"
-                geoblocked={geoblocked}
                 filterEmojis={filterBigEmojis}
               />
             </Flex>

--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -37,11 +37,7 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
     <Box pt="85px">
       <TextCarousel />
       <MainInfo data={props.data} />
-      {isTablet || isMobile ? (
-        <MobileGrid data={props.data} />
-      ) : (
-        <DesktopGrid data={props.data} />
-      )}
+      {isTablet || isMobile ? <MobileGrid data={props.data} /> : <DesktopGrid data={props.data} />}
     </Box>
   );
 };

--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -38,9 +38,9 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
       <TextCarousel />
       <MainInfo data={props.data} />
       {isTablet || isMobile ? (
-        <MobileGrid geoblocked={props.geoblocked} data={props.data} />
+        <MobileGrid data={props.data} />
       ) : (
-        <DesktopGrid geoblocked={props.geoblocked} data={props.data} />
+        <DesktopGrid data={props.data} />
       )}
     </Box>
   );

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -111,7 +111,6 @@ const ChatBox = (props: ChatProps) => {
         >
           {sortedChatsWithNames.map((chat, index) => {
             const message = {
-              // TODO: Resolve address to Aptos name, store in state.
               sender: chat.user,
               text: chat.message,
               senderRank: getRankFromEvent(chat).rankIcon,
@@ -129,7 +128,7 @@ const ChatBox = (props: ChatProps) => {
         </motion.div>
       </Flex>
 
-      <EmojiPickerWithInput geoblocked={props.geoblocked} handleClick={sendChatMessage} />
+      <EmojiPickerWithInput handleClick={sendChatMessage} />
     </Column>
   );
 };

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
@@ -44,7 +44,7 @@ const DesktopGrid = (props: GridProps) => {
             </StyledBlockWrapper>
           </StyledBlock>
           <StyledBlock width="43%">
-            <LiquidityButton geoblocked={props.geoblocked} data={props.data} />
+            <LiquidityButton data={props.data} />
 
             <StyledBlockWrapper>
               <SwapComponent
@@ -52,7 +52,6 @@ const DesktopGrid = (props: GridProps) => {
                 marketAddress={props.data.marketView.metadata.marketAddress}
                 marketEmojis={props.data.symbolEmojis}
                 initNumSwaps={props.data.swaps.length}
-                geoblocked={props.geoblocked}
               />
             </StyledBlockWrapper>
           </StyledBlock>
@@ -79,7 +78,7 @@ const DesktopGrid = (props: GridProps) => {
             </StyledContentHeader>
 
             <StyledBlockWrapper>
-              <ChatBox geoblocked={props.geoblocked} data={props.data} />
+              <ChatBox data={props.data} />
             </StyledBlockWrapper>
           </StyledBlock>
         </StyledContentColumn>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
@@ -84,12 +84,11 @@ const MobileGrid = (props: GridProps) => {
         ) : tab === 2 ? (
           <>
             <div style={{ width: "100%" }}>
-              <LiquidityButton geoblocked={props.geoblocked} data={props.data} />
+              <LiquidityButton data={props.data} />
             </div>
             <StyledMobileContentInner>
               <Flex width="100%" justifyContent="center" px="17px">
                 <SwapComponent
-                  geoblocked={props.geoblocked}
                   emojicoin={props.data.symbol}
                   marketAddress={props.data.marketAddress}
                   marketEmojis={props.data.symbolEmojis}
@@ -100,7 +99,7 @@ const MobileGrid = (props: GridProps) => {
           </>
         ) : (
           <StyledMobileContentInner>
-            <ChatBox geoblocked={props.geoblocked} data={props.data} />
+            <ChatBox data={props.data} />
           </StyledMobileContentInner>
         )}
       </StyledMobileContentBlock>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
@@ -33,7 +33,7 @@ export const LiquidityButton = (props: GridProps) => {
         </StyledContentHeader>
       ) : canTrade ? (
         <StyledContentHeader className="!p-0">
-          <AnimatedProgressBar geoblocked={props.geoblocked} data={props.data} />
+          <AnimatedProgressBar data={props.data} />
         </StyledContentHeader>
       ) : (
         <StyledContentHeader>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
@@ -14,7 +14,6 @@ import { toast } from "react-toastify";
 import { CongratulationsToast } from "./CongratulationsToast";
 import { useCanTradeMarket } from "lib/hooks/queries/use-grace-period";
 import Popup from "components/popup";
-import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 const GRACE_PERIOD_MESSAGE =
   "This market is in its grace period. During the grace period of a market, only the market " +

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
@@ -14,6 +14,7 @@ import { toast } from "react-toastify";
 import { CongratulationsToast } from "./CongratulationsToast";
 import { useCanTradeMarket } from "lib/hooks/queries/use-grace-period";
 import Popup from "components/popup";
+import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 const GRACE_PERIOD_MESSAGE =
   "This market is in its grace period. During the grace period of a market, only the market " +
@@ -26,7 +27,6 @@ export const SwapButton = ({
   marketAddress,
   setSubmit,
   disabled,
-  geoblocked,
   symbol,
   minOutputAmount,
 }: {
@@ -35,7 +35,6 @@ export const SwapButton = ({
   marketAddress: AccountAddressString;
   setSubmit: Dispatch<SetStateAction<(() => Promise<void>) | null>>;
   disabled?: boolean;
-  geoblocked: boolean;
   symbol: string;
   minOutputAmount: bigint | number | string;
 }) => {
@@ -100,7 +99,7 @@ export const SwapButton = ({
 
   return (
     <>
-      <ButtonWithConnectWalletFallback geoblocked={geoblocked}>
+      <ButtonWithConnectWalletFallback>
         {canTrade ? (
           <>
             <Button disabled={disabled} onClick={handleClick} scale="lg">

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -94,7 +94,6 @@ export default function SwapComponent({
   marketAddress,
   marketEmojis,
   initNumSwaps,
-  geoblocked,
 }: SwapComponentProps) {
   const { t } = translationFunction();
   const searchParams = useSearchParams();
@@ -351,7 +350,6 @@ export default function SwapComponent({
             // Disable the button if and only if the balance has been fetched and isn't sufficient *and*
             // the user is connected.
             disabled={!sufficientBalance && !isLoading && !!account}
-            geoblocked={geoblocked}
             symbol={emojicoin}
             minOutputAmount={minOutputAmount}
           />

--- a/src/typescript/frontend/src/components/pages/emojicoin/types.ts
+++ b/src/typescript/frontend/src/components/pages/emojicoin/types.ts
@@ -17,7 +17,6 @@ type DataProps = MarketMetadataModel & {
 
 export interface EmojicoinProps {
   data: DataProps;
-  geoblocked: boolean;
 }
 
 export interface MainInfoProps {
@@ -26,19 +25,16 @@ export interface MainInfoProps {
 
 export interface GridProps {
   data: DataProps;
-  geoblocked: boolean;
 }
 
 export interface ChatProps {
   data: Omit<DataProps, "swaps">;
-  geoblocked: boolean;
 }
 export interface SwapComponentProps {
   emojicoin: string;
   marketAddress: AccountAddressString;
   marketEmojis: SymbolEmoji[];
   initNumSwaps: number;
-  geoblocked: boolean;
 }
 export interface TradeHistoryProps {
   data: Omit<DataProps, "chats">;

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
@@ -126,7 +126,7 @@ const EmojiTable = (props: EmojiTableProps) => {
               }}
             >
               <SearchWrapper>
-                <SearchBar geoblocked={props.geoblocked} />
+                <SearchBar />
               </SearchWrapper>
               <FilterOptionsWrapper>
                 <FilterOptions

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
@@ -27,7 +27,7 @@ export const LaunchButtonOrGoToMarketLink = ({
 
   return (
     <>
-      <ButtonWithConnectWalletFallback geoblocked={geoblocked}>
+      <ButtonWithConnectWalletFallback>
         {registered ? (
           <Link
             className="font-pixelar text-lg uppercase text-ec-blue"

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
@@ -10,12 +10,10 @@ export const LaunchButtonOrGoToMarketLink = ({
   onWalletButtonClick,
   registered,
   invalid,
-  geoblocked,
 }: {
   onWalletButtonClick: () => void;
   registered?: boolean;
   invalid: boolean;
-  geoblocked: boolean;
 }) => {
   const emojis = useEmojiPicker((state) => state.emojis);
   const { t } = translationFunction();

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
@@ -22,7 +22,6 @@ import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 const labelClassName = "whitespace-nowrap body-sm md:body-lg text-light-gray uppercase font-forma";
 
 export const MemoizedLaunchAnimation = ({ loading }: { loading: boolean }) => {
-  const geoblocked = useIsUserGeoblocked();
   const { t } = translationFunction();
   const emojis = useEmojiPicker((state) => state.emojis);
   const setIsLoadingRegisteredMarket = useEmojiPicker(
@@ -187,7 +186,6 @@ export const MemoizedLaunchAnimation = ({ loading }: { loading: boolean }) => {
             }}
           >
             <LaunchButtonOrGoToMarketLink
-              geoblocked={geoblocked}
               invalid={invalid}
               registered={registered}
               onWalletButtonClick={() => {

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
@@ -88,7 +88,6 @@ export const MemoizedLaunchAnimation = ({ loading }: { loading: boolean }) => {
           <div className="flex relative mb-1">
             <div className="flex flex-col grow relative w-full">
               <EmojiPickerWithInput
-                geoblocked={geoblocked}
                 handleClick={handleClick}
                 inputClassName="!border !border-solid !border-light-gray rounded-md !flex-row-reverse pl-3 pr-1.5"
                 inputGroupProps={{ label: "Select Emojis", scale: "xm" }}

--- a/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
@@ -21,13 +21,12 @@ import { useSearchParams } from "next/navigation";
 import { encodeEmojis, getEmojisInString, type SymbolEmoji } from "@sdk/emoji_data";
 import SearchBar from "components/inputs/search-bar";
 import { type MarketStateModel, type UserPoolsRPCModel } from "@sdk/indexer-v2/types";
+import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 export type PoolsData = MarketStateModel | UserPoolsRPCModel;
 
-export const ClientPoolsPage: React.FC<{ geoblocked: boolean; initialData: PoolsData[] }> = ({
-  geoblocked,
-  initialData,
-}) => {
+export const ClientPoolsPage = ({ initialData }: { initialData: PoolsData[] }) => {
+  const geoblocked = useIsUserGeoblocked();
   const searchParams = useSearchParams();
   const poolParam = searchParams.get("pool");
   const [sortBy, setSortBy] = useState<SortByPageQueryParams>("all_time_vol");
@@ -91,7 +90,7 @@ export const ClientPoolsPage: React.FC<{ geoblocked: boolean; initialData: Pools
             alignItems="center"
             gap="13px"
           >
-            {!isMobile ? <SearchBar geoblocked={geoblocked} /> : null}
+            {!isMobile ? <SearchBar /> : null}
 
             <TableHeaderSwitcher
               title1="Pools"
@@ -110,7 +109,7 @@ export const ClientPoolsPage: React.FC<{ geoblocked: boolean; initialData: Pools
       {isMobile ? (
         <StyledSubHeader>
           <StyledHeaderInner>
-            <SearchBar geoblocked={geoblocked} />
+            <SearchBar />
           </StyledHeaderInner>
         </StyledSubHeader>
       ) : null}

--- a/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
@@ -21,12 +21,10 @@ import { useSearchParams } from "next/navigation";
 import { encodeEmojis, getEmojisInString, type SymbolEmoji } from "@sdk/emoji_data";
 import SearchBar from "components/inputs/search-bar";
 import { type MarketStateModel, type UserPoolsRPCModel } from "@sdk/indexer-v2/types";
-import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 export type PoolsData = MarketStateModel | UserPoolsRPCModel;
 
 export const ClientPoolsPage = ({ initialData }: { initialData: PoolsData[] }) => {
-  const geoblocked = useIsUserGeoblocked();
   const searchParams = useSearchParams();
   const poolParam = searchParams.get("pool");
   const [sortBy, setSortBy] = useState<SortByPageQueryParams>("all_time_vol");
@@ -141,10 +139,7 @@ export const ClientPoolsPage = ({ initialData }: { initialData: PoolsData[] }) =
         </StyledInner>
 
         <StyledInner flexGrow={1} width={{ _: "100%", laptopL: "43%" }}>
-          <Liquidity
-            geoblocked={geoblocked}
-            market={selectedIndex !== undefined ? markets[selectedIndex] : undefined}
-          />
+          <Liquidity market={selectedIndex !== undefined ? markets[selectedIndex] : undefined} />
         </StyledInner>
       </StyledWrapper>
     </StyledPoolsPage>

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -298,7 +298,7 @@ const Liquidity: React.FC<LiquidityProps> = ({ market, geoblocked }) => {
           mb={{ _: "17px", tablet: "37px" }}
           position="relative"
         >
-          <ButtonWithConnectWalletFallback geoblocked={geoblocked}>
+          <ButtonWithConnectWalletFallback>
             <Button
               scale="lg"
               disabled={!isActionPossible}

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -31,7 +31,6 @@ import { type PoolsData } from "../../ClientPoolsPage";
 
 type LiquidityProps = {
   market: PoolsData | undefined;
-  geoblocked: boolean;
 };
 
 const fmtCoin = (n: AnyNumberString | undefined) => {
@@ -68,7 +67,7 @@ const inputAndOutputStyles = `
   border-transparent !p-0 text-white
 `;
 
-const Liquidity: React.FC<LiquidityProps> = ({ market, geoblocked }) => {
+const Liquidity = ({ market }: LiquidityProps) => {
   const { t } = translationFunction();
   const { theme } = useThemeContext();
 

--- a/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
@@ -14,7 +14,7 @@ import { LINKS } from "lib/env";
 import { ROUTES } from "router/routes";
 import { type AccountAddressString } from "@sdk/emojicoin_dot_fun";
 
-export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked }) => {
+export const ClientVerifyPage = () => {
   const { account } = useAptos();
   const { connected, disconnect } = useWallet();
   const [verified, setVerified] = useState<boolean | null>(null);
@@ -87,7 +87,7 @@ export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked
                 <span ref={backRef}>Back</span>
               </motion.div>
             )}
-            <ButtonWithConnectWalletFallback geoblocked={geoblocked} arrow={false}>
+            <ButtonWithConnectWalletFallback arrow={false}>
               <div className="flex flex-row uppercase mt-[8ch]">
                 <span className="px-2.5">{"{"}</span>
                 <span ref={ref} onMouseEnter={replay} />

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -12,8 +12,11 @@ import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
 import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
-const checkmarkOrX = (bool: boolean) => (
-  <Emoji className="text-lg" emojis={bool ? emoji("check mark button") : emoji("cross mark")} />
+const checkmarkOrX = (checkmark: boolean) => (
+  <Emoji
+    className="text-lg"
+    emojis={checkmark ? emoji("check mark button") : emoji("cross mark")}
+  />
 );
 
 export const ClientVerifyPage = () => {
@@ -73,7 +76,7 @@ export const ClientVerifyPage = () => {
                 </div>
                 <div>Galxe: {checkmarkOrX(galxe)}</div>
                 <div>Custom allowlist: {checkmarkOrX(customAllowlisted)}</div>
-                <div>Passes geoblocking: {checkmarkOrX(geoblocked)}</div>
+                <div>Passes geoblocking: {checkmarkOrX(!geoblocked)}</div>
                 <a
                   className="underline text-ec-blue"
                   href={process.env.NEXT_PUBLIC_GALXE_CAMPAIGN_REDIRECT}

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -10,16 +10,18 @@ import { getVerificationStatus } from "./get-verification-status";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
+import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 const checkmarkOrX = (bool: boolean) => (
   <Emoji className="text-lg" emojis={bool ? emoji("check mark button") : emoji("cross mark")} />
 );
 
-export const ClientVerifyPage: React.FC<{ geoblocked: boolean }> = ({ geoblocked }) => {
+export const ClientVerifyPage = () => {
   const { account } = useAptos();
   const { connected, disconnect } = useWallet();
   const [galxe, setGalxe] = useState(false);
   const [customAllowlisted, setCustomAllowlisted] = useState(false);
+  const geoblocked = useIsUserGeoblocked();
 
   useEffect(() => {
     if (!account || !connected) {

--- a/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify_status/VerifyStatusPage.tsx
@@ -63,7 +63,7 @@ export const ClientVerifyPage = () => {
                 <span>Disconnect Wallet</span>
               </motion.div>
             )}
-            <ButtonWithConnectWalletFallback geoblocked={false} arrow={false}>
+            <ButtonWithConnectWalletFallback forceAllowConnect={true} arrow={false}>
               <div className="flex flex-col uppercase mt-[20ch] gap-1">
                 <div>
                   Wallet address:{" "}

--- a/src/typescript/frontend/src/context/providers.tsx
+++ b/src/typescript/frontend/src/context/providers.tsx
@@ -33,10 +33,7 @@ enableMapSet();
 
 const queryClient = new QueryClient();
 
-const ThemedApp: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = ({
-  children,
-  geoblocked,
-}) => {
+const ThemedApp: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { theme } = useThemeContext();
   const [isOpen, setIsOpen] = useState(false);
   const { isDesktop } = useMatchBreakpoints();
@@ -56,7 +53,7 @@ const ThemedApp: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = 
               dappConfig={{ network: APTOS_NETWORK }}
             >
               <WalletModalContextProvider>
-                <AptosContextProvider geoblocked={geoblocked}>
+                <AptosContextProvider>
                   <EmojiPickerProvider
                     initialState={{
                       nativePicker: isMobile || isTablet,
@@ -67,11 +64,7 @@ const ThemedApp: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = 
                     <Suspense fallback={<Loader />}>
                       <StyledToaster />
                       <ContentWrapper>
-                        <Header
-                          isOpen={isMobileMenuOpen}
-                          setIsOpen={setIsOpen}
-                          geoblocked={geoblocked}
-                        />
+                        <Header isOpen={isMobileMenuOpen} setIsOpen={setIsOpen} />
                         {children}
                         <Footer />
                       </ContentWrapper>
@@ -87,10 +80,7 @@ const ThemedApp: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = 
   );
 };
 
-const Providers: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = ({
-  children,
-  geoblocked,
-}) => {
+const Providers: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [p, setP] = useState(false);
 
   // Hack for now because I'm unsure how to get rid of the warning.
@@ -102,7 +92,7 @@ const Providers: React.FC<{ children: React.ReactNode; geoblocked: boolean }> = 
   return (
     p && (
       <ThemeContextProvider>
-        <ThemedApp geoblocked={geoblocked}>{children}</ThemedApp>
+        <ThemedApp>{children}</ThemedApp>
       </ThemeContextProvider>
     )
   );

--- a/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
+++ b/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
@@ -40,6 +40,7 @@ import {
 } from "@sdk/utils/parse-changes-for-balances";
 import { getEventsAsProcessorModelsFromResponse } from "@sdk/mini-processor";
 import { emoji } from "utils";
+import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 type WalletContextState = ReturnType<typeof useWallet>;
 export type SubmissionResponse = Promise<{
@@ -78,10 +79,7 @@ export type AptosContextState = {
 
 export const AptosContext = createContext<AptosContextState | undefined>(undefined);
 
-export function AptosContextProvider({
-  children,
-  geoblocked,
-}: PropsWithChildren<{ geoblocked: boolean }>) {
+export function AptosContextProvider({ children }: PropsWithChildren) {
   const {
     signAndSubmitTransaction: adapterSignAndSubmitTxn,
     account,
@@ -94,6 +92,7 @@ export function AptosContextProvider({
   const [lastResponse, setLastResponse] = useState<ResponseType>(null);
   const [lastResponseStoredAt, setLastResponseStoredAt] = useState(-1);
   const [emojicoinType, setEmojicoinType] = useState<string | undefined>();
+  const geoblocked = useIsUserGeoblocked();
 
   const { emojicoin, emojicoinLP } = useMemo(() => {
     if (!emojicoinType) return { emojicoin: undefined, emojicoinLP: undefined };

--- a/src/typescript/frontend/src/hooks/use-is-user-geoblocked.ts
+++ b/src/typescript/frontend/src/hooks/use-is-user-geoblocked.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { isUserGeoblockedServerAction } from "utils/server/geoblocked";
+import { isUserGeoblocked } from "utils/geolocation";
 
 const useIsUserGeoblocked = () => {
   const { data } = useQuery({
     queryKey: ["geoblocked"],
-    queryFn: () => isUserGeoblockedServerAction(),
+    queryFn: () => isUserGeoblocked(),
     staleTime: Infinity,
   });
 

--- a/src/typescript/frontend/src/utils/geolocation.ts
+++ b/src/typescript/frontend/src/utils/geolocation.ts
@@ -1,4 +1,7 @@
+"use server";
+
 import { GEOBLOCKED, GEOBLOCKING_ENABLED, VPNAPI_IO_API_KEY } from "lib/server-env";
+import { headers } from "next/headers";
 
 export type Location = {
   country: string;
@@ -19,7 +22,8 @@ const isDisallowedLocation = (location: Location) => {
   return false;
 };
 
-export const isUserGeoblocked = async (ip: string | undefined | null) => {
+export const isUserGeoblocked = async () => {
+  const ip = headers().get("x-real-ip");
   if (!GEOBLOCKING_ENABLED) return false;
   if (ip === "undefined" || typeof ip === "undefined" || ip === "null" || ip === null) {
     return true;

--- a/src/typescript/frontend/src/utils/server/geoblocked.ts
+++ b/src/typescript/frontend/src/utils/server/geoblocked.ts
@@ -1,8 +1,0 @@
-"use server";
-
-import { headers } from "next/headers";
-import { isUserGeoblocked } from "utils/geolocation";
-
-export async function isUserGeoblockedServerAction() {
-  return await isUserGeoblocked(headers().get("x-real-ip"));
-}


### PR DESCRIPTION
# Description

Since a dedicated user could bypass most restrictions anyway, remove the `headers()` call server-side by moving the various `isGeoblocked` functions to being client-side.

- [x] Move all usage of `geoblocked` and checking if the user is geoblocked to be client-side
- [x] Fix `Passes Geoblocked` logic in the `/verify_status` page display

# Testing

- [x] Test and make sure the `vpnapi` API key is not exposed to the client (check network requests and ensure this is called server-side)
- [x] Ensure a geoblocked user is properly geoblocked

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
