### PR TITLE
[ECO-2266] Add go to page button

### DIFF
--- a/src/typescript/frontend/src/components/EmojiPill.tsx
+++ b/src/typescript/frontend/src/components/EmojiPill.tsx
@@ -1,5 +1,4 @@
 import { type MouseEventHandler } from "react";
-import { Text } from "components/text";
 import { Emoji } from "utils/emoji";
 import Popup from "./popup";
 import { emoji } from "utils";
@@ -15,13 +14,7 @@ export const EmojiPill = ({
   onClick?: MouseEventHandler<HTMLDivElement>;
 }) => {
   return (
-    <Popup
-      content={
-        <Text textScale="pixelHeading4" textTransform="uppercase" color="black">
-          {description}
-        </Text>
-      }
-    >
+    <Popup content={description}>
       <div
         className={
           "px-[.7rem] py-[.2rem] border-[1px] border-solid rounded-full " +

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -9,7 +9,6 @@ import OuterConnectText from "./OuterConnectText";
 import Arrow from "@icons/Arrow";
 import { useNameStore } from "context/event-store-context";
 import Popup from "components/popup";
-import Text from "components/text";
 import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 export interface ConnectWalletProps extends PropsWithChildren<{ className?: string }> {
@@ -124,19 +123,7 @@ export const ButtonWithConnectWalletFallback: React.FC<ConnectWalletProps> = ({
       children
     );
 
-  return geoblocked ? (
-    <Popup
-      content={
-        <Text textTransform="uppercase" color="black">
-          not available in your jurisdiction
-        </Text>
-      }
-    >
-      {inner}
-    </Popup>
-  ) : (
-    inner
-  );
+  return geoblocked ? <Popup content="not available in your jurisdiction">{inner}</Popup> : inner;
 };
 
 export default ButtonWithConnectWalletFallback;

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/table-row/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/table-row/index.tsx
@@ -7,7 +7,6 @@ import { toNominalPrice } from "@sdk/utils/nominal-price";
 import { ExplorerLink } from "components/link/component";
 import { darkColors } from "theme";
 import { formatDisplayName } from "@sdk/utils";
-import Text from "components/text";
 import Popup from "components/popup";
 import { motion } from "framer-motion";
 import { emoji } from "utils";
@@ -76,14 +75,13 @@ const TableRow = ({
       <td className={`min-w-[60px] xl:min-w-[71px] xl:ml-[0.5ch] xl:mr-[-0.5ch] ${Height}`}>
         <Popup
           content={
-            <Text textScale="pixelHeading4" lineHeight="20px" color="black">
-              {item.rankIcon === emoji("blowfish")
-                ? "n00b"
-                : item.rankIcon === emoji("spouting whale")
-                  ? "365 UR SO JULIA"
-                  : "SKILL ISSUE"}
-            </Text>
+            item.rankIcon === emoji("blowfish")
+              ? "n00b"
+              : item.rankIcon === emoji("spouting whale")
+                ? "365 UR SO JULIA"
+                : "SKILL ISSUE"
           }
+          uppercase={false}
         >
           <div className="flex h-full relative">
             <Emoji className="text-light-gray m-auto" emojis={item.rankIcon} />

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -275,16 +275,9 @@ const Liquidity = ({ market }: LiquidityProps) => {
               </Text>
 
               <Info>
-                <Text
-                  textScale="pixelHeading4"
-                  lineHeight="20px"
-                  color="black"
-                  textTransform="uppercase"
-                >
-                  Liquidity providers receive a 0.25% fee from all trades, proportional to their
-                  pool share. Fees are continuously reinvested in the pool and can be claimed by
-                  withdrawing liquidity.
-                </Text>
+                Liquidity providers receive a 0.25% fee from all trades, proportional to their pool
+                share. Fees are continuously reinvested in the pool and can be claimed by
+                withdrawing liquidity.
               </Info>
             </FlexGap>
           </Flex>

--- a/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-header/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-header/index.tsx
@@ -34,39 +34,24 @@ const TableHeader: React.FC<TableHeaderProps> = ({ item, isLast, onClick }) => {
       >
         {isLast && (
           <Info>
-            <Text
-              textScale="pixelHeading4"
-              lineHeight="20px"
-              color="black"
-              textTransform="uppercase"
-            >
+            <div>
               <FlexGap gap=".2rem" justifyContent="space-between">
                 <span>DPR:</span>
                 <span>Daily Percentage Return</span>
               </FlexGap>
-            </Text>
-            <Text
-              textScale="pixelHeading4"
-              lineHeight="20px"
-              color="black"
-              textTransform="uppercase"
-            >
+            </div>
+            <div>
               <FlexGap gap=".2rem" justifyContent="space-between">
                 <span>WPR:</span>
                 <span>Weekly Percentage Return</span>
               </FlexGap>
-            </Text>
-            <Text
-              textScale="pixelHeading4"
-              lineHeight="20px"
-              color="black"
-              textTransform="uppercase"
-            >
+            </div>
+            <div>
               <FlexGap gap=".2rem" justifyContent="space-between">
                 <span>APR:</span>
                 <span>Annual Percentage Return</span>
               </FlexGap>
-            </Text>
+            </div>
           </Info>
         )}
         <Text

--- a/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-row-desktop/XprPopup.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-row-desktop/XprPopup.tsx
@@ -1,56 +1,32 @@
 import { type ReactNode } from "react";
-import { Big } from "big.js";
-import { emoji } from "utils";
-import { Emoji } from "utils/emoji";
 
-const DAYS_IN_WEEK = 7;
-const DAYS_IN_YEAR = 365;
-
-// prettier-ignore
-export const getXPR = (x: number, tvlPerLpCoinGrowth: Big) =>
-  Big(tvlPerLpCoinGrowth)
-    .pow(x)
-    .sub(Big(1))
-    .mul(Big(100));
-
-export const formatXPR = (time: number, bigDailyTvl: Big) => {
-  if (bigDailyTvl.eq(Big(0))) {
-    return <Emoji emojis={emoji("hourglass not done")} />;
-  }
-  const xprIn = getXPR(time, bigDailyTvl);
-  const xpr = xprIn.toFixed(4);
-  return `${xpr.replace(/(\.0*|(?<=(\..*))0*)$/, "")}%`;
-};
-
-export const XprPopup = ({ bigDailyTvl }: { bigDailyTvl: Big }): ReactNode => {
-  return bigDailyTvl.eq(Big(0)) ? (
-    <div className="leading-5 text-black !font-forma text-md">
-      <span>{"Please wait until this pool has existed for at"}</span>
-      <br />
-      <span>{"least one day to view its percentage returns."}</span>
+export const XprPopup = ({
+  dpr,
+  wpr,
+  apr,
+}: {
+  dpr: string;
+  wpr: string;
+  apr: string;
+}): ReactNode => (
+  <>
+    <div>
+      <div className="flex gap-[0.2rem] justify-between">
+        <span>DPR:</span>
+        <span>{dpr}</span>
+      </div>
     </div>
-  ) : (
-    [
-      <div className="font-pixelar pixel-heading-4 leading-5 text-black uppercase" key="DPR">
-        <div className="flex gap-[0.2rem] justify-between">
-          <span>DPR:</span>
-          <span>{formatXPR(1, bigDailyTvl)}</span>
-        </div>
-      </div>,
-      <div className="font-pixelar pixel-heading-4 leading-5 text-black uppercase" key="WPR">
-        <div className="flex gap-[0.2rem] justify-between">
-          <span>WPR:</span>
-          <span>{formatXPR(DAYS_IN_WEEK, bigDailyTvl)}</span>
-        </div>
-      </div>,
-      <div className="font-pixelar pixel-heading-4 leading-5 text-black uppercase" key="APR">
-        <div className="flex gap-[0.2rem] justify-between">
-          <span>APR:</span>
-          <span>{formatXPR(DAYS_IN_YEAR, bigDailyTvl)}</span>
-        </div>
-      </div>,
-    ]
-  );
-};
-
-export default formatXPR;
+    <div>
+      <div className="flex gap-[0.2rem] justify-between">
+        <span>WPR:</span>
+        <span>{wpr}</span>
+      </div>
+    </div>
+    <div>
+      <div className="flex gap-[0.2rem] justify-between">
+        <span>APR:</span>
+        <span>{apr}</span>
+      </div>
+    </div>
+  </>
+);

--- a/src/typescript/frontend/src/components/popup/index.tsx
+++ b/src/typescript/frontend/src/components/popup/index.tsx
@@ -1,25 +1,21 @@
 import React from "react";
 import * as RadixTooltip from "@radix-ui/react-tooltip";
 import "./styles.css";
-import Text from "components/text";
 
 const Popup: React.FC<
-  React.PropsWithChildren<{ content: React.ReactNode; className?: string }>
-> = ({ children, content, className }) => {
+  React.PropsWithChildren<{ content: React.ReactNode; className?: string; uppercase?: boolean }>
+> = ({ children, content, className, uppercase = true }) => {
   return (
     <RadixTooltip.Provider delayDuration={200}>
       <RadixTooltip.Root>
         <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>
         <RadixTooltip.Portal>
           <RadixTooltip.Content className={`TooltipContent ${className}`} sideOffset={5}>
-            {typeof content === "string" ||
-            typeof content === "bigint" ||
-            typeof content === "number" ||
-            typeof content === "boolean" ? (
-              <Text color="black">{content}</Text>
-            ) : (
-              content
-            )}
+            <div
+              className={`text-black pixel-heading-4 font-pixelar ${uppercase ? "uppercase" : ""}`}
+            >
+              {content}
+            </div>
             <RadixTooltip.Arrow className="TooltipArrow" />
           </RadixTooltip.Content>
         </RadixTooltip.Portal>


### PR DESCRIPTION
# Description

This PR adds a button to go to the market page from the pools page.

This also optimizes the pools page by using `Number` instead of `Big` for the XPR calculations. This looses some precision but is not that visible.

It also refactors the `Popup` component with default styling.

