### PR TITLE
[ECO-2469] Remove galxe campaign fetch in allowlist checks

### DIFF
--- a/src/typescript/frontend/src/components/pages/verify/session.ts
+++ b/src/typescript/frontend/src/components/pages/verify/session.ts
@@ -22,14 +22,14 @@ export const createSession = async (address: AccountAddressString) => {
 
   cookies().set(COOKIE_FOR_HASHED_ADDRESS, hashed, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: process.env.NODE_ENV === "production" || process.env.VERCEL === "1",
     maxAge: COOKIE_LENGTH,
     path: "/",
   });
 
   cookies().set(COOKIE_FOR_ACCOUNT_ADDRESS, address, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: process.env.NODE_ENV === "production" || process.env.VERCEL === "1",
     maxAge: COOKIE_LENGTH,
     path: "/",
   });

--- a/src/typescript/frontend/src/lib/server-env.ts
+++ b/src/typescript/frontend/src/lib/server-env.ts
@@ -14,8 +14,7 @@ if (!process.env.HASH_SEED || process.env.HASH_SEED.length < 8) {
 
 if (
   IS_ALLOWLIST_ENABLED &&
-  typeof process.env.ALLOWLISTER3K_URL === "undefined" &&
-  typeof process.env.GALXE_CAMPAIGN_ID === "undefined"
+  typeof process.env.ALLOWLISTER3K_URL === "undefined"
 ) {
   throw new Error("Allowlist is enabled but no allowlist provider is set.");
 }
@@ -38,7 +37,6 @@ if (GEOBLOCKING_ENABLED) {
 }
 
 export const ALLOWLISTER3K_URL: string | undefined = process.env.ALLOWLISTER3K_URL;
-export const GALXE_CAMPAIGN_ID: string | undefined = process.env.GALXE_CAMPAIGN_ID;
 export const REVALIDATION_TIME: number = Number(process.env.REVALIDATION_TIME);
 export const VPNAPI_IO_API_KEY: string = process.env.VPNAPI_IO_API_KEY!;
 export const PRE_LAUNCH_TEASER: boolean = process.env.PRE_LAUNCH_TEASER === "true";

--- a/src/typescript/frontend/src/lib/utils/allowlist.ts
+++ b/src/typescript/frontend/src/lib/utils/allowlist.ts
@@ -1,11 +1,9 @@
 import "server-only";
 
 import { IS_ALLOWLIST_ENABLED } from "lib/env";
-import { ALLOWLISTER3K_URL, GALXE_CAMPAIGN_ID } from "lib/server-env";
+import { ALLOWLISTER3K_URL } from "lib/server-env";
 
-export const GALXE_URL = "https://graphigo.prd.galaxy.eco/query";
-
-// Checks if the given address is allow listed either in Galxe or in Allowlister3000.
+// Checks if the given address is allow listed in Allowlister3000.
 //
 // If IS_ALLOWLIST_ENABLED is not truthy, the function returns true.
 //
@@ -19,44 +17,8 @@ export async function isAllowListed(addressIn: string): Promise<boolean> {
     ? (addressIn as `0x${string}`)
     : (`0x${addressIn}` as const);
 
-  const [inCampaign, onAllowlist] = await Promise.all([
-    isInGalxeCampaign(address),
-    isOnCustomAllowlist(address),
-  ]);
-  return inCampaign || onAllowlist;
+  return await isOnCustomAllowlist(address);
 }
-
-export const isInGalxeCampaign = async (address: `0x${string}`): Promise<boolean> => {
-  if (GALXE_CAMPAIGN_ID !== undefined) {
-    const condition = await fetch(GALXE_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify({
-        query: `{
-        campaign(id: "${GALXE_CAMPAIGN_ID}") {
-          whitelistInfo(address: "${address}") {
-            maxCount
-            usedCount
-            claimedLoyaltyPoints
-            currentPeriodMaxLoyaltyPoints
-            currentPeriodClaimedLoyaltyPoints
-          }
-        }
-      }`,
-      }),
-    })
-      .then((r) => r.json())
-      .then((data) => data.data.campaign && data.data.campaign.whitelistInfo.usedCount === 1);
-    if (condition) {
-      return true;
-    }
-  }
-
-  return false;
-};
 
 export const isOnCustomAllowlist = async (address: `0x${string}`): Promise<boolean> => {
   if (ALLOWLISTER3K_URL !== undefined) {


### PR DESCRIPTION
# Description

This allows us to re-enable allowlist.ts checks on `main` without letting people in by being previously on the galxe campaign.

Note this only affects builds who have `IS_ALLOWLIST_ENABLED` set to `true`.

# Testing

Check it manually using the preview build here.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
