### PR TITLE
[ECO-2459] Display all time volume as the secondary metric in the table card when it's the `sortBy` type

### DIFF
--- a/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
@@ -56,20 +56,27 @@ const TableCard = ({
   );
   const animationEvent = stateEvents.at(0);
 
-  const { isBumpOrder, secondaryMetric, marketCap } = useMemo(() => {
-    const isBumpOrder = sortBy === SortMarketsBy.BumpOrder;
-    const { lastSwapVolume, marketCap } = animationEvent
+  const { secondaryLabel, secondaryMetric, marketCap } = useMemo(() => {
+    const { allTimeVolume, lastSwapVolume, marketCap } = animationEvent
       ? {
+          allTimeVolume: animationEvent.state.cumulativeStats.quoteVolume,
           lastSwapVolume: animationEvent.lastSwap.quoteVolume,
           marketCap: animationEvent.state.instantaneousStats.marketCap,
         }
       : {
+          allTimeVolume: 0n,
           lastSwapVolume: 0n,
           marketCap: staticMarketCap,
         };
+    const [secondaryLabel, secondaryMetric] =
+      sortBy === SortMarketsBy.BumpOrder
+        ? ["Last Swap", lastSwapVolume]
+        : sortBy === SortMarketsBy.AllTimeVolume
+          ? ["All Time Vol", allTimeVolume]
+          : ["24h Volume", staticVolume24H];
     return {
-      isBumpOrder,
-      secondaryMetric: isBumpOrder ? lastSwapVolume : staticVolume24H,
+      secondaryLabel,
+      secondaryMetric,
       marketCap,
     };
   }, [sortBy, animationEvent, staticVolume24H, staticMarketCap]);
@@ -106,7 +113,7 @@ const TableCard = ({
     if (animationEvent) {
       runAnimationSequence(animationEvent);
     }
-  }, [animationEvent, runAnimationSequence, isBumpOrder]);
+  }, [animationEvent, runAnimationSequence, sortBy]);
 
   const { curr, prev, variant, displayIndex, layoutDelay } = useMemo(() => {
     const { curr, prev } = calculateGridData({
@@ -269,7 +276,7 @@ const TableCard = ({
                     "group-hover:text-ec-blue uppercase p-[1px] transition-all"
                   }
                 >
-                  {isBumpOrder ? t("Last Swap") : t("24h Volume")}
+                  {t(secondaryLabel)}
                 </div>
                 <motion.div
                   animate={controls}


### PR DESCRIPTION
# Description

Display a market's all time volume as the secondary metric in the table card when it's the `sortBy` type.

# Testing

Manual testing + on preview build! Change the sort order in the grid.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
