### PR TITLE
[ECO-2551] Update volume bars to all use quote volume

### DIFF
--- a/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
+++ b/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
@@ -1,9 +1,10 @@
 import { type Types } from "@sdk-types";
-import { ONE_APT_BIGINT, type Period, periodEnumToRawDuration, rawPeriodToEnum } from "@sdk/const";
+import { type Period, periodEnumToRawDuration, rawPeriodToEnum } from "@sdk/const";
 import { type SwapEventModel, type PeriodicStateEventModel } from "@sdk/indexer-v2/types";
 import { getPeriodStartTimeFromTime } from "@sdk/utils";
 import { q64ToBig } from "@sdk/utils/nominal-price";
 import Big from "big.js";
+import { toNominal } from "lib/utils/decimals";
 
 export type Bar = {
   time: number;
@@ -30,7 +31,7 @@ export const periodicStateTrackerToLatestBar = (
     high: q64ToBig(tracker.highPriceQ64).toNumber(),
     low: q64ToBig(tracker.lowPriceQ64).toNumber(),
     close: q64ToBig(tracker.closePriceQ64).toNumber(),
-    volume: Number(tracker.volumeQuote / ONE_APT_BIGINT),
+    volume: toNominal(tracker.volumeQuote),
     period: rawPeriodToEnum(tracker.period),
     marketNonce,
   };
@@ -59,7 +60,7 @@ export const toBar = (event: PeriodicStateEventModel): Bar => ({
   high: q64ToBig(event.periodicState.highPriceQ64).toNumber(),
   low: q64ToBig(event.periodicState.lowPriceQ64).toNumber(),
   close: q64ToBig(event.periodicState.closePriceQ64).toNumber(),
-  volume: Number(event.periodicState.volumeQuote / ONE_APT_BIGINT),
+  volume: toNominal(event.periodicState.volumeQuote),
 });
 
 export const toBars = (events: PeriodicStateEventModel | PeriodicStateEventModel[]) =>
@@ -81,7 +82,7 @@ export const createBarFromSwap = (
     high: price,
     low: price,
     close: price,
-    volume: Number(swap.quoteVolume / ONE_APT_BIGINT),
+    volume: toNominal(swap.quoteVolume),
     period,
     marketNonce: market.marketNonce,
   };

--- a/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
+++ b/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
@@ -30,7 +30,7 @@ export const periodicStateTrackerToLatestBar = (
     high: q64ToBig(tracker.highPriceQ64).toNumber(),
     low: q64ToBig(tracker.lowPriceQ64).toNumber(),
     close: q64ToBig(tracker.closePriceQ64).toNumber(),
-    volume: Number(tracker.volumeBase),
+    volume: Number(tracker.volumeQuote),
     period: rawPeriodToEnum(tracker.period),
     marketNonce,
   };
@@ -81,7 +81,7 @@ export const createBarFromSwap = (
     high: price,
     low: price,
     close: price,
-    volume: Number(swap.baseVolume),
+    volume: Number(swap.quoteVolume),
     period,
     marketNonce: market.marketNonce,
   };

--- a/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
+++ b/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
@@ -1,5 +1,5 @@
 import { type Types } from "@sdk-types";
-import { ONE_APT, type Period, periodEnumToRawDuration, rawPeriodToEnum } from "@sdk/const";
+import { ONE_APT_BIGINT, type Period, periodEnumToRawDuration, rawPeriodToEnum } from "@sdk/const";
 import { type SwapEventModel, type PeriodicStateEventModel } from "@sdk/indexer-v2/types";
 import { getPeriodStartTimeFromTime } from "@sdk/utils";
 import { q64ToBig } from "@sdk/utils/nominal-price";
@@ -30,7 +30,7 @@ export const periodicStateTrackerToLatestBar = (
     high: q64ToBig(tracker.highPriceQ64).toNumber(),
     low: q64ToBig(tracker.lowPriceQ64).toNumber(),
     close: q64ToBig(tracker.closePriceQ64).toNumber(),
-    volume: Number(tracker.volumeQuote),
+    volume: Number(tracker.volumeQuote / ONE_APT_BIGINT),
     period: rawPeriodToEnum(tracker.period),
     marketNonce,
   };
@@ -59,7 +59,7 @@ export const toBar = (event: PeriodicStateEventModel): Bar => ({
   high: q64ToBig(event.periodicState.highPriceQ64).toNumber(),
   low: q64ToBig(event.periodicState.lowPriceQ64).toNumber(),
   close: q64ToBig(event.periodicState.closePriceQ64).toNumber(),
-  volume: Number(event.periodicState.volumeQuote) / ONE_APT,
+  volume: Number(event.periodicState.volumeQuote / ONE_APT_BIGINT),
 });
 
 export const toBars = (events: PeriodicStateEventModel | PeriodicStateEventModel[]) =>
@@ -81,7 +81,7 @@ export const createBarFromSwap = (
     high: price,
     low: price,
     close: price,
-    volume: Number(swap.quoteVolume),
+    volume: Number(swap.quoteVolume / ONE_APT_BIGINT),
     period,
     marketNonce: market.marketNonce,
   };

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -1,4 +1,4 @@
-import { Period, PERIODS, periodEnumToRawDuration, ONE_APT_BIGINT } from "@sdk/const";
+import { Period, PERIODS, periodEnumToRawDuration } from "@sdk/const";
 import { type SubscribeBarsCallback } from "@static/charting_library/datafeed-api";
 import { type WritableDraft } from "immer";
 import { type EventState, type CandlestickData, type MarketEventStore } from "./types";
@@ -12,6 +12,7 @@ import {
 import { getPeriodStartTimeFromTime } from "@sdk/utils";
 import { createBarFromPeriodicState, createBarFromSwap, type LatestBar } from "./candlestick-bars";
 import { q64ToBig } from "@sdk/utils/nominal-price";
+import { toNominal } from "lib/utils/decimals";
 
 type PeriodicState = DatabaseModels["periodic_state_events"];
 
@@ -80,7 +81,7 @@ export const handleLatestBarForSwapEvent = (
       data.latestBar.high = Math.max(data.latestBar.high, price);
       data.latestBar.low = Math.min(data.latestBar.low, price);
       data.latestBar.marketNonce = event.market.marketNonce;
-      data.latestBar.volume += Number(event.swap.quoteVolume / ONE_APT_BIGINT);
+      data.latestBar.volume += toNominal(event.swap.quoteVolume);
       // Note this results in `time order violation` errors if we set `has_empty_bars`
       // to `true` in the `LibrarySymbolInfo` configuration.
       callbackClonedLatestBarIfSubscribed(data.callback, data.latestBar);
@@ -122,7 +123,7 @@ export const handleLatestBarForPeriodicStateEvent = (
         data.latestBar.high = Math.max(data.latestBar.high, price);
         data.latestBar.low = Math.min(data.latestBar.low, price);
         data.latestBar.marketNonce = innerMarket.marketNonce;
-        data.latestBar.volume += Number(innerSwap.quoteVolume / ONE_APT_BIGINT);
+        data.latestBar.volume += toNominal(innerSwap.quoteVolume);
       }
     }
     // Call the callback with the new latest bar.

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -80,7 +80,7 @@ export const handleLatestBarForSwapEvent = (
       data.latestBar.high = Math.max(data.latestBar.high, price);
       data.latestBar.low = Math.min(data.latestBar.low, price);
       data.latestBar.marketNonce = event.market.marketNonce;
-      data.latestBar.volume += Number(event.swap.baseVolume);
+      data.latestBar.volume += Number(event.swap.quoteVolume);
       // Note this results in `time order violation` errors if we set `has_empty_bars`
       // to `true` in the `LibrarySymbolInfo` configuration.
       callbackClonedLatestBarIfSubscribed(data.callback, data.latestBar);
@@ -122,7 +122,7 @@ export const handleLatestBarForPeriodicStateEvent = (
         data.latestBar.high = Math.max(data.latestBar.high, price);
         data.latestBar.low = Math.min(data.latestBar.low, price);
         data.latestBar.marketNonce = innerMarket.marketNonce;
-        data.latestBar.volume += Number(innerSwap.baseVolume);
+        data.latestBar.volume += Number(innerSwap.quoteVolume);
       }
     }
     // Call the callback with the new latest bar.


### PR DESCRIPTION
# Description

SSIA, use quote volume instead of base when displaying it in the candlestick bars. This was an oversight when moving from base => quote a few days ago.

Note only the final candlestick bar was incorrect- all of the candlesticks prior to it used quote volume, so it looked like the last bar had an extraordinary amount of volume.

- [x] Fix this before merging the change to quote volume to production.
- [x] Update the bars to use the `toNominal(...)` function to correctly display decimalized prices

# Testing

Preview build!

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
