### PR TITLE
[ECO-2615] Fix the dexscreener endpoints to return floored numbers, set caching policies

### DIFF
--- a/src/typescript/frontend/src/app/dexscreener/asset/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/asset/route.ts
@@ -26,6 +26,7 @@ import { EMOJICOIN_SUPPLY } from "@sdk/const";
 import { calculateCirculatingSupply } from "@sdk/markets";
 import { symbolEmojiStringToArray } from "../util";
 import { fetchMarketState } from "@/queries/market";
+import { toNominal } from "lib/utils/decimals";
 
 /**
  * - In most cases, asset ids will correspond to contract addresses. Ids are case-sensitive.
@@ -63,14 +64,14 @@ async function getAsset(assetId: string): Promise<Asset> {
 
   const circulatingSupply: { circulatingSupply?: number | string } = {};
   if (marketState && marketState.state) {
-    circulatingSupply.circulatingSupply = calculateCirculatingSupply(marketState.state).toString();
+    circulatingSupply.circulatingSupply = toNominal(calculateCirculatingSupply(marketState.state));
   }
 
   return {
     id: assetId,
     name: marketEmojiData.symbolData.name,
     symbol: marketEmojiData.symbolData.symbol,
-    totalSupply: EMOJICOIN_SUPPLY.toString(),
+    totalSupply: toNominal(EMOJICOIN_SUPPLY),
     ...circulatingSupply,
     // coinGeckoId: assetId,
     // coinMarketCapId: assetId,

--- a/src/typescript/frontend/src/app/dexscreener/asset/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/asset/route.ts
@@ -77,6 +77,16 @@ async function getAsset(assetId: string): Promise<Asset> {
   };
 }
 
+// Although this route would be ideal for caching, nextjs doesn't offer the ability to control
+// caches for failed responses. In other words, if someone queries an asset that doesn't exist
+// yet at this endpoint, it would permanently cache that asset as not existing and thus return
+// the failed query JSON response. This is obviously problematic for not yet existing markets,
+// so unless we have some way to not cache failed queries/empty responses, we can't cache this
+// endpoint at all.
+export const revalidate = 0;
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
 // NextJS JSON response handler
 export async function GET(request: NextRequest): Promise<NextResponse<AssetResponse>> {
   const searchParams = request.nextUrl.searchParams;

--- a/src/typescript/frontend/src/app/dexscreener/asset/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/asset/route.ts
@@ -70,7 +70,7 @@ async function getAsset(assetId: string): Promise<Asset> {
     id: assetId,
     name: marketEmojiData.symbolData.name,
     symbol: marketEmojiData.symbolData.symbol,
-    totalSupply: Number(EMOJICOIN_SUPPLY),
+    totalSupply: EMOJICOIN_SUPPLY.toString(),
     ...circulatingSupply,
     // coinGeckoId: assetId,
     // coinMarketCapId: assetId,

--- a/src/typescript/frontend/src/app/dexscreener/asset/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/asset/route.ts
@@ -87,12 +87,11 @@ export const revalidate = 0;
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
-// NextJS JSON response handler
 export async function GET(request: NextRequest): Promise<NextResponse<AssetResponse>> {
   const searchParams = request.nextUrl.searchParams;
   const assetId = searchParams.get("id");
   if (!assetId) {
-    // This is a required field, and is an error otherwise
+    // This is a required field, and is an error otherwise.
     return new NextResponse("id is a parameter", { status: 400 });
   }
   const asset = await getAsset(assetId);

--- a/src/typescript/frontend/src/app/dexscreener/events/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/events/route.ts
@@ -84,7 +84,7 @@ import {
   type toLiquidityEventModel,
   type toSwapEventModel,
 } from "@sdk/indexer-v2/types";
-import { calculateCurvePrice, getReserves } from "@sdk/markets";
+import { calculateCurvePrice, calculateRealReserves } from "@sdk/markets";
 import { toCoinDecimalString } from "../../../lib/utils/decimals";
 import { DECIMALS } from "@sdk/const";
 import { symbolEmojisToPairId } from "../util";
@@ -215,7 +215,7 @@ function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Swa
         asset1In: toCoinDecimalString(event.swap.quoteVolume, DECIMALS),
       };
 
-  const { base, quote } = getReserves(event.state);
+  const { base, quote } = calculateRealReserves(event.state);
   const reserves = {
     asset0: toCoinDecimalString(base, DECIMALS),
     asset1: toCoinDecimalString(quote, DECIMALS),
@@ -236,7 +236,7 @@ function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Swa
     txnIndex: Number(event.transaction.version),
     eventIndex: Number(event.blockAndEvent.eventIndex),
 
-    maker: event.transaction.sender,
+    maker: event.swap.swapper,
     pairId: symbolEmojisToPairId(event.market.symbolEmojis),
 
     ...assetInOut,
@@ -248,7 +248,7 @@ function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Swa
 function toDexscreenerJoinExitEvent(
   event: ReturnType<typeof toLiquidityEventModel>
 ): JoinExitEvent & BlockInfo {
-  const { base, quote } = getReserves(event.state);
+  const { base, quote } = calculateRealReserves(event.state);
   const reserves = {
     asset0: toCoinDecimalString(base, DECIMALS),
     asset1: toCoinDecimalString(quote, DECIMALS),
@@ -268,7 +268,7 @@ function toDexscreenerJoinExitEvent(
     txnIndex: Number(event.transaction.version),
     eventIndex: Number(event.blockAndEvent.eventIndex),
 
-    maker: event.transaction.sender,
+    maker: event.liquidity.provider,
     pairId: symbolEmojisToPairId(event.market.symbolEmojis),
 
     amount0: toCoinDecimalString(event.liquidity.baseAmount, DECIMALS),

--- a/src/typescript/frontend/src/app/dexscreener/events/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/events/route.ts
@@ -298,7 +298,6 @@ export const revalidate = 0;
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
-// NextJS JSON response handler
 /**
  * We treat our versions as "blocks" because it's faster to implement given our current architecture
  * This requires dexscreener to have relatively large `fromBlock - toBlock` ranges to keep up

--- a/src/typescript/frontend/src/app/dexscreener/events/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/events/route.ts
@@ -84,7 +84,7 @@ import {
   type toLiquidityEventModel,
   type toSwapEventModel,
 } from "@sdk/indexer-v2/types";
-import { calculateCurvePrice, calculateRealReserves } from "@sdk/markets";
+import { calculateCurvePrice, getReserves } from "@sdk/markets";
 import { toCoinDecimalString } from "../../../lib/utils/decimals";
 import { DECIMALS } from "@sdk/const";
 import { symbolEmojisToPairId } from "../util";
@@ -215,7 +215,7 @@ function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Swa
         asset1In: toCoinDecimalString(event.swap.quoteVolume, DECIMALS),
       };
 
-  const { base, quote } = calculateRealReserves(event.state);
+  const { base, quote } = getReserves(event.state);
   const reserves = {
     asset0: toCoinDecimalString(base, DECIMALS),
     asset1: toCoinDecimalString(quote, DECIMALS),
@@ -248,7 +248,7 @@ function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Swa
 function toDexscreenerJoinExitEvent(
   event: ReturnType<typeof toLiquidityEventModel>
 ): JoinExitEvent & BlockInfo {
-  const { base, quote } = calculateRealReserves(event.state);
+  const { base, quote } = getReserves(event.state);
   const reserves = {
     asset0: toCoinDecimalString(base, DECIMALS),
     asset1: toCoinDecimalString(quote, DECIMALS),

--- a/src/typescript/frontend/src/app/dexscreener/events/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/events/route.ts
@@ -202,9 +202,7 @@ type Event = (SwapEvent | JoinExitEvent) & BlockInfo;
 interface EventsResponse {
   events: Event[];
 }
-type Asdf = Flatten<SwapEvent & BlockInfo>;
-
-function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Asdf {
+function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): SwapEvent & BlockInfo {
   // Base / quote is emojicoin / APT.
   // Thus asset0 / asset1 is always base volume / quote volume.
   const assetInOut = event.swap.isSell
@@ -238,7 +236,7 @@ function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Asd
     txnIndex: Number(event.transaction.version),
     eventIndex: Number(event.blockAndEvent.eventIndex),
 
-    maker: event.swap.swapper,
+    maker: event.transaction.sender,
     pairId: symbolEmojisToPairId(event.market.symbolEmojis),
 
     ...assetInOut,
@@ -270,7 +268,7 @@ function toDexscreenerJoinExitEvent(
     txnIndex: Number(event.transaction.version),
     eventIndex: Number(event.blockAndEvent.eventIndex),
 
-    maker: event.liquidity.provider,
+    maker: event.transaction.sender,
     pairId: symbolEmojisToPairId(event.market.symbolEmojis),
 
     amount0: toCoinDecimalString(event.liquidity.baseAmount, DECIMALS),

--- a/src/typescript/frontend/src/app/dexscreener/events/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/events/route.ts
@@ -88,7 +88,27 @@ import { calculateCurvePrice, calculateRealReserves } from "@sdk/markets";
 import { toCoinDecimalString } from "../../../lib/utils/decimals";
 import { DECIMALS } from "@sdk/const";
 import { symbolEmojisToPairId } from "../util";
-import { compareBigInt } from "@econia-labs/emojicoin-sdk";
+import { compareBigInt, type Flatten } from "@econia-labs/emojicoin-sdk";
+import { type XOR } from "@sdk/utils/utility-types";
+
+export type Asset0In1Out = {
+  asset0In: number | string;
+  asset1Out: number | string;
+};
+
+export type Asset1In0Out = {
+  asset0Out: number | string;
+  asset1In: number | string;
+};
+
+export type AssetInOut = XOR<Asset0In1Out, Asset1In0Out>;
+
+export type DexscreenerReserves = {
+  reserves: {
+    asset0: number | string;
+    asset1: number | string;
+  };
+};
 
 /**
  * - `txnId` is a transaction identifier such as a transaction hash
@@ -128,24 +148,19 @@ import { compareBigInt } from "@econia-labs/emojicoin-sdk";
  * - The Indexer automatically handles calculations for USD pricing (`priceUsd` as opposed to
  * `priceNative`)
  */
-export interface SwapEvent {
-  eventType: "swap";
-  txnId: string;
-  txnIndex: number;
-  eventIndex: number;
-  maker: string;
-  pairId: string;
-  asset0In?: number | string;
-  asset1In?: number | string;
-  asset0Out?: number | string;
-  asset1Out?: number | string;
-  priceNative: number | string;
-  reserves?: {
-    asset0: number | string;
-    asset1: number | string;
-  };
-  metadata?: Record<string, string>;
-}
+export type SwapEvent = Flatten<
+  {
+    eventType: "swap";
+    txnId: string;
+    txnIndex: number;
+    eventIndex: number;
+    maker: string;
+    pairId: string;
+    priceNative: number | string;
+    metadata?: Record<string, string>;
+  } & AssetInOut &
+    DexscreenerReserves
+>;
 
 /**
  * - `txnId` is a transaction identifier such as a transaction hash
@@ -167,21 +182,19 @@ export interface SwapEvent {
  * - `metadata` includes any optional auxiliary info not covered in the default schema and not
  * required in most cases
  */
-interface JoinExitEvent {
-  eventType: "join" | "exit";
-  txnId: string;
-  txnIndex: number;
-  eventIndex: number;
-  maker: string;
-  pairId: string;
-  amount0: number | string;
-  amount1: number | string;
-  reserves?: {
-    asset0: number | string;
-    asset1: number | string;
-  };
-  metadata?: Record<string, string>;
-}
+type JoinExitEvent = Flatten<
+  {
+    eventType: "join" | "exit";
+    txnId: string;
+    txnIndex: number;
+    eventIndex: number;
+    maker: string;
+    pairId: string;
+    amount0: number | string;
+    amount1: number | string;
+    metadata?: Record<string, string>;
+  } & DexscreenerReserves
+>;
 
 type BlockInfo = { block: Block };
 type Event = (SwapEvent | JoinExitEvent) & BlockInfo;
@@ -189,27 +202,20 @@ type Event = (SwapEvent | JoinExitEvent) & BlockInfo;
 interface EventsResponse {
   events: Event[];
 }
+type Asdf = Flatten<SwapEvent & BlockInfo>;
 
-function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): SwapEvent & BlockInfo {
-  let assetInOut;
-
-  if (event.swap.isSell) {
-    // We are selling to APT
-    assetInOut = {
-      asset0In: toCoinDecimalString(event.swap.inputAmount, DECIMALS),
-      asset0Out: 0,
-      asset1In: 0,
-      asset1Out: toCoinDecimalString(event.swap.baseVolume, DECIMALS),
-    };
-  } else {
-    // We are buying with APT
-    assetInOut = {
-      asset0In: 0,
-      asset0Out: toCoinDecimalString(event.swap.quoteVolume, DECIMALS),
-      asset1In: toCoinDecimalString(event.swap.inputAmount, DECIMALS),
-      asset1Out: 0,
-    };
-  }
+function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Asdf {
+  // Base / quote is emojicoin / APT.
+  // Thus asset0 / asset1 is always base volume / quote volume.
+  const assetInOut = event.swap.isSell
+    ? {
+        asset0In: toCoinDecimalString(event.swap.baseVolume, DECIMALS),
+        asset1Out: toCoinDecimalString(event.swap.quoteVolume, DECIMALS),
+      }
+    : {
+        asset0Out: toCoinDecimalString(event.swap.baseVolume, DECIMALS),
+        asset1In: toCoinDecimalString(event.swap.quoteVolume, DECIMALS),
+      };
 
   const { base, quote } = calculateRealReserves(event.state);
   const reserves = {
@@ -236,11 +242,8 @@ function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Swa
     pairId: symbolEmojisToPairId(event.market.symbolEmojis),
 
     ...assetInOut,
-
-    asset0In: event.swap.inputAmount.toString(),
-    asset1Out: event.swap.quoteVolume.toString(),
     priceNative,
-    ...reserves,
+    reserves,
   };
 }
 

--- a/src/typescript/frontend/src/app/dexscreener/events/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/events/route.ts
@@ -224,7 +224,7 @@ function toDexscreenerSwapEvent(event: ReturnType<typeof toSwapEventModel>): Swa
   return {
     block: {
       blockNumber: Number(event.blockAndEvent.blockNumber),
-      blockTimestamp: event.transaction.timestamp.getTime() / 1000,
+      blockTimestamp: Math.floor(event.transaction.timestamp.getTime() / 1000),
     },
     eventType: "swap",
     txnId: event.transaction.version.toString(),
@@ -258,7 +258,7 @@ function toDexscreenerJoinExitEvent(
   return {
     block: {
       blockNumber: Number(event.blockAndEvent.blockNumber),
-      blockTimestamp: event.transaction.timestamp.getTime() / 1000,
+      blockTimestamp: Math.floor(event.transaction.timestamp.getTime() / 1000),
     },
     eventType: event.liquidity.liquidityProvided ? "join" : "exit",
 
@@ -289,6 +289,14 @@ async function getEventsByVersion(fromBlock: number, toBlock: number): Promise<E
         : toDexscreenerSwapEvent(event)
     );
 }
+
+// Don't cache this request, because we could inadvertently cache data that is immediately invalid
+// in the case where the `toBlock` is larger than the present block. Although this shouldn't happen,
+// it's not worth caching these queries anyway, because they should only be called once or twice
+// with the same query parameters.
+export const revalidate = 0;
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
 
 // NextJS JSON response handler
 /**

--- a/src/typescript/frontend/src/app/dexscreener/latest-block/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/latest-block/route.ts
@@ -36,7 +36,6 @@ interface LatestBlockResponse {
 
 export const revalidate = 1;
 
-// NextJS JSON response handler
 export async function GET(_request: NextRequest): Promise<NextResponse<LatestBlockResponse>> {
   const status = await getProcessorStatus();
   const aptos = getAptosClient();

--- a/src/typescript/frontend/src/app/dexscreener/latest-block/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/latest-block/route.ts
@@ -26,7 +26,7 @@ import { getAptosClient } from "@sdk/utils/aptos-client";
  */
 export interface Block {
   blockNumber: number;
-  blockTimestamp: number; // Whole number integer representing UNIX timestamp in seconds.
+  blockTimestamp: number; // Whole number representing a UNIX timestamp in seconds.
   metadata?: Record<string, string>;
 }
 
@@ -48,7 +48,6 @@ export async function GET(_request: NextRequest): Promise<NextResponse<LatestBlo
   return NextResponse.json({
     block: {
       blockNumber,
-      // Convert to seconds
       blockTimestamp: Math.floor(status.lastTransactionTimestamp.getTime() / 1000),
     },
   });

--- a/src/typescript/frontend/src/app/dexscreener/latest-block/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/latest-block/route.ts
@@ -26,13 +26,15 @@ import { getAptosClient } from "@sdk/utils/aptos-client";
  */
 export interface Block {
   blockNumber: number;
-  blockTimestamp: number;
+  blockTimestamp: number; // Whole number integer representing UNIX timestamp in seconds.
   metadata?: Record<string, string>;
 }
 
 interface LatestBlockResponse {
   block: Block;
 }
+
+export const revalidate = 1;
 
 // NextJS JSON response handler
 export async function GET(_request: NextRequest): Promise<NextResponse<LatestBlockResponse>> {
@@ -48,7 +50,7 @@ export async function GET(_request: NextRequest): Promise<NextResponse<LatestBlo
     block: {
       blockNumber,
       // Convert to seconds
-      blockTimestamp: status.lastTransactionTimestamp.getTime() / 1000,
+      blockTimestamp: Math.floor(status.lastTransactionTimestamp.getTime() / 1000),
     },
   });
 }

--- a/src/typescript/frontend/src/app/dexscreener/pair/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/pair/route.ts
@@ -121,7 +121,6 @@ export const revalidate = 0;
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
-// NextJS JSON response handler
 export async function GET(request: NextRequest): Promise<NextResponse<PairResponse>> {
   const searchParams = request.nextUrl.searchParams;
   const pairId = searchParams.get("id");

--- a/src/typescript/frontend/src/app/dexscreener/pair/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/pair/route.ts
@@ -53,7 +53,7 @@ interface Pair {
   asset0Id: string;
   asset1Id: string;
   createdAtBlockNumber?: number;
-  createdAtBlockTimestamp?: number;
+  createdAtBlockTimestamp?: number; // Whole number representing a UNIX timestamp in seconds.
   createdAtTxnId?: string;
   creator?: string;
   feeBps?: number;
@@ -104,7 +104,9 @@ async function getPair(
       asset0Id: symbolEmojisToString(symbolEmojis),
       asset1Id: "APT",
       createdAtBlockNumber: parseInt(block.block_height),
-      createdAtBlockTimestamp: marketRegistration.transaction.timestamp.getTime() / 1000,
+      createdAtBlockTimestamp: Math.floor(
+        marketRegistration.transaction.timestamp.getTime() / 1000
+      ),
       createdAtTxnId: String(marketRegistration.transaction.version),
       feeBps: INTEGRATOR_FEE_RATE_BPS,
     },

--- a/src/typescript/frontend/src/app/dexscreener/pair/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/pair/route.ts
@@ -111,6 +111,16 @@ async function getPair(
   };
 }
 
+// Although this route would be ideal for caching, nextjs doesn't offer the ability to control
+// caches for failed responses. In other words, if someone queries an asset that doesn't exist
+// yet at this endpoint, it would permanently cache that asset as not existing and thus return
+// the failed query JSON response. This is obviously problematic for not yet existing markets,
+// so unless we have some way to not cache failed queries/empty responses, we can't cache this
+// endpoint at all.
+export const revalidate = 0;
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
 // NextJS JSON response handler
 export async function GET(request: NextRequest): Promise<NextResponse<PairResponse>> {
   const searchParams = request.nextUrl.searchParams;

--- a/src/typescript/sdk/src/markets/utils.ts
+++ b/src/typescript/sdk/src/markets/utils.ts
@@ -456,7 +456,34 @@ PreciseBig.DP = 100;
  * This is equivalent to calculating the slope of the tangent line created from the exact point on
  * the curve, where the curve is the function the AMM uses to calculate the price for the market.
  *
- * The price is denominated in `base / quote`, where `base` is the emojicoin and `quote` is APT.
+ * The price is denominated in `base / quote`, but this is *NOT* a mathematical representation.
+ * Since the `base` is simply `1`, in a `base / quote` representation, the order of base and quote
+ * don't actually mean anything other than which one is being expressed as the whole number `1`.
+ *
+ * That is, `base / quote` does not imply that you divide `base` by `quote` to get the price, it
+ * just indicates how the price is going to be expressed semantically. What it really means is
+ * that you are describing the price in terms of `1 base` per `P quote`.
+ *
+ * To calculate this with the reserves, we need to find `P` below:
+ *
+ * 1 emojicoin / P APT
+ *
+ * We already know the reserves, now just structure them as the same fraction:
+ *
+ * emojicoin_reserves / APT_reserves
+ *
+ * Thus:
+ *
+ * 1 / P = emojicoin_reserves / APT_reserves
+ * =>
+ * 1 = (emojicoin_reserves / APT_reserves) * P
+ * =>
+ * 1 / (emojicoin_reserves / APT_reserves) = P
+ * =>
+ * APT_reserves / emojicoin_reserves = P
+ * =>
+ * Thus, when APT = quote and emojicoin = base,
+ * the price P = (quote.reserves / base.reserves)
  *
  *  * For an in depth explanation of the math and behavior behind the AMMs:
  * @see {@link https://github.com/econia-labs/emojicoin-dot-fun/blob/main/doc/blackpaper/emojicoin-dot-fun-blackpaper.pdf}

--- a/src/typescript/sdk/src/markets/utils.ts
+++ b/src/typescript/sdk/src/markets/utils.ts
@@ -416,6 +416,16 @@ export const calculateRealReserves = ({
       }
     : cpammRealReserves;
 
+// Returns the reserves of a market that are used to calculate the price of the asset along its
+// AMM curve. For `inBondingCurve` markets, this is the virtual reserves, for post-bonding curve
+// markets, this is the market's real reserves.
+export const getReserves = ({
+  clammVirtualReserves,
+  cpammRealReserves,
+  ...args
+}: ReservesAndBondingCurveState): Types["Reserves"] =>
+  isInBondingCurve(args) ? clammVirtualReserves : cpammRealReserves;
+
 /**
  * *NOTE*: If you already have a market's state, call {@link calculateRealReserves} directly.
  *

--- a/src/typescript/sdk/src/markets/utils.ts
+++ b/src/typescript/sdk/src/markets/utils.ts
@@ -456,7 +456,7 @@ PreciseBig.DP = 100;
  * This is equivalent to calculating the slope of the tangent line created from the exact point on
  * the curve, where the curve is the function the AMM uses to calculate the price for the market.
  *
- * The price is denominated in `quote / base`, where `base` is the emojicoin and `quote` is APT.
+ * The price is denominated in `base / quote`, where `base` is the emojicoin and `quote` is APT.
  *
  *  * For an in depth explanation of the math and behavior behind the AMMs:
  * @see {@link https://github.com/econia-labs/emojicoin-dot-fun/blob/main/doc/blackpaper/emojicoin-dot-fun-blackpaper.pdf}

--- a/src/typescript/sdk/src/utils/utility-types.ts
+++ b/src/typescript/sdk/src/utils/utility-types.ts
@@ -36,3 +36,8 @@ export type Writable<T> = {
 export type DeepWritable<T> = {
   -readonly [P in keyof T]: DeepWritable<T[P]>;
 };
+
+// prettier-ignore
+export type XOR<T, U> =
+  | (T & { [K in keyof U]?: never })
+  | (U & { [K in keyof T]?: never });

--- a/src/typescript/sdk/tests/e2e/calculate-curve-price.test.ts
+++ b/src/typescript/sdk/tests/e2e/calculate-curve-price.test.ts
@@ -112,8 +112,8 @@ describe(`curve price calculations w/ geometric mean, at least ${accuracy * 100}
       )
       .then(({ beforePrice, swap, response }) => ({
         before: beforePrice,
-        average: PreciseBig(swap.event.quoteVolume.toString()).div(
-          swap.event.baseVolume.toString()
+        average: PreciseBig(swap.event.baseVolume.toString()).div(
+          swap.event.quoteVolume.toString()
         ),
         after: calculateCurvePrice(swap.model.state),
         response,

--- a/src/typescript/sdk/tests/e2e/calculate-curve-price.test.ts
+++ b/src/typescript/sdk/tests/e2e/calculate-curve-price.test.ts
@@ -112,8 +112,8 @@ describe(`curve price calculations w/ geometric mean, at least ${accuracy * 100}
       )
       .then(({ beforePrice, swap, response }) => ({
         before: beforePrice,
-        average: PreciseBig(swap.event.baseVolume.toString()).div(
-          swap.event.quoteVolume.toString()
+        average: PreciseBig(swap.event.quoteVolume.toString()).div(
+          swap.event.baseVolume.toString()
         ),
         after: calculateCurvePrice(swap.model.state),
         response,


### PR DESCRIPTION
# Description

- [x] Fix the date times to be floored seconds, not decimalized seconds
- [x] Update the cache policies for each endpoint
- [x] Use force no store (no caching) for all endpoints except the `/dexscreener/latest-block` endpoint, which will have a revalidation time of `1` second
- [x] Return real reserves per tg chat
- [x] Decimalize all supply amounts
- [x] Return user address, not aggregator (for `maker`)
- [x] Fix the `reserves` field and ensure the types are correct/expected

# Testing

- [x] Testing the cache manually
- [x] Check the timestamp in the response manually
- [x] Ensure latest block doesn't cache permanently anymore
- [x] Ensure the responses make sense

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

