### PR TITLE
[ECO-2526] Fix bug where you can't sort by market cap

### DIFF
--- a/src/typescript/frontend/src/lib/queries/sorting/query-params.ts
+++ b/src/typescript/frontend/src/lib/queries/sorting/query-params.ts
@@ -1,7 +1,7 @@
 import { type OrderByStrings } from "@sdk/queries/const";
 import { toMarketDataSortByHomePage, type SortByPageQueryParams } from "./types";
 import { safeParsePageWithDefault } from "lib/routes/home-page-params";
-import { SortMarketsBy } from "@sdk/indexer-v2/types/common";
+import { DEFAULT_SORT_BY, type SortMarketsBy } from "@sdk/indexer-v2/types/common";
 
 export type HomePageSearchParams = {
   page: string | undefined;
@@ -33,7 +33,7 @@ export const constructURLForHomePage = ({
     newURL.searchParams.set("q", searchBytes);
   }
   const newSort = toMarketDataSortByHomePage(sort);
-  if (newSort !== SortMarketsBy.MarketCap) {
+  if (newSort !== DEFAULT_SORT_BY) {
     newURL.searchParams.set("sort", newSort);
   }
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes a bug that made it impossible to sort by market cap.

The issue was due to how query parameters for the home page were handled.

The fix should prevent this from happening in the future, even if we change the default sorting order again.

