### PR TITLE
[ECO-2459] Quadruple resources on DB, PostgREST, Broker

### DIFF
--- a/src/cloud-formation/indexer.cfn.yaml
+++ b/src/cloud-formation/indexer.cfn.yaml
@@ -110,7 +110,7 @@ Parameters:
   BrokerImageVersion:
     Type: 'String'
   DbMaxCapacity:
-    Default: 4
+    Default: 16
     Type: 'Number'
   DbMinCapacity:
     Default: 0.5
@@ -654,10 +654,10 @@ Resources:
           - 'Constants'
           - 'Networking'
           - 'BrokerPort'
-      Cpu: '256'
+      Cpu: '1024'
       ExecutionRoleArn: !GetAtt 'ContainerRole.Arn'
       Family: !Ref 'AWS::StackName'
-      Memory: '512'
+      Memory: '2048'
       NetworkMode: 'awsvpc'
       RequiresCompatibilities:
       - 'FARGATE'
@@ -1305,10 +1305,10 @@ Resources:
           - 'Constants'
           - 'Networking'
           - 'PostgrestHealthCheckPort'
-      Cpu: '256'
+      Cpu: '1024'
       ExecutionRoleArn: !GetAtt 'ContainerRole.Arn'
       Family: !Ref 'AWS::StackName'
-      Memory: '512'
+      Memory: '2048'
       NetworkMode: 'awsvpc'
       RequiresCompatibilities:
       - 'FARGATE'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Quadruple resources on DB, PostgREST, and Broker instances

Update does not require replacement for DB, but does require replacement for the task definition for the other services

However since multiple services can run concurrently this should just spawn new instances then gradually retire the old ones


# Testing

Passes `cfn-lint` checks for allowable values
