### PR TITLE
[ECO-2616] Fix prerelease semvar `parse` causing an undefined bug and WSOD

### DIFF
--- a/src/typescript/frontend/src/components/svg/icons/LogoIcon.tsx
+++ b/src/typescript/frontend/src/components/svg/icons/LogoIcon.tsx
@@ -24,12 +24,14 @@ const Badge: React.FC<React.PropsWithChildren<{ color: keyof Colors }>> = ({ chi
   );
 };
 
-const VersionBadge: React.FC<{ color: keyof Colors }> = ({ color }) => (
+const VersionBadge: React.FC<{ color: keyof Colors }> = ({ color }) =>
+  // prettier-ignore
   <Badge color={color}>
-    {VERSION?.prerelease[0].toString().toUpperCase()}&nbsp;v{VERSION?.major}.{VERSION?.minor}.
-    {VERSION?.patch}
-  </Badge>
-);
+    {VERSION?.prerelease.at(0)?.toString().toUpperCase()}
+    {VERSION?.prerelease.at(0) && <>&nbsp;</>}
+    v
+    {VERSION?.major}.{VERSION?.minor}.{VERSION?.patch}
+  </Badge>;
 
 const Icon: React.FC<SvgProps & { versionBadge?: boolean }> = ({
   color = "econiaBlue",


### PR DESCRIPTION
# Description

Going from `0.0.3-alpha` in the `package.json` to `1.0.0` means the `prerelease` field in semver `parse` returns an empty array. Thus, the first element was undefined, and we were calling `.toString()` on it, causing a WSOD.

Fix this by conditionally parsing that part of the semver string.

# Testing

Visually inspecting the site, make sure it doesn't crash or show a WSOD still. (Already tested locally, will test in preview, too)

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
