### PR TITLE
[ECO-2470] Add okx icon/logo to middleware.ts so it shows up in the wallet adapter on `/verify`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/.env
 **/.turbo
+**/.vercel
+**/.env*.local

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -20,14 +20,7 @@ export default async function middleware(request: NextRequest) {
   if (MAINTENANCE_MODE && pathname !== "/maintenance") {
     return NextResponse.redirect(new URL(ROUTES.maintenance, request.url));
   }
-  if (
-    pathname === "/social-preview.png" ||
-    pathname === "/webclip.png" ||
-    pathname === "/icon.png" ||
-    pathname === "/test" ||
-    pathname === "/geolocation" ||
-    pathname === "/verify_status"
-  ) {
+  if (pathname === "/test" || pathname === "/verify_status") {
     return NextResponse.next();
   }
 
@@ -63,6 +56,20 @@ export default async function middleware(request: NextRequest) {
   return NextResponse.next();
 }
 
+const negativeLookaheads = [
+  "verify",
+  "api",
+  "_next/static",
+  "_next/image",
+  "favicon.ico",
+  "logo192.png",
+  "icon.png",
+  "webclip.png",
+  "social-preview.png",
+  "okx-logo.png",
+  "manifest.json",
+].join("|");
+
 export const config = {
-  matcher: "/((?!verify|api|_next/static|_next/image|favicon.ico|logo192.png|okx-logo.png|manifest.json).*)",
+  matcher: `/((?!${negativeLookaheads}).*)`,
 };

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -64,5 +64,5 @@ export default async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: "/((?!verify|api|_next/static|_next/image|favicon.ico|logo192.png|manifest.json).*)",
+  matcher: "/((?!verify|api|_next/static|_next/image|favicon.ico|logo192.png|okx-logo.png|manifest.json).*)",
 };

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -56,20 +56,8 @@ export default async function middleware(request: NextRequest) {
   return NextResponse.next();
 }
 
-const negativeLookaheads = [
-  "verify",
-  "api",
-  "_next/static",
-  "_next/image",
-  "favicon.ico",
-  "logo192.png",
-  "icon.png",
-  "webclip.png",
-  "social-preview.png",
-  "okx-logo.png",
-  "manifest.json",
-].join("|");
-
+// Note this must be a static string- we can't dynamically construct it.
 export const config = {
-  matcher: `/((?!${negativeLookaheads}).*)`,
+  /* eslint-disable-next-line */
+  matcher: `/((?!verify|api|_next/static|_next/image|favicon.ico|logo192.png|icon.png|webclip.png|social-preview.png|okx-logo.png|manifest.json).*)`,
 };


### PR DESCRIPTION
# Description

Fairly self explanatory- the image won't load unless the matcher allows it through on `middleware.ts` unauthenticated (that is, let an unauthenticated user see the okx logo in the wallet adapter).

We didn't have to do this before because the wallet adapter used all SVGs and those aren't public/static files, but pure HTML elements.

