### PR TITLE
[ECO-2412] Make sure `LP` shows up on liquidity page

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/InputLabels.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/InputLabels.tsx
@@ -7,9 +7,9 @@ export const AptosInputLabel = () => (
   </div>
 );
 
+export const EmojiInputLabelStyles =
+  "pixel-heading-3 text-light-gray text-[24px] md:text-[30px] cursor-default";
+
 export const EmojiInputLabel = ({ emoji }: { emoji: string }) => (
-  <Emoji
-    className="pixel-heading-3 text-light-gray text-[24px] md:text-[30px] cursor-default"
-    emojis={emoji}
-  />
+  <Emoji className={EmojiInputLabelStyles} emojis={emoji} />
 );

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -11,6 +11,7 @@ import { toCoinDecimalString } from "lib/utils/decimals";
 import {
   AptosInputLabel,
   EmojiInputLabel,
+  EmojiInputLabelStyles,
 } from "components/pages/emojicoin/components/trade-emojicoin/InputLabels";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { toActualCoinDecimals } from "lib/utils/decimals";
@@ -216,7 +217,10 @@ const Liquidity = ({ market }: LiquidityProps) => {
           disabled
         ></input>
       </Column>
-      <EmojiInputLabel emoji={market ? market.market.symbolData.symbol : "-"} />
+      <div>
+        <EmojiInputLabel emoji={market ? market.market.symbolData.symbol : "-"} />
+        <span className={EmojiInputLabelStyles}>{market ? "" : "-"}</span>
+      </div>
     </InnerWrapper>
   );
 
@@ -246,7 +250,10 @@ const Liquidity = ({ market }: LiquidityProps) => {
           />
         )}
       </Column>
-      <EmojiInputLabel emoji={market ? `${market.market.symbolData.symbol} LP` : "- LP"} />
+      <div>
+        <EmojiInputLabel emoji={market ? `${market.market.symbolData.symbol}` : ""} />
+        <span className={EmojiInputLabelStyles}>{market ? " LP" : "-"}</span>
+      </div>
     </InnerWrapper>
   );
 


### PR DESCRIPTION
# Description

- [x] Add `LP` to the coin suffixes on the pools page
- [x] Use `-` when no LP coin is selected

# Testing

## When an LP coin is selected
<img width="553" alt="Screenshot 2024-11-15 at 12 05 09 PM" src="https://github.com/user-attachments/assets/be08b370-88ca-4b1f-9b9c-303b08e63bc0">
<img width="553" alt="Screenshot 2024-11-15 at 12 05 05 PM" src="https://github.com/user-attachments/assets/2c6763f6-5b2c-4ef2-8761-08dcafcc8f66">

## When no LP coin is selected
<img width="553" alt="Screenshot 2024-11-15 at 12 05 18 PM" src="https://github.com/user-attachments/assets/0c1bd1b2-39d2-48d9-abfc-83c7900f58d1">
<img width="553" alt="Screenshot 2024-11-15 at 12 05 15 PM" src="https://github.com/user-attachments/assets/9e273dd3-592a-4b2b-a8e2-4225b455491f">
# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
