### PR TITLE
[ECO-2565] Add proper search params to the pools page server component; copy the GET request params logic

### DIFF
--- a/src/typescript/frontend/src/app/pools/page.tsx
+++ b/src/typescript/frontend/src/app/pools/page.tsx
@@ -1,9 +1,10 @@
 import ClientPoolsPage, { type PoolsData } from "components/pages/pools/ClientPoolsPage";
 import { getPoolData } from "./api/getPoolDataQuery";
-import { SortMarketsBy } from "@sdk/indexer-v2/types/common";
 import { symbolBytesToEmojis } from "@sdk/emoji_data/utils";
 import { type Metadata } from "next";
 import { emoji, parseJSON } from "utils";
+import { getValidSortByForPoolsPage } from "@sdk/indexer-v2/queries/query-params";
+import { safeParsePageWithDefault, handleEmptySearchBytes } from "lib/routes/home-page-params";
 
 export const revalidate = 2;
 
@@ -12,16 +13,31 @@ export const metadata: Metadata = {
   description: `Provide ${emoji("water wave")}liquidity${emoji("water wave")} and earn APR using your emojis !`,
 };
 
-export default async function PoolsPage({ searchParams }: { searchParams: { pool: string } }) {
+type PoolsSearchParams = {
+  page: string | null;
+  sortby: string | null;
+  orderby: string | null;
+  searchBytes: string | null;
+  pool: string | null;
+  account: string | null;
+};
+
+export default async function PoolsPage({ searchParams }: { searchParams: PoolsSearchParams }) {
+  const page = safeParsePageWithDefault(searchParams.page);
+  const sortBy = getValidSortByForPoolsPage(searchParams.sortby);
+  const orderBy = searchParams.orderby ?? "desc";
+  const q = handleEmptySearchBytes(searchParams.searchBytes);
+  const searchEmojis = q ? symbolBytesToEmojis(q).emojis.map((e) => e.emoji) : undefined;
+
+  if (orderBy !== "asc" && orderBy !== "desc") {
+    throw new Error("Invalid params");
+  }
+
+  // The liquidity `provider`, aka the account to search for in the user liquidity pools.
+  const provider = searchParams.account;
+
   const initialData: PoolsData[] = parseJSON(
-    await getPoolData(
-      1,
-      SortMarketsBy.AllTimeVolume,
-      "desc",
-      searchParams.pool
-        ? symbolBytesToEmojis(searchParams.pool).emojis.map((e) => e.emoji)
-        : undefined
-    )
+    await getPoolData(page, sortBy, orderBy, searchEmojis, provider ?? undefined)
   );
 
   return <ClientPoolsPage initialData={initialData} />;

--- a/src/typescript/frontend/src/app/pools/page.tsx
+++ b/src/typescript/frontend/src/app/pools/page.tsx
@@ -22,6 +22,10 @@ type PoolsSearchParams = {
   account: string | null;
 };
 
+/**
+ * Uses the same exact parsing logic as the /pools/api route.
+ * @see {@link src/pools/api/route.ts}
+ */
 export default async function PoolsPage({ searchParams }: { searchParams: PoolsSearchParams }) {
   const page = safeParsePageWithDefault(searchParams.page);
   const sortBy = getValidSortByForPoolsPage(searchParams.sortby);


### PR DESCRIPTION
# Description

- [x] Add search params that use the same logic and params as the `GET` request to the server component
- [x] Ensure the sort order doesn't cause the rows to flash anymore upon load

# Testing

Ocular patdown of the row order on load. Otherwise, this logic is exactly the same as the GET request so it should generally just synchronize the initial load with the first GET request in all different combinations of search params.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
