### PR TITLE
[ECO-2419] Bump stack image versions

### DIFF
--- a/src/cloud-formation/deploy-indexer-main.yaml
+++ b/src/cloud-formation/deploy-indexer-main.yaml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  BrokerImageVersion: '0.9.1'
+  BrokerImageVersion: '1.0.0'
   DeployAlb: 'true'
   DeployAlbDnsRecord: 'true'
   DeployBastionHost: 'true'
@@ -20,7 +20,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'main'
   Network: 'testnet'
-  ProcessorImageVersion: '0.9.1'
+  ProcessorImageVersion: '1.0.0'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  BrokerImageVersion: '0.9.1'
+  BrokerImageVersion: '1.0.0'
   DeployAlb: 'true'
   DeployAlbDnsRecord: 'true'
   DeployBastionHost: 'true'
@@ -20,7 +20,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'testnet'
-  ProcessorImageVersion: '0.9.1'
+  ProcessorImageVersion: '1.0.0'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Bump image bersions for broker and processor to `v1.0.0`, which are located on `main` and `emojicoin-dot-fun` branches of the respective repos

# Testing

SDK tests are passing for v1.0.0 AMD builds on other PRs

