### PR TITLE
[ECO-2499] Update deploy files

### DIFF
--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '1.0.1'
+  BrokerImageVersion: '1.1.0'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -23,7 +23,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '1.0.1'
+  ProcessorImageVersion: '1.1.0'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-main.yaml
+++ b/src/cloud-formation/deploy-indexer-main.yaml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  BrokerImageVersion: '1.0.1'
+  BrokerImageVersion: '1.1.1'
   DeployAlb: 'true'
   DeployAlbDnsRecord: 'true'
   DeployBastionHost: 'true'
@@ -20,7 +20,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'main'
   Network: 'testnet'
-  ProcessorImageVersion: '1.0.1'
+  ProcessorImageVersion: '1.1.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-main.yaml
+++ b/src/cloud-formation/deploy-indexer-main.yaml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  BrokerImageVersion: '1.1.1'
+  BrokerImageVersion: '1.1.0'
   DeployAlb: 'true'
   DeployAlbDnsRecord: 'true'
   DeployBastionHost: 'true'
@@ -20,7 +20,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'main'
   Network: 'testnet'
-  ProcessorImageVersion: '1.1.1'
+  ProcessorImageVersion: '1.1.0'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '1.0.1'
+  BrokerImageVersion: '1.1.0'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -23,7 +23,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '1.0.1'
+  ProcessorImageVersion: '1.1.0'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'


### PR DESCRIPTION
# Description

Bump deploy files to use the processor (and broker) with updates to the `price_feed` where it returns `market_state` as well.

# Testing

Unit/e2e tests, testing on the `main` deployment branch. Currently `main` is pointing to the old stack and thus is "broken" (price feed isn't working).

Once these changes take effect, the `main` preview build should function perfectly.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
