### PR TITLE
[ECO-2619]  Bump the processor submodule to include the new indexer logic for `event_index`; add simple checks in e2e tests to verify correctness

### DIFF
--- a/src/typescript/sdk/src/emojicoin_dot_fun/events.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/events.ts
@@ -44,6 +44,9 @@ export const toCamelCaseEventName = <T extends FullEventName>(s: T): PascalToCam
 };
 
 export type Events = { [K in CamelCaseEventNames]: Types[Capitalize<RemovePlurality<K>>][] };
+export type EventsWithIndices = {
+  [K in keyof Events]: (Events[K][number] & { eventIndex: number })[];
+};
 
 export const createEmptyEvents = (): Events => ({
   swapEvents: [],

--- a/src/typescript/sdk/src/emojicoin_dot_fun/utils.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/utils.ts
@@ -68,7 +68,7 @@ export async function getRegistryAddress(args: {
 }
 
 export const getEvents = (response?: UserTransactionResponse | PendingTransactionResponse | null) =>
-  getEventsMaybeWithIndices(response);
+  getEventsMaybeWithIndices(response, false);
 
 export const getEventsWithIndices = (
   response?: UserTransactionResponse | PendingTransactionResponse | null

--- a/src/typescript/sdk/src/emojicoin_dot_fun/utils.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/utils.ts
@@ -14,6 +14,7 @@ import {
   createEmptyEvents,
   toCamelCaseEventName,
   isAnEmojicoinStructName,
+  type EventsWithIndices,
 } from "./events";
 import { typeTagInputToStructName } from "../utils/type-tags";
 import { createNamedObjectAddress } from "../utils/aptos-utils";
@@ -66,25 +67,42 @@ export async function getRegistryAddress(args: {
   return AccountAddress.from(registryAddressResource.registry_address);
 }
 
-export function getEvents(
+export const getEvents = (response?: UserTransactionResponse | PendingTransactionResponse | null) =>
+  getEventsMaybeWithIndices(response);
+
+export const getEventsWithIndices = (
   response?: UserTransactionResponse | PendingTransactionResponse | null
-): Events {
-  const events = createEmptyEvents();
+) => getEventsMaybeWithIndices(response, true);
+
+function getEventsMaybeWithIndices(
+  response: UserTransactionResponse | PendingTransactionResponse | null | undefined,
+  withIndices?: false | undefined
+): Events;
+function getEventsMaybeWithIndices(
+  response: UserTransactionResponse | PendingTransactionResponse | null | undefined,
+  withIndices: true
+): EventsWithIndices;
+function getEventsMaybeWithIndices(
+  response: UserTransactionResponse | PendingTransactionResponse | null | undefined,
+  withIndices: boolean = false
+): Events | EventsWithIndices {
+  const events = createEmptyEvents() as EventsWithIndices;
   if (!response || !isUserTransactionResponse(response)) {
     return events;
   }
 
-  response.events.forEach((event): void => {
+  response.events.forEach((event, eventIndex): void => {
     const structName = typeTagInputToStructName(event.type);
     if (!structName || !isAnEmojicoinStructName(structName)) {
       return;
     }
     const data = converter[structName](event.data, response.version);
     const camelCasedAndPlural = `${toCamelCaseEventName(structName)}s` as const;
+    const eventData = withIndices ? { ...data, eventIndex } : data;
     // TypeScript can't infer or narrow the type. It's too difficult to figure out how to get it to
     // do it properly so we must use `as any` here, although we know for sure its type is correct.
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    events[camelCasedAndPlural].push(data as any);
+    events[camelCasedAndPlural].push(eventData as any);
   });
   return events;
 }

--- a/src/typescript/sdk/tests/e2e/queries/equality-checks.ts
+++ b/src/typescript/sdk/tests/e2e/queries/equality-checks.ts
@@ -83,7 +83,8 @@ const checkEventIndex = (
   }
 
   // It would be nice to check the block number/height here if possible, but it's not returned by
-  // the fullnode and graphql is a pain to work with in jest unit tests.
+  // the fullnode and graphql is a pain to work with in jest unit tests, and this can just be
+  // verified manually.
   expect(eventIndex.toString()).toEqual(row.blockAndEvent?.eventIndex.toString());
 };
 


### PR DESCRIPTION
# Description

- [x] Bump the processor submodule to include the new indexer logic to use the `event_index` properly
- [x] Add tests to check it

# Testing

I've added tests to check that the `event_index` comes in as expected, according to the fullnode JSON response.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
