### PR TITLE
[ECO-2403] Parallelize docker image builds

### DIFF
--- a/.github/workflows/push-broker.yaml
+++ b/.github/workflows/push-broker.yaml
@@ -25,9 +25,14 @@ jobs:
         context: 'src/rust'
         file: 'src/rust/broker/Dockerfile'
         labels: '${{ steps.metadata.outputs.labels }}'
-        platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
+        platforms: '${{ matrix.platform }}'
         push: 'true'
         tags: '${{ steps.metadata.outputs.tags }}'
+    strategy:
+      matrix:
+        platform:
+        - 'linux/amd64'
+        - 'linux/arm64'
     timeout-minutes: 360
 name: 'Build broker Docker image and push to Docker Hub'
 'on':


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Parallelize broker image builds using a GitHub actions matrix strategy, bump processor version

# Testing

`broker-v0.9.2` tag build completed

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
