### PR TITLE
[ECO-2525] Sort pool page by dpr by default

### DIFF
--- a/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
@@ -27,7 +27,7 @@ export type PoolsData = MarketStateModel | UserPoolsRPCModel;
 export const ClientPoolsPage = ({ initialData }: { initialData: PoolsData[] }) => {
   const searchParams = useSearchParams();
   const poolParam = searchParams.get("pool");
-  const [sortBy, setSortBy] = useState<SortByPageQueryParams>("all_time_vol");
+  const [sortBy, setSortBy] = useState<SortByPageQueryParams>("apr");
   const [orderBy, setOrderBy] = useState<"desc" | "asc">("desc");
   const [selectedIndex, setSelectedIndex] = useState<number | undefined>(poolParam ? 0 : undefined);
   const [page, setPage] = useState<number>(1);

--- a/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
@@ -21,13 +21,14 @@ import { useSearchParams } from "next/navigation";
 import { encodeEmojis, getEmojisInString, type SymbolEmoji } from "@sdk/emoji_data";
 import SearchBar from "components/inputs/search-bar";
 import { type MarketStateModel, type UserPoolsRPCModel } from "@sdk/indexer-v2/types";
+import { DEFAULT_POOLS_SORT_BY } from "@sdk/indexer-v2/queries/query-params";
 
 export type PoolsData = MarketStateModel | UserPoolsRPCModel;
 
 export const ClientPoolsPage = ({ initialData }: { initialData: PoolsData[] }) => {
   const searchParams = useSearchParams();
   const poolParam = searchParams.get("pool");
-  const [sortBy, setSortBy] = useState<SortByPageQueryParams>("apr");
+  const [sortBy, setSortBy] = useState<SortByPageQueryParams>(DEFAULT_POOLS_SORT_BY);
   const [orderBy, setOrderBy] = useState<"desc" | "asc">("desc");
   const [selectedIndex, setSelectedIndex] = useState<number | undefined>(poolParam ? 0 : undefined);
   const [page, setPage] = useState<number>(1);

--- a/src/typescript/sdk/src/indexer-v2/queries/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/index.ts
@@ -1,3 +1,4 @@
 export * from "./app";
 export * from "./client";
 export * from "./utils";
+export * from "./query-params";

--- a/src/typescript/sdk/src/indexer-v2/queries/query-params.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/query-params.ts
@@ -40,9 +40,12 @@ const isValidSortBy = (input?: string | null): input is SortMarketsBy =>
   validSortBy.has((input ?? "") as unknown as SortMarketsBy);
 
 /* eslint-disable-next-line import/no-unused-modules */
+export const DEFAULT_POOLS_SORT_BY = SortMarketsBy.Apr;
+
+/* eslint-disable-next-line import/no-unused-modules */
 export const getValidSortByForPoolsPage = (input?: string | null): SortMarketsBy => {
   if (isValidSortBy(input)) {
     return input;
   }
-  return SortMarketsBy.MarketCap;
+  return DEFAULT_POOLS_SORT_BY;
 };


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR makes it so that by default, the pool page is sorted by APR.

# Testing

See pool page on vercel.

# Checklist

- [ ] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
