### PR TITLE
[ECO-2429] Move the `emoji => name` middleware conversion to be before the allow…

### DIFF
--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -21,10 +21,9 @@ export default async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  if (!IS_ALLOWLIST_ENABLED) {
-    return NextResponse.next();
-  }
-
+  // This will replace emojis in the path name with their actual text names. Since this occurs
+  // before the allowlist check, it will redirect the user to the pure text version of their path
+  // but then still require them to verify after.
   const possibleMarketPath = normalizePossibleMarketPath(pathname, request.url);
   if (possibleMarketPath) {
     return NextResponse.redirect(possibleMarketPath);


### PR DESCRIPTION
# Description

Right now, if the allowlist is disabled, `middleware.ts` will call `NextResponse.next()` before normalizing the market path (converting emojis to their corresponding text names) and thus causing the page to return emoji not found.

- [x] To fix this, simply put the normalization of the market path before the allowlist check.

This will still require the user to verify once they're redirected to the normalized market path version of their URL, but will not result in the emoji not found error.

NOTE: This was actually in two places, so it looks like I'm removing the check entirely, but there's another identical check right after the path normalization.

# Testing

Delete this sentence and provide a description of how to test the changes in
this PR.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
