### PR TITLE
[ECO-2516] Merge local storage JSON parse hotfix to production

### DIFF
--- a/src/typescript/frontend/src/configs/local-storage-keys.ts
+++ b/src/typescript/frontend/src/configs/local-storage-keys.ts
@@ -30,8 +30,8 @@ export function readLocalStorageCache<T>(key: keyof typeof LOCAL_STORAGE_KEYS): 
   if (str === null) {
     return null;
   }
-  const cache = parseJSON<LocalStorageCache<T>>(str);
   try {
+    const cache = parseJSON<LocalStorageCache<T>>(str);
     if (new Date(cache.expiry) > new Date()) {
       return cache.data;
     }


### PR DESCRIPTION
# Description

Merge local storage hotfix to production. No try/catch around the parse means old invalid JSON values aren't correctly caught.

This fixes that.

# Testing

Tested by manually setting `@econia-labs/emojicoin-frontend_theme` local storage value to `light`.