### PR TITLE
[ECO-2420] Refactor claim link module for ease of DevOps

### DIFF
--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -749,14 +749,14 @@ module rewards::emojicoin_dot_fun_claim_link {
             &rewards_signer,
             vector[claim_link_validated_public_key_bytes]
         );
-        assert!(!public_key_is_eligible(claim_link_validated_public_key_bytes));
+        assert!(public_key_claimant(claim_link_validated_public_key_bytes) == option::some(CLAIMANT));
 
         // Verify silent return for trying to remove public key that is not eligible.
         let (_, new_public_key) = ed25519::generate_keys();
-        remove_public_keys(
-            &rewards_signer,
-            vector[ed25519::validated_public_key_to_bytes(&new_public_key)]
-        );
+        let new_public_key_bytes = ed25519::validated_public_key_to_bytes(&new_public_key);
+        remove_public_keys(&rewards_signer, vector[new_public_key_bytes]);
+        assert!(public_key_claimant(new_public_key_bytes) == option::none());
+        assert!(!public_key_is_eligible(new_public_key_bytes));
         */
     }
 

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -743,13 +743,13 @@ module rewards::emojicoin_dot_fun_claim_link {
             public_keys_that_are_claimed_to_simple_map().values() == vector[CLAIMANT]
         );
 
-        /*
         // Verify that public key entry can no longer be removed.
         remove_public_keys(
             &rewards_signer,
             vector[claim_link_validated_public_key_bytes]
         );
         assert!(public_key_claimant(claim_link_validated_public_key_bytes) == option::some(CLAIMANT));
+        /*
 
         // Verify silent return for trying to remove public key that is not eligible.
         let (_, new_public_key) = ed25519::generate_keys();

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -723,7 +723,6 @@ module rewards::emojicoin_dot_fun_claim_link {
         // Verify claimant's emojicoin balance.
         assert!(coin::balance<BlackCatEmojicoin>(CLAIMANT) == net_proceeds);
 
-        /*
         // Check vault balance, state.
         assert!(vault_balance() == 0);
         assert!(
@@ -736,6 +735,7 @@ module rewards::emojicoin_dot_fun_claim_link {
         assert!(keys == vector[claim_link_validated_public_key]);
         assert!(starting_bucket_index == option::none());
         assert!(starting_vector_index == option::none());
+        /*
         assert!(
             public_keys_that_are_claimed_to_simple_map().keys()
                 == vector[claim_link_validated_public_key]

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -290,7 +290,7 @@ module rewards::emojicoin_dot_fun_claim_link {
         vault_ref_mut
     }
 
-    fun validate_public_key_bytes(public_key_bytes: vector<u8>): ValidatedPublicKey {
+    inline fun validate_public_key_bytes(public_key_bytes: vector<u8>): ValidatedPublicKey {
         let validated_public_key_option =
             ed25519::new_validated_public_key_from_bytes(public_key_bytes);
         assert!(option::is_some(&validated_public_key_option), E_INVALID_PUBLIC_KEY);
@@ -376,7 +376,7 @@ module rewards::emojicoin_dot_fun_claim_link {
         add_public_keys(&not_admin_signer, vector[]);
     }
 
-    #[test_only]
+    #[test]
     fun test_add_public_keys_and_fund_gas_escrows() acquires Vault {
         // Prepare escrow account public keys.
         let n_escrows = 3;
@@ -424,9 +424,7 @@ module rewards::emojicoin_dot_fun_claim_link {
 
         // Call with zero public keys argument to invoke silent return.
         assert!(coin::balance<AptosCoin>(@rewards) == 0);
-        add_public_keys_and_fund_gas_escrows(
-            &rewards_signer, vector[], amount_per_escrow
-        );
+        add_public_keys_and_fund_gas_escrows(&rewards_signer, vector[], amount_per_escrow);
         assert!(coin::balance<AptosCoin>(@rewards) == 0);
 
     }

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -581,7 +581,8 @@ module rewards::emojicoin_dot_fun_claim_link {
         emojicoin_dot_fun::tests::init_package_then_exact_transition();
 
         // Get claim link private, public keys, bogus public key.
-        let (claim_link_private_key, claim_link_validated_public_key) = ed25519::generate_keys();
+        let (claim_link_private_key, claim_link_validated_public_key) =
+            ed25519::generate_keys();
         let claim_link_validated_public_key_bytes =
             ed25519::validated_public_key_to_bytes(&claim_link_validated_public_key);
 
@@ -594,8 +595,13 @@ module rewards::emojicoin_dot_fun_claim_link {
         assert!(claim_amount() == DEFAULT_CLAIM_AMOUNT);
         assert!(!public_key_is_eligible(claim_link_validated_public_key_bytes));
         assert!(!public_key_is_eligible(vector[0]));
-        assert!(public_key_claimant(claim_link_validated_public_key_bytes) == option::none());
-        assert!(public_key_claimant(vector[0]) == option::none());
+        assert!(
+            public_key_claimant(claim_link_validated_public_key_bytes)
+                == option::none()
+        );
+        assert!(
+            public_key_claimant(vector[0]) == option::none()
+        );
         assert!(public_keys_that_are_claimed().is_empty());
         assert!(public_keys_that_are_eligible().is_empty());
         let (keys, starting_bucket_index, starting_vector_index) =
@@ -603,11 +609,9 @@ module rewards::emojicoin_dot_fun_claim_link {
         assert!(keys == vector[]);
         assert!(starting_bucket_index == option::none());
         assert!(starting_vector_index == option::none());
-        (
-            keys,
-            starting_bucket_index,
-            starting_vector_index
-        ) = public_keys_that_are_eligible_paginated(0, 0, 1);
+        (keys, starting_bucket_index, starting_vector_index) = public_keys_that_are_eligible_paginated(
+            0, 0, 1
+        );
         assert!(keys == vector[]);
         assert!(starting_bucket_index == option::none());
         assert!(starting_vector_index == option::none());
@@ -641,8 +645,13 @@ module rewards::emojicoin_dot_fun_claim_link {
             public_key_claimant(claim_link_validated_public_key_bytes)
                 == option::none()
         );
-        assert!(public_key_claimant(claim_link_validated_public_key_bytes) == option::none());
-        assert!(public_key_claimant(vector[0]) == option::none());
+        assert!(
+            public_key_claimant(claim_link_validated_public_key_bytes)
+                == option::none()
+        );
+        assert!(
+            public_key_claimant(vector[0]) == option::none()
+        );
         assert!(
             public_keys_that_are_eligible() == vector[claim_link_validated_public_key]
         );
@@ -650,11 +659,9 @@ module rewards::emojicoin_dot_fun_claim_link {
             public_key_claimant(claim_link_validated_public_key_bytes)
                 == option::none()
         );
-        (
-            keys,
-            starting_bucket_index,
-            starting_vector_index
-        ) = public_keys_that_are_eligible_paginated(0, 0, 1);
+        (keys, starting_bucket_index, starting_vector_index) = public_keys_that_are_eligible_paginated(
+            0, 0, 1
+        );
         assert!(keys == vector[claim_link_validated_public_key]);
         assert!(starting_bucket_index == option::none());
         assert!(starting_vector_index == option::none());
@@ -746,11 +753,15 @@ module rewards::emojicoin_dot_fun_claim_link {
             &rewards_signer,
             vector[claim_link_validated_public_key_bytes]
         );
-        assert!(public_key_claimant(claim_link_validated_public_key_bytes) == option::some(CLAIMANT));
+        assert!(
+            public_key_claimant(claim_link_validated_public_key_bytes)
+                == option::some(CLAIMANT)
+        );
 
         // Verify silent return for trying to remove public key that is not eligible.
         let (_, new_public_key) = ed25519::generate_keys();
-        let new_public_key_bytes = ed25519::validated_public_key_to_bytes(&new_public_key);
+        let new_public_key_bytes =
+            ed25519::validated_public_key_to_bytes(&new_public_key);
         remove_public_keys(&rewards_signer, vector[new_public_key_bytes]);
         assert!(public_key_claimant(new_public_key_bytes) == option::none());
         assert!(!public_key_is_eligible(new_public_key_bytes));
@@ -811,7 +822,7 @@ module rewards::emojicoin_dot_fun_claim_link {
     fun test_redeem_invalid_signature() acquires Vault {
         let (signature_bytes, claim_link_validated_public_key_bytes) =
             prepare_for_redemption();
-        signature_bytes[0] ^= 0xff;
+        signature_bytes[0] = signature_bytes[0] ^ 0xff;
         redeem<BlackCatEmojicoin, BlackCatEmojicoinLP>(
             &get_signer(CLAIMANT),
             signature_bytes,

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -754,8 +754,8 @@ module rewards::emojicoin_dot_fun_claim_link {
         let (_, new_public_key) = ed25519::generate_keys();
         let new_public_key_bytes = ed25519::validated_public_key_to_bytes(&new_public_key);
         remove_public_keys(&rewards_signer, vector[new_public_key_bytes]);
-        /*
         assert!(public_key_claimant(new_public_key_bytes) == option::none());
+        /*
         assert!(!public_key_is_eligible(new_public_key_bytes));
         */
     }

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -424,6 +424,30 @@ module rewards::emojicoin_dot_fun_claim_link {
         add_admin(&not_admin_signer, not_admin);
     }
 
+    #[test, expected_failure(abort_code = E_CLAIM_LINK_ALREADY_CLAIMED)]
+    fun test_add_public_keys_claim_link_already_claimed() acquires Vault {
+        let (signature_bytes, claim_link_validated_public_key_bytes) =
+            prepare_for_redemption();
+        redeem<BlackCatEmojicoin, BlackCatEmojicoinLP>(
+            &get_signer(CLAIMANT),
+            signature_bytes,
+            claim_link_validated_public_key_bytes,
+            @black_cat_market,
+            1
+        );
+        add_public_keys(
+            &get_signer(@rewards), vector[claim_link_validated_public_key_bytes]
+        );
+    }
+
+    #[test, expected_failure(abort_code = E_CLAIM_LINK_ALREADY_ELIGIBLE)]
+    fun test_add_public_keys_claim_link_already_eligible() acquires Vault {
+        let (_, claim_link_validated_public_key_bytes) = prepare_for_redemption();
+        add_public_keys(
+            &get_signer(@rewards), vector[claim_link_validated_public_key_bytes]
+        );
+    }
+
     #[test, expected_failure(abort_code = E_INVALID_PUBLIC_KEY)]
     fun test_add_public_keys_invalid_public_key() acquires Vault {
         emojicoin_dot_fun::tests::init_package();
@@ -494,6 +518,42 @@ module rewards::emojicoin_dot_fun_claim_link {
         );
         assert!(coin::balance<AptosCoin>(@rewards) == 0);
 
+    }
+
+    #[test, expected_failure(abort_code = E_CLAIM_LINK_ALREADY_CLAIMED)]
+    fun test_add_public_keys_and_fund_gas_escrows_claim_link_already_claimed() acquires Vault {
+        let (signature_bytes, claim_link_validated_public_key_bytes) =
+            prepare_for_redemption();
+        redeem<BlackCatEmojicoin, BlackCatEmojicoinLP>(
+            &get_signer(CLAIMANT),
+            signature_bytes,
+            claim_link_validated_public_key_bytes,
+            @black_cat_market,
+            1
+        );
+        let amount_per_escrow = 1;
+        emojicoin_dot_fun::test_acquisitions::mint_aptos_coin_to(
+            @rewards, amount_per_escrow
+        );
+        add_public_keys_and_fund_gas_escrows(
+            &get_signer(@rewards),
+            vector[claim_link_validated_public_key_bytes],
+            amount_per_escrow
+        );
+    }
+
+    #[test, expected_failure(abort_code = E_CLAIM_LINK_ALREADY_ELIGIBLE)]
+    fun test_add_public_keys_and_fund_gas_escrows_claim_link_already_eligible() acquires Vault {
+        let (_, claim_link_validated_public_key_bytes) = prepare_for_redemption();
+        let amount_per_escrow = 1;
+        emojicoin_dot_fun::test_acquisitions::mint_aptos_coin_to(
+            @rewards, amount_per_escrow
+        );
+        add_public_keys_and_fund_gas_escrows(
+            &get_signer(@rewards),
+            vector[claim_link_validated_public_key_bytes],
+            amount_per_escrow
+        );
     }
 
     #[test, expected_failure(abort_code = E_INVALID_PUBLIC_KEY)]

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -735,7 +735,6 @@ module rewards::emojicoin_dot_fun_claim_link {
         assert!(keys == vector[claim_link_validated_public_key]);
         assert!(starting_bucket_index == option::none());
         assert!(starting_vector_index == option::none());
-        /*
         assert!(
             public_keys_that_are_claimed_to_simple_map().keys()
                 == vector[claim_link_validated_public_key]
@@ -744,6 +743,7 @@ module rewards::emojicoin_dot_fun_claim_link {
             public_keys_that_are_claimed_to_simple_map().values() == vector[CLAIMANT]
         );
 
+        /*
         // Verify that public key entry can no longer be removed.
         remove_public_keys(
             &rewards_signer,

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -749,12 +749,12 @@ module rewards::emojicoin_dot_fun_claim_link {
             vector[claim_link_validated_public_key_bytes]
         );
         assert!(public_key_claimant(claim_link_validated_public_key_bytes) == option::some(CLAIMANT));
-        /*
 
         // Verify silent return for trying to remove public key that is not eligible.
         let (_, new_public_key) = ed25519::generate_keys();
         let new_public_key_bytes = ed25519::validated_public_key_to_bytes(&new_public_key);
         remove_public_keys(&rewards_signer, vector[new_public_key_bytes]);
+        /*
         assert!(public_key_claimant(new_public_key_bytes) == option::none());
         assert!(!public_key_is_eligible(new_public_key_bytes));
         */

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -755,9 +755,7 @@ module rewards::emojicoin_dot_fun_claim_link {
         let new_public_key_bytes = ed25519::validated_public_key_to_bytes(&new_public_key);
         remove_public_keys(&rewards_signer, vector[new_public_key_bytes]);
         assert!(public_key_claimant(new_public_key_bytes) == option::none());
-        /*
         assert!(!public_key_is_eligible(new_public_key_bytes));
-        */
     }
 
     #[test, expected_failure(abort_code = E_CLAIM_LINK_ALREADY_CLAIMED)]

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -585,7 +585,7 @@ module rewards::emojicoin_dot_fun_claim_link {
         let claim_link_validated_public_key_bytes =
             ed25519::validated_public_key_to_bytes(&claim_link_validated_public_key);
         let invalid_public_key_bytes = claim_link_validated_public_key_bytes;
-        invalid_public_key_bytes[0] ^= 0xff;
+        invalid_public_key_bytes[0] = invalid_public_key_bytes ^ 0xff;
 
         // Initialize module.
         let rewards_signer = get_signer(@rewards);

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -584,8 +584,6 @@ module rewards::emojicoin_dot_fun_claim_link {
         let (claim_link_private_key, claim_link_validated_public_key) = ed25519::generate_keys();
         let claim_link_validated_public_key_bytes =
             ed25519::validated_public_key_to_bytes(&claim_link_validated_public_key);
-        let invalid_public_key_bytes = claim_link_validated_public_key_bytes;
-        invalid_public_key_bytes[0] = invalid_public_key_bytes[0] ^ 0xff;
 
         // Initialize module.
         let rewards_signer = get_signer(@rewards);
@@ -595,9 +593,9 @@ module rewards::emojicoin_dot_fun_claim_link {
         assert!(admins() == vector[@rewards]);
         assert!(claim_amount() == DEFAULT_CLAIM_AMOUNT);
         assert!(!public_key_is_eligible(claim_link_validated_public_key_bytes));
-        assert!(!public_key_is_eligible(invalid_public_key_bytes));
+        assert!(!public_key_is_eligible(vector[0]));
         assert!(public_key_claimant(claim_link_validated_public_key_bytes) == option::none());
-        assert!(public_key_claimant(invalid_public_key_bytes) == option::none());
+        assert!(public_key_claimant(vector[0]) == option::none());
         assert!(public_keys_that_are_claimed().is_empty());
         assert!(public_keys_that_are_eligible().is_empty());
         let (keys, starting_bucket_index, starting_vector_index) =
@@ -644,7 +642,7 @@ module rewards::emojicoin_dot_fun_claim_link {
                 == option::none()
         );
         assert!(public_key_claimant(claim_link_validated_public_key_bytes) == option::none());
-        assert!(public_key_claimant(invalid_public_key_bytes) == option::none());
+        assert!(public_key_claimant(vector[0]) == option::none());
         assert!(
             public_keys_that_are_eligible() == vector[claim_link_validated_public_key]
         );

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -643,7 +643,6 @@ module rewards::emojicoin_dot_fun_claim_link {
             public_key_claimant(claim_link_validated_public_key_bytes)
                 == option::none()
         );
-        assert!(!public_key_is_eligible(claim_link_validated_public_key_bytes));
         assert!(public_key_claimant(claim_link_validated_public_key_bytes) == option::none());
         assert!(public_key_claimant(invalid_public_key_bytes) == option::none());
         assert!(
@@ -724,6 +723,7 @@ module rewards::emojicoin_dot_fun_claim_link {
         // Verify claimant's emojicoin balance.
         assert!(coin::balance<BlackCatEmojicoin>(CLAIMANT) == net_proceeds);
 
+        /*
         // Check vault balance, state.
         assert!(vault_balance() == 0);
         assert!(
@@ -757,6 +757,7 @@ module rewards::emojicoin_dot_fun_claim_link {
             &rewards_signer,
             vector[ed25519::validated_public_key_to_bytes(&new_public_key)]
         );
+        */
     }
 
     #[test, expected_failure(abort_code = E_CLAIM_LINK_ALREADY_CLAIMED)]

--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -585,7 +585,7 @@ module rewards::emojicoin_dot_fun_claim_link {
         let claim_link_validated_public_key_bytes =
             ed25519::validated_public_key_to_bytes(&claim_link_validated_public_key);
         let invalid_public_key_bytes = claim_link_validated_public_key_bytes;
-        invalid_public_key_bytes[0] = invalid_public_key_bytes ^ 0xff;
+        invalid_public_key_bytes[0] = invalid_public_key_bytes[0] ^ 0xff;
 
         // Initialize module.
         let rewards_signer = get_signer(@rewards);


### PR DESCRIPTION
# Description

1. Implement `add_public_keys_and_fund_gas_escrows` API with 100% coverage testing.
1. Update vector-wise `for_each` to `for_each_ref` since the latter does not have to reverse the vector in place before iteration.
1. Split public keys into `claimed` and `eligible` tables for ease of fetching eligible public keys.
1. Update assorted APIs as needed for `claimed` and `eligible` table paradigm.

# Testing

`emojicoin_dot_fun_claim_link` module tested to 100% coverage. From in repo root:

```sh
cd src/move/rewards
```

```sh
aptos move test --dev --move-2 --coverage
```

Note that per https://github.com/aptos-labs/aptos-core/issues/15284 the `test_general_flow` test fails non-deterministically. If it fails, running it again will probably result in a pass, eventually.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you check all checkboxes from the linked Linear task?