### PR TITLE
[ECO-2488] Fix emojicoin balance query by using the view function instead of the external indexer API

### DIFF
--- a/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { withResponseError } from "./client";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { type TypeTagInput } from "@sdk/emojicoin_dot_fun";
+import { Balance } from "@sdk/emojicoin_dot_fun/aptos-framework";
 
 /**
  * __NOTE: If you're using this for a connected user's APT balance, you should use__
@@ -60,12 +61,11 @@ export const useWalletBalance = ({
         return res;
       }
       return withResponseError(
-        aptos
-          .getAccountCoinAmount({
-            accountAddress,
-            coinType: coinType.toString() as `${string}::${string}::${string}`,
-          })
-          .then((r) => BigInt(r))
+        Balance.view({
+          aptos,
+          owner: accountAddress,
+          typeTags: [coinType],
+        }).then((res) => BigInt(res))
       );
     },
     placeholderData: (previousBalance) => previousBalance ?? 0,

--- a/src/typescript/sdk/src/emojicoin_dot_fun/aptos-framework.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/aptos-framework.ts
@@ -2,13 +2,13 @@
 import {
   MoveVector,
   AccountAddress,
+  Aptos,
   U64,
   type AccountAddressInput,
   type Uint64,
   type AptosConfig,
   type InputGenerateTransactionOptions,
   buildTransaction,
-  type Aptos,
   type Account,
   type WaitForTransactionOptions,
   type UserTransactionResponse,
@@ -21,7 +21,7 @@ import {
   EntryFunctionTransactionBuilder,
   ViewFunctionPayloadBuilder,
 } from "./payload-builders";
-import { type TypeTagInput } from ".";
+import { Uint64String, type TypeTagInput } from ".";
 import { getAptosClient } from "../utils/aptos-client";
 
 export type MintPayloadMoveArguments = {
@@ -362,6 +362,56 @@ export class ExistsAt extends ViewFunctionPayloadBuilder<[boolean]> {
     options?: LedgerVersionArg;
   }): Promise<boolean> {
     const [res] = await new ExistsAt(args).view(args);
+    return res;
+  }
+}
+
+export type BalancePayloadMoveArguments = {
+  owner: AccountAddress;
+};
+
+/**
+ *```
+ *  #[view]
+ *  public fun balance<CoinType>(
+ *     owner: address,
+ *  ): u64
+ *```
+ * */
+
+export class Balance extends ViewFunctionPayloadBuilder<[Uint64String]> {
+  public readonly moduleAddress = AccountAddress.ONE;
+
+  public readonly moduleName = "coin";
+
+  public readonly functionName = "balance";
+
+  public readonly args: BalancePayloadMoveArguments;
+
+  public readonly typeTags: [TypeTag]; // [CoinType]
+
+  constructor(args: {
+    owner: AccountAddressInput; // address
+    typeTags: [TypeTagInput]; // [CoinType]
+  }) {
+    super();
+    const { owner, typeTags } = args;
+
+    this.args = {
+      owner: AccountAddress.from(owner),
+    };
+    this.typeTags = typeTags.map((typeTag) =>
+      typeof typeTag === "string" ? parseTypeTag(typeTag) : typeTag
+    ) as [TypeTag];
+  }
+
+  static async view(args: {
+    aptos: Aptos | AptosConfig;
+    owner: AccountAddressInput; // address
+    typeTags: [TypeTagInput]; // [CoinType]
+    options?: LedgerVersionArg;
+  }): Promise<Uint64String> {
+    const [res] = await new Balance(args).view(args);
     return res;
   }
 }

--- a/src/typescript/sdk/src/emojicoin_dot_fun/aptos-framework.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/aptos-framework.ts
@@ -2,7 +2,7 @@
 import {
   MoveVector,
   AccountAddress,
-  Aptos,
+  type Aptos,
   U64,
   type AccountAddressInput,
   type Uint64,
@@ -21,7 +21,7 @@ import {
   EntryFunctionTransactionBuilder,
   ViewFunctionPayloadBuilder,
 } from "./payload-builders";
-import { Uint64String, type TypeTagInput } from ".";
+import { type Uint64String, type TypeTagInput } from ".";
 import { getAptosClient } from "../utils/aptos-client";
 
 export type MintPayloadMoveArguments = {

--- a/src/typescript/sdk/src/emojicoin_dot_fun/index.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/index.ts
@@ -1,3 +1,4 @@
+export * as AptosFramework from "./aptos-framework";
 export * as EmojicoinDotFun from "./emojicoin-dot-fun";
 export * from "./types";
 export * from "./utils";


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The external indexer API (the Aptos Labs hosted one) expects addresses *without* leading zeroes. If you send a CoinType with a leading zero in the first third of the MoveStruct (e.g. `0x0...beef::coin_module::CoinType`, even if the address is correct, the `current_fungible_asset_balance` query will return zero.

One out of 16 addresses will start with a 0, so this was a fairly pervasive issue.

An example is the two billiard coin:

https://explorer.aptoslabs.com/coin/0x072a70c925a8260880de81b500ecd743e652cd74797eb1d024f44ea195cbf8bb::coin_factory::Emojicoin?network=mainnet

Note the address starts with 0x072

The issue is that AIP-40 stipulates that a standardized address *does* include leading zeros, but the indexer expects no leading zeroes.

We could parse it and conform to the expected indexer format, but it's simpler to just use a view function instead, since the address is serialized and thus the leading zero is no longer an issue.

- [x] Fix this by using a view function to check the `0x1::coin::balance<EmojicoinType>` directly

# Testing

Testing it in the preview build

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
