### PR TITLE
[ECO-2467] Merge `main` to `production`, add back in autoConnect for the wallet adapter

### DIFF
--- a/src/typescript/frontend/src/context/providers.tsx
+++ b/src/typescript/frontend/src/context/providers.tsx
@@ -55,7 +55,7 @@ const ThemedApp: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           <UserSettingsProvider>
             <AptosWalletAdapterProvider
               plugins={wallets}
-              autoConnect={false}
+              autoConnect={true}
               dappConfig={{
                 aptosApiKey: APTOS_API_KEY,
                 network: APTOS_NETWORK,


### PR DESCRIPTION
# Description

Reconnecting manually is cumbersome and this should have been flipped back on a while ago anyway

# Testing

Testing in preview build

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
