### PR TITLE
[ECO-23439] Add `--move-2` flag to rewards publish command

### DIFF
--- a/src/move/rewards/README.md
+++ b/src/move/rewards/README.md
@@ -35,6 +35,7 @@ NAMED_ADDRESSES=$(
 )
 aptos move publish \
     --assume-yes \
+    --move-2 \
     --named-addresses $NAMED_ADDRESSES \
     --profile $PROFILE
 ```


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Add `--move-2` flag to CLI command now that package has Move 2 syntax.

# Testing

Publishing on devnet
