### PR TITLE
[ECO-2442] Update default claim amount

### DIFF
--- a/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
+++ b/src/move/rewards/sources/emojicoin_dot_fun_claim_link.move
@@ -17,7 +17,7 @@ module rewards::emojicoin_dot_fun_claim_link {
     use std::signer;
 
     const INTEGRATOR_FEE_RATE_BPS: u8 = 100;
-    const DEFAULT_CLAIM_AMOUNT: u64 = 100_000_000;
+    const DEFAULT_CLAIM_AMOUNT: u64 = 500_000_000;
     const VAULT: vector<u8> = b"Claim link vault";
 
     /// Signer does not correspond to admin.


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Update default claim amount to 5 APT

# Testing

`aptos move test --dev --move-2` passes, except for the non-deterministic `test_general_flow` documented in #360 and https://github.com/aptos-labs/aptos-core/issues/15284
