### PR TITLE
[ECO-2448] Update audited git tag references

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 The emojicoin dot fun Move package is audited:
 
 - [PDF Report]
-- Corresponding `git` tag [`move-v1.0.0-audited`]
+- Corresponding `git` tag [`move-v1.0.1-audited`]
 
 <!-- markdownlint-enable MD036 -->
 
@@ -186,4 +186,4 @@ git submodule update --init --recursive
 [pre-commit shield]: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit
 [uploading environment variables with vercel's ui]: https://github.com/user-attachments/assets/d613725d-82ed-4a4e-a467-a89b2cf57d91
 [vercel cli]: https://vercel.com/docs/cli
-[`move-v1.0.0-audited`]: https://github.com/econia-labs/emojicoin-dot-fun/releases/tag/move-v1.0.0-audited
+[`move-v1.0.1-audited`]: https://github.com/econia-labs/emojicoin-dot-fun/releases/tag/move-v1.0.1-audited

--- a/doc/doc-site/docs/resources/audit.md
+++ b/doc/doc-site/docs/resources/audit.md
@@ -7,7 +7,7 @@ hide_title: false
 The emojicoin dot fun Move package is audited:
 
 - [PDF Report]
-- Corresponding `git` tag [`move-v1.0.0-audited`]
+- Corresponding `git` tag [`move-v1.0.1-audited`]
 
 [pdf report]: https://econia-labs.notion.site/emojicoin-dot-fun-audit-8806ffea2b594c8e846ce3d32e5630b9
-[`move-v1.0.0-audited`]: https://github.com/econia-labs/emojicoin-dot-fun/releases/tag/move-v1.0.0-audited
+[`move-v1.0.1-audited`]: https://github.com/econia-labs/emojicoin-dot-fun/releases/tag/move-v1.0.1-audited


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Update audited git tag references in README and in docs site

# Testing

Local markdown render clickthrough

# Checklist