### PR TITLE
[ECO-2570] Fix package.json linked `tsconfig.*.json` file name for publishing

### DIFF
--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -61,7 +61,7 @@
     "build": "tsc",
     "build:debug": "BUILD_DEBUG=true pnpm run build",
     "build:no-checks": "tsc --skipLibCheck",
-    "build:publish": "tsc -p tsconfig.prod.json",
+    "build:publish": "tsc -p tsconfig.publish.json",
     "check": "tsc -p tests/tsconfig.json --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "e2e:testnet": "pnpm load-test-env -v NO_TEST_SETUP=true -- pnpm jest tests/e2e/queries/testnet",


### PR DESCRIPTION
# Description

- [x] Change from `tsconfig.prod.json` => `tsconfig.publish.json`
- [ ] Publish to npm registry after merge
- [ ] Make the git tag/release after merge

