### PR TITLE
[ECO-2558] Remove `Connect wallet` in the mobile menu if a user is geoblocked

### DIFF
--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -16,6 +16,7 @@ import { Copy, LogOut, User } from "lucide-react";
 import { useWalletModal } from "context/wallet-context/WalletModalContext";
 import { AnimatePresence, useAnimationControls } from "framer-motion";
 import AnimatedDropdownItem from "./components/animated-dropdown-item";
+import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
 
 const IconClass = "w-[22px] h-[22px] m-auto ml-[3ch] mr-[1.5ch]";
 
@@ -86,17 +87,20 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
       }
     }
   };
+  const geoblocked = useIsUserGeoblocked();
 
   return (
     <StyledMotion initial="hidden" animate={isOpen ? "visible" : "hidden"} variants={slideVariants}>
       <MobileMenuWrapper>
         <MobileMenuInner>
-          <ButtonWithConnectWalletFallback
-            className="w-full"
-            mobile={true}
-            onClick={subMenuOnClick}
-            arrow
-          />
+          {!geoblocked && (
+            <ButtonWithConnectWalletFallback
+              className={"w-full"}
+              mobile={true}
+              onClick={subMenuOnClick}
+              arrow
+            />
+          )}
           <AnimatePresence>
             {subMenuOpen && (
               <>


### PR DESCRIPTION
# Description

Right now, if a user is geoblocked, the `Connect Wallet` item in the mobile menu isn't disabled visually, so it's confusing why clicking it doesn't work. The simplest solution for this is just removing it from the mobile menu if the user is geoblocked.

We can't disable the `Menu` item entirely, because that contains the links to the other pages, so we just remove the option to connect the wallet.

Geoblocked:
![image](https://github.com/user-attachments/assets/4820667d-16df-42eb-aa32-c9490ecdf8e0)

Not geoblocked:
![image](https://github.com/user-attachments/assets/e771c3f1-fd81-46c0-9f5c-24559346739a)


# Testing

Tested it locally by clearing my cache and enabling geoblocking, then clearing my cache and disabling geoblocking.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
