### PR TITLE
[ECO-2548] Fix swap component inputs so it swaps the input/output amounts upon buy => sell and vice versa

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -244,9 +244,8 @@ export default function SwapComponent({
         <FlipInputsArrow
           onClick={() => {
             setInputAmount(outputAmount);
-            // This is done as to not display an old value if the swap simulation fails.
-            setOutputAmount(0n);
-            setPrevious(0n);
+            setOutputAmount(inputAmount);
+            setPrevious(inputAmount);
             setIsSell((v) => !v);
           }}
         />


### PR DESCRIPTION
# Description

We can make the swap component perfectly simulate + not lose precision when displaying input/output amounts and swapping back and forth between buy/sell now.

This is a very small fix.

# Testing

Already tested locally.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
