### PR TITLE
[ECO-2430] Build `deployer` service with Aptos CLI `v4.4.0`

### DIFF
--- a/src/docker/deployer/Dockerfile
+++ b/src/docker/deployer/Dockerfile
@@ -5,7 +5,7 @@
 # the `yq` releases on apt are outdated and technically deprecated.
 FROM mikefarah/yq:4.44.3 AS yq
 
-FROM econialabs/aptos-cli:4.1.0
+FROM econialabs/aptos-cli:4.4.0
 
 COPY --from=yq /usr/bin/yq /usr/bin/yq
 

--- a/src/docker/deployer/sh/build-publish-payloads.sh
+++ b/src/docker/deployer/sh/build-publish-payloads.sh
@@ -28,4 +28,5 @@ aptos move build-publish-payload \
 	--included-artifacts none \
 	--package-dir $move_dir/rewards/ \
 	--json-output-file $json_dir/rewards.json \
-	--skip-fetch-latest-git-deps
+	--skip-fetch-latest-git-deps \
+	--move-2

--- a/src/docker/deployer/sh/init-profile.sh
+++ b/src/docker/deployer/sh/init-profile.sh
@@ -19,7 +19,7 @@ fi
 # This script initializes a profile on the `testnet` network and then updates
 # the profile to use the `custom` network with the correct rest and faucet URLs.
 # This is a workaround to avoid having to run a local testnet during the image
-# build process.
+# build process. If the testnet query fails, it tries to use mainnet.
 # This facilitates checking the derived address against the expected address at
 # build time and initializing the profile and subsequent `aptos` config.yaml
 # file without having to run a local testnet.
@@ -29,12 +29,13 @@ fi
 profile="publisher"
 
 # See the note above for why we use `testnet` below.
-result_json=$(aptos init \
-	--assume-yes \
-	--profile $profile \
-	--private-key $PUBLISHER_PRIVATE_KEY \
-	--encoding hex \
-	--network testnet 2>/dev/null)
+# Use `mainnet` if `testnet` fails.
+base_cmd="aptos init --assume-yes --encoding hex"
+cmd="$base_cmd --profile $profile --private-key $PUBLISHER_PRIVATE_KEY"
+result_json=$(
+	$cmd --network testnet 2>/dev/null ||
+		$cmd --network mainnet 2>/dev/null
+)
 
 result=$(echo $result_json | jq -r '.Error')
 


### PR DESCRIPTION
# Description

- [x] Build `deployer` service with Aptos CLI `v4.4.0` since the new Move contract uses Move 2 constructs
- [x] Also, fallback to using `mainnet` if `testnet` is down when deriving the private key. Tested earlier when testnet API wasn't available due to the SSL cert being expired

# Testing

e2e tests will use it when it's done deploying and we'll know if it fails/succeeds or not for sure by then.
- [x] Will also build/test locally

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
