### PR TITLE
[ECO-2456] Add serialization fix for cached query

### DIFF
--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -1,6 +1,6 @@
 import ClientEmojicoinPage from "components/pages/emojicoin/ClientEmojicoinPage";
 import EmojiNotFoundPage from "./not-found";
-import { cachedContractMarketView } from "lib/queries/aptos-client/market-view";
+import { wrappedCachedContractMarketView } from "lib/queries/aptos-client/market-view";
 import { SYMBOL_EMOJI_DATA } from "@sdk/emoji_data";
 import { pathToEmojiNames } from "utils/pathname-helpers";
 import { fetchChatEvents, fetchMarketState, fetchSwapEvents } from "@/queries/market";
@@ -76,7 +76,7 @@ const EmojicoinPage = async (params: EmojicoinPageProps) => {
     const [chats, swaps, marketView] = await Promise.all([
       fetchChatEvents({ marketID }),
       fetchSwapEvents({ marketID }),
-      cachedContractMarketView(marketAddress.toString()),
+      wrappedCachedContractMarketView(marketAddress.toString()),
     ]);
 
     return (

--- a/src/typescript/frontend/src/lib/queries/aptos-client/market-view.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-client/market-view.ts
@@ -4,6 +4,7 @@ import { toMarketView } from "@sdk-types";
 import { MarketView } from "@sdk/emojicoin_dot_fun/emojicoin-dot-fun";
 import { getAptos } from "lib/utils/aptos-client";
 import { unstable_cache } from "next/cache";
+import { parseJSON, stringifyJSON } from "utils";
 
 export const fetchContractMarketView = async (marketAddress: `0x${string}`) => {
   const aptos = getAptos();
@@ -12,13 +13,14 @@ export const fetchContractMarketView = async (marketAddress: `0x${string}`) => {
     marketAddress,
   });
 
-  return toMarketView(res);
+  return stringifyJSON(toMarketView(res));
 };
 
-export const cachedContractMarketView = unstable_cache(
-  fetchContractMarketView,
-  ["fetch-market-view"],
-  {
-    revalidate: 10,
-  }
-);
+const cachedContractMarketView = unstable_cache(fetchContractMarketView, ["fetch-market-view"], {
+  revalidate: 10,
+});
+
+export const wrappedCachedContractMarketView = async (marketAddress: `0x${string}`) => {
+  const cached = await cachedContractMarketView(marketAddress);
+  return parseJSON<ReturnType<typeof toMarketView>>(cached);
+};


### PR DESCRIPTION
# Description

We didn't properly serialize the data for `unstable_cache` so the build was failing at preview time. Now we serialize by typing the data, stringifying it, and then parsing it later when pulling from the cache or from a fetch.

# Testing

Testing in the preview build again.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
