### PR TITLE
[ECO-2618] Finalize emojicoin arena core logic design

### DIFF
--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -55,6 +55,7 @@ keycap
 khanda
 kitts
 leaderboard
+leaderboards
 leste
 libclang
 libdw
@@ -78,6 +79,7 @@ nohup
 octa
 octas
 oden
+offchain
 parallelizable
 permissionless
 pgrst
@@ -110,5 +112,7 @@ viewports
 vpnapi
 websocat
 websockets
+writeset
+writesets
 xbtmatt
 zustand

--- a/src/move/emojicoin_arena/Move.toml
+++ b/src/move/emojicoin_arena/Move.toml
@@ -6,8 +6,8 @@ integrator = "_"
 local = "../emojicoin_dot_fun"
 
 [dev-addresses]
-emojicoin_arena = "0xaaa"
 coin_factory = "0xbbb"
+emojicoin_arena = "0xaaa"
 emojicoin_dot_fun = "0xc0de"
 integrator = "0xddd"
 

--- a/src/move/emojicoin_arena/Move.toml
+++ b/src/move/emojicoin_arena/Move.toml
@@ -11,6 +11,15 @@ emojicoin_arena = "0xaaa"
 emojicoin_dot_fun = "0xc0de"
 integrator = "0xddd"
 
+[dev-dependencies.YinYangCoinFactory]
+local = "../test_coin_factories/yin_yang"
+
+[dev-dependencies.ZebraCoinFactory]
+local = "../test_coin_factories/zebra"
+
+[dev-dependencies.ZombieCoinFactory]
+local = "../test_coin_factories/zombie"
+
 [package]
 authors = ["Econia Labs (developers@econialabs.com)"]
 name = "EmojicoinArena"

--- a/src/move/emojicoin_arena/Move.toml
+++ b/src/move/emojicoin_arena/Move.toml
@@ -1,12 +1,12 @@
 [addresses]
-arena = "_"
+emojicoin_arena = "_"
 integrator = "_"
 
 [dependencies.EmojicoinDotFun]
 local = "../emojicoin_dot_fun"
 
 [dev-addresses]
-arena = "0xaaa"
+emojicoin_arena = "0xaaa"
 coin_factory = "0xbbb"
 emojicoin_dot_fun = "0xc0de"
 integrator = "0xddd"

--- a/src/move/emojicoin_arena/README.md
+++ b/src/move/emojicoin_arena/README.md
@@ -1,11 +1,88 @@
-# Emojicoin Arena
+# Emojicoin arena
 
-## A note on pseudo-randomness
+## Overview
+
+Emojicoin arena is a gamified trading experience wherein users may trade back
+and forth between two emojicoins during a set period known as a melee. The
+two emojicoins for a given melee are selected using Aptos randomness, via a
+crank mechanism that is called at the beginning of all public APIs.
+
+A user enters a melee by swapping APT into one of two emojicoins, which are held
+in escrow to enable constraints and to ease the indexing process. In particular,
+a user can only hold one of the two emojicoins in escrow, and if they want to
+swap to the other emojicoin, all of their holdings in escrow are swapped into
+the other emojicoin. That is, holdings inside the escrow for a given melee are
+all-or-nothing for one of the two emojicoins. If a user wishes to top off their
+escrow with more emojicoins, they must swap into the kind they already hold.
+
+A user can still hold any combination of the two emojicoins for a melee outside
+of escrow in their Aptos wallet, via emojicoin dot fun core functionality.
+However in this case they will miss out on:
+
+1. Profit and loss (PnL) indexing and leaderboards that are enabled by escrow
+   sandboxing.
+1. Ease of participation in the melee via the emojicoin arena feature page.
+1. Rewards.
+
+Rewards are provided by the Aptos Foundation and are loaded into a vault that
+anyone can claim from: when a user enters a melee, they can elect to lock in
+their contributions, and if they do so, rewards from the vault will be combined
+with their APT contribution to buy even more emojicoins. However, once a user
+has locked in, they can not exit the melee until it has ended unless they first
+pay back in full all APT rewards they have received from matching ("tap out").
+Conversely, if a user does not lock in, they can exit at any time without
+penalty.
+
+Note that the matching percentage decreases as time goes on, such that if a user
+locks in at the beginning of a melee they will be matched at a higher percentage
+than if they lock in halfway through. This is to ensure that if users claim
+rewards, they are in it for the long haul and will participate through to the
+end of the melee. There is a ceiling on how much APT a user can be matched in
+one given melee, but this value along with other parameters like the duration of
+each melee are configurable.
+
+## Terminology
+
+1. **Melee**: A trading free-for-all between two randomly-selected emojicions.
+   New melees start periodically.
+1. **Arena**: The venue inside of which melees take place.
+1. **Escrow**: A sandbox of two emojicoins for a given melee.
+1. **Entering**: Adding funds to an escrow.
+1. **Locking in**: Accepting rewards upon entry.
+1. **Topping off**: Adding more funds into an existing escrow.
+1. **Exiting**: Withdrawing emojicoins from escrow.
+1. **Tapping out**: Exiting a melee before it has ended when locked in, thus
+   incurring the penalty of having to pay back all matched rewards.
+1. **Match amount**: The amount of APT a user has been rewarded by locking in.
+
+## Indexing
+
+Structs and events are deisgined according to the principle of minimized onchain
+indexing. That is, runtime state and event fields are designed to provide the
+minimum amount of information required to enable comprehensive indexing via
+writeset-aware offchain processing. In order words, the data model is designed
+to enable full indexing using only writesets and events, with as few struct and
+event fields as possible.
+
+As an example, calculating PnL offchain for a given escrow looks something like:
+
+```
+profit =
+    sum_over_all_events_since_escrow_was_last_empty(
+        Enter.input_amount + Enter.match_amount
+    ) / current_value_of_holdings()
+```
+
+Where `current_value_of_holdings()` aggregates all `Enter`, `Swap`, and `Exit`
+events for a given `{user, melee_id}` to determine current holdings and then
+converts them to octas using the most recent `ExchangeRate`.
+
+## Pseudo-randomness
 
 Since randomness is not supported in `init_module` per [`aptos-core` #15436],
 pseudo-random substitute implementations are used for the first crank. For a
-detailed rationale that explains how this is effectively random in practice, see
-[this `emojicoin-dot-fun` pull request comment].
+detailed rationale that explains how this implementation is effectively random
+in practice, see [this `emojicoin-dot-fun` pull request comment].
 
 [this `emojicoin-dot-fun` pull request comment]: https://github.com/econia-labs/emojicoin-dot-fun/pull/408#discussion_r1887856202
 [`aptos-core` #15436]: https://github.com/aptos-labs/aptos-core/issues/15436

--- a/src/move/emojicoin_arena/README.md
+++ b/src/move/emojicoin_arena/README.md
@@ -1,3 +1,5 @@
+<!-- cspell:word gamified -->
+
 # Emojicoin arena
 
 ## Overview
@@ -19,8 +21,7 @@ A user can still hold any combination of the two emojicoins for a melee outside
 of escrow in their Aptos wallet, via emojicoin dot fun core functionality.
 However in this case they will miss out on:
 
-1. Profit and loss (PnL) indexing and leaderboards that are enabled by escrow
-   sandboxing.
+1. Profit and loss (PnL) indexing and leaderboards that are enabled by escrow.
 1. Ease of participation in the melee via the emojicoin arena feature page.
 1. Rewards.
 
@@ -43,7 +44,7 @@ each melee are configurable.
 
 ## Terminology
 
-1. **Melee**: A trading free-for-all between two randomly-selected emojicions.
+1. **Melee**: A trading free-for-all between two randomly-selected emojicoins.
    New melees start periodically.
 1. **Arena**: The venue inside of which melees take place.
 1. **Escrow**: A sandbox of two emojicoins for a given melee.
@@ -57,7 +58,7 @@ each melee are configurable.
 
 ## Indexing
 
-Structs and events are deisgined according to the principle of minimized onchain
+Structs and events are designed according to the principle of minimized onchain
 indexing. That is, runtime state and event fields are designed to provide the
 minimum amount of information required to enable comprehensive indexing via
 writeset-aware offchain processing. In order words, the data model is designed
@@ -66,7 +67,7 @@ event fields as possible.
 
 As an example, calculating PnL offchain for a given escrow looks something like:
 
-```
+```python
 profit =
     sum_over_all_events_since_escrow_was_last_empty(
         Enter.input_amount + Enter.match_amount

--- a/src/move/emojicoin_arena/README.md
+++ b/src/move/emojicoin_arena/README.md
@@ -68,10 +68,9 @@ event fields as possible.
 As an example, calculating PnL offchain for a given escrow looks something like:
 
 ```python
-profit =
-    sum_over_all_events_since_escrow_was_last_empty(
-        Enter.input_amount + Enter.match_amount
-    ) / current_value_of_holdings()
+profit = sum_over_all_events_since_escrow_was_last_empty(
+    Enter.input_amount + Enter.match_amount
+) / current_value_of_holdings()
 ```
 
 Where `current_value_of_holdings()` aggregates all `Enter`, `Swap`, and `Exit`

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -212,7 +212,7 @@ module arena::emojicoin_arena {
     }
 
     #[event]
-    /// Emitted after a user enters or exits, representing ther final `UserMelees` state.
+    /// Emitted after a user enters or exits, representing their final `UserMelees` state.
     struct UserMeleesState has copy, drop, store {
         n_entered_melees: u64,
         n_exited_melees: u64,

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -78,6 +78,8 @@ module arena::emojicoin_arena {
         available_rewards: u64
     }
 
+    /// Tracks all melees, holds a signer capability for the rewards vault, and stores parameters
+    /// for the next melee.
     struct Registry has key {
         /// A map of each `Melee`'s `melee_id` to the `Melee` itself. 1-indexed for conformity with
         /// emojicoin market ID indexing.
@@ -97,6 +99,7 @@ module arena::emojicoin_arena {
         next_melee_max_match_amount: u64
     }
 
+    /// Tracks user's emojicoin holdings and octas matched since the escrow was last empty.
     struct Escrow<phantom Coin0, phantom LP0, phantom Coin1, phantom LP1> has key {
         /// Corresponding `Melee.melee_id`.
         melee_id: u64,
@@ -104,8 +107,8 @@ module arena::emojicoin_arena {
         emojicoin_0: Coin<Coin0>,
         /// Emojicoin 1 holdings.
         emojicoin_1: Coin<Coin1>,
-        /// Cumulative amount of APT matched since most recent deposit into an empty `Escrow`, reset
-        /// to 0 upon exit. Must be paid back in full when tapping out.
+        /// Cumulative octas matched since the `Escrow` was last empty, reset to 0 upon exit. Must
+        /// be paid back in full when tapping out.
         match_amount: u64
     }
 
@@ -114,6 +117,7 @@ module arena::emojicoin_arena {
     struct Enter has copy, drop, store {
         user: address,
         melee_id: u64,
+        /// Argument passed to `enter`, independent of potential `match_amount`.
         input_amount: u64,
         quote_volume: u64,
         match_amount: u64,
@@ -130,6 +134,7 @@ module arena::emojicoin_arena {
     struct Exit has copy, drop, store {
         user: address,
         melee_id: u64,
+        /// Octas user had to pay if exiting before the end of the melee, if applicable.
         tap_out_fee: u64,
         emojicoin_0_proceeds: u64,
         emojicoin_1_proceeds: u64,

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -1,3 +1,4 @@
+// cspell:word funder
 // cspell:word unexited
 module arena::emojicoin_arena {
 
@@ -180,7 +181,7 @@ module arena::emojicoin_arena {
     }
 
     #[event]
-    /// Emmitted whenever a user swaps within their escrow.
+    /// Emitted whenever a user swaps within their escrow.
     struct Swap has copy, drop, store {
         user: address,
         melee_id: u64,

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -1050,7 +1050,7 @@ module arena::emojicoin_arena {
             // operation, to reduce truncation errors. Equivalent to:
             //
             //                max match percentage   remaining time
-            // input_amount * -------------------- * --------------
+            // input amount * -------------------- * --------------
             //                100                    duration
             let raw_match_amount =
                 (

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -1192,12 +1192,6 @@ module emojicoin_arena::emojicoin_arena {
     }
 
     #[test_only]
-    public fun unpack_exchange_rate(self: ExchangeRate): (u64, u64) {
-        let ExchangeRate { base, quote } = self;
-        (base, quote)
-    }
-
-    #[test_only]
     public fun unpack_enter(
         self: Enter
     ): (address, u64, u64, u64, u64, u64, u64, u64, ExchangeRate, ExchangeRate) {
@@ -1225,6 +1219,12 @@ module emojicoin_arena::emojicoin_arena {
             emojicoin_0_exchange_rate,
             emojicoin_1_exchange_rate
         )
+    }
+
+    #[test_only]
+    public fun unpack_exchange_rate(self: ExchangeRate): (u64, u64) {
+        let ExchangeRate { base, quote } = self;
+        (base, quote)
     }
 
     #[test_only]

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -255,6 +255,7 @@ module arena::emojicoin_arena {
     entry fun swap<Coin0, LP0, Coin1, LP1>(swapper: &signer) acquires Escrow, Registry {
         // Crank schedule, set local variables.
         let (registry_ref_mut, melee_is_active, swapper_address, escrow_ref_mut, melee_id) =
+
             existing_participant_prologue<Coin0, LP0, Coin1, LP1>(swapper);
 
         // Get melee market addresses.
@@ -300,8 +301,9 @@ module arena::emojicoin_arena {
     #[randomness]
     entry fun exit<Coin0, LP0, Coin1, LP1>(participant: &signer) acquires Escrow, Registry {
         // Crank schedule, set local variables.
-        let (registry_ref_mut, melee_is_active, participant_address, escrow_ref_mut, melee_id) =
-            existing_participant_prologue<Coin0, LP0, Coin1, LP1>(participant);
+        let (
+            registry_ref_mut, melee_is_active, participant_address, escrow_ref_mut, melee_id
+        ) = existing_participant_prologue<Coin0, LP0, Coin1, LP1>(participant);
 
         exit_inner<Coin0, LP0, Coin1, LP1>(
             registry_ref_mut,

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -1023,7 +1023,7 @@ module arena::emojicoin_arena {
         (time / period) * period
     }
 
-    /// Uses mutable references to avoid freezing references up the stack.
+    /// Uses mutable references to avoid borrowing issues.
     inline fun market_addresses(melee_ref_mut: &mut Melee): (address, address) {
         let market_metadatas = melee_ref_mut.market_metadatas;
         let (_, market_address_0, _) =
@@ -1033,7 +1033,7 @@ module arena::emojicoin_arena {
         (market_address_0, market_address_1)
     }
 
-    /// Uses mutable references to avoid freezing references up the stack.
+    /// Uses mutable references to avoid borrowing issues.
     inline fun match_amount<Coin0, LP0, Coin1, LP1>(
         input_amount: u64,
         escrow_ref_mut: &mut Escrow<Coin0, LP0, Coin1, LP1>,
@@ -1170,7 +1170,7 @@ module arena::emojicoin_arena {
         self.swaps_volume = self.swaps_volume + amount;
     }
 
-    /// Accepts a mutable reference to avoid freezing references up the stack.
+    /// Accepts a mutable reference to avoid borrowing issues.
     inline fun next_melee_market_ids(registry_ref_mut: &mut Registry): vector<u64> {
         let n_markets = get_n_registered_markets();
         let market_ids;

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -53,8 +53,6 @@ module arena::emojicoin_arena {
     const DEFAULT_MAX_MATCH_PERCENTAGE: u64 = 50;
     const DEFAULT_MAX_MATCH_AMOUNT: u64 = 5 * 100_000_000;
 
-    struct Nil has drop, store {}
-
     #[event]
     /// Tracks state for active and historical melees. Also emitted whenever a new melee starts.
     struct Melee has copy, drop, store {

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -172,11 +172,11 @@ module arena::emojicoin_arena {
     struct Exit has copy, drop, store {
         user: address,
         melee_id: u64,
-        emojicoin_0_proceeds: u64,
-        emojicoin_1_proceeds: u64,
         octas_entered: u64,
         octas_matched: u64,
-        tap_out_fee: u64
+        tap_out_fee: u64,
+        emojicoin_0_proceeds: u64,
+        emojicoin_1_proceeds: u64
     }
 
     #[event]

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -302,7 +302,11 @@ module emojicoin_arena::emojicoin_arena {
     entry fun exit<Coin0, LP0, Coin1, LP1>(participant: &signer) acquires Escrow, Registry {
         // Crank schedule, set local variables.
         let (
-            registry_ref_mut, melee_is_active, participant_address, escrow_ref_mut, melee_id
+            registry_ref_mut,
+            melee_is_active,
+            participant_address,
+            escrow_ref_mut,
+            melee_id
         ) = existing_participant_prologue<Coin0, LP0, Coin1, LP1>(participant);
 
         exit_inner<Coin0, LP0, Coin1, LP1>(

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -302,7 +302,11 @@ module arena::emojicoin_arena {
     entry fun exit<Coin0, LP0, Coin1, LP1>(participant: &signer) acquires Escrow, Registry {
         // Crank schedule, set local variables.
         let (
-            registry_ref_mut, melee_is_active, participant_address, escrow_ref_mut, melee_id
+            registry_ref_mut,
+            melee_is_active,
+            participant_address,
+            escrow_ref_mut,
+            melee_id
         ) = existing_participant_prologue<Coin0, LP0, Coin1, LP1>(participant);
 
         exit_inner<Coin0, LP0, Coin1, LP1>(

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -269,8 +269,8 @@ module arena::emojicoin_arena {
                 coin::value(&escrow_ref_mut.emojicoin_0) == 0, E_ENTER_COIN_BALANCE_0
             );
 
-        // Verify that if user has been matched since their most recent deposit into an empty esrow,
-        // they lock in again.
+        // Verify that if user has been matched since their most recent deposit into an empty
+        // escrow, they lock in again.
         if (escrow_ref_mut.octas_matched > 0) {
             assert!(lock_in, E_TOP_OFF_MUST_LOCK_IN);
         };

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -24,8 +24,7 @@ module emojicoin_arena::emojicoin_arena {
     const E_ENTER_COIN_BALANCE_0: u64 = 1;
     /// User's melee escrow has nonzero emojicoin 1 balance.
     const E_ENTER_COIN_BALANCE_1: u64 = 2;
-    /// User did not elect to lock in even though they've been matched since their most recent
-    /// deposit into an empty escrow.
+    /// User did not select lock in even though they've been matched since escrow was last empty.
     const E_TOP_OFF_MUST_LOCK_IN: u64 = 3;
     /// Provided escrow coin type is invalid.
     const E_INVALID_ESCROW_COIN_TYPE: u64 = 4;

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -255,7 +255,6 @@ module arena::emojicoin_arena {
     entry fun swap<Coin0, LP0, Coin1, LP1>(swapper: &signer) acquires Escrow, Registry {
         // Crank schedule, set local variables.
         let (registry_ref_mut, melee_is_active, swapper_address, escrow_ref_mut, melee_id) =
-
             existing_participant_prologue<Coin0, LP0, Coin1, LP1>(swapper);
 
         // Get melee market addresses.
@@ -301,13 +300,8 @@ module arena::emojicoin_arena {
     #[randomness]
     entry fun exit<Coin0, LP0, Coin1, LP1>(participant: &signer) acquires Escrow, Registry {
         // Crank schedule, set local variables.
-        let (
-            registry_ref_mut,
-            melee_is_active,
-            participant_address,
-            escrow_ref_mut,
-            melee_id
-        ) = existing_participant_prologue<Coin0, LP0, Coin1, LP1>(participant);
+        let (registry_ref_mut, melee_is_active, participant_address, escrow_ref_mut, melee_id) =
+            existing_participant_prologue<Coin0, LP0, Coin1, LP1>(participant);
 
         exit_inner<Coin0, LP0, Coin1, LP1>(
             registry_ref_mut,

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -510,14 +510,6 @@ module arena::emojicoin_arena {
         (cranked, registry_ref_mut, time, n_melees_before_cranking)
     }
 
-    /// Octa-denominated value of emojicoins at given exchange rate.
-    inline fun effective_value(
-        emojicoin_holdings: u64, exchange_rate: ExchangeRate
-    ): u128 {
-        (emojicoin_holdings as u128) * (exchange_rate.quote as u128)
-            / (exchange_rate.base as u128)
-    }
-
     inline fun emit_vault_balance_update_with_singer_capability_ref(
         signer_capability_ref: &SignerCapability
     ) {

--- a/src/move/emojicoin_arena/sources/pseudo_randomness.move
+++ b/src/move/emojicoin_arena/sources/pseudo_randomness.move
@@ -1,10 +1,10 @@
-module arena::pseudo_randomness {
+module emojicoin_arena::pseudo_randomness {
 
     use aptos_framework::transaction_context;
     use std::bcs;
     use std::vector;
 
-    friend arena::emojicoin_arena;
+    friend emojicoin_arena::emojicoin_arena;
 
     /// Pseudo-random substitute for `aptos_framework::randomness::u64_range`, since
     /// the randomness API is not available during `init_module`.

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -1,0 +1,442 @@
+#[test_only]
+// This test module uses the same design schema as the emojicoin dot fun core test module.
+module emojicoin_arena::tests {
+    use aptos_framework::account::{
+        create_resource_address,
+        create_signer_for_test as get_signer
+    };
+    use aptos_framework::event::{emitted_events};
+    use aptos_framework::timestamp;
+    use aptos_framework::transaction_context;
+    use emojicoin_dot_fun::emojicoin_dot_fun::{
+        MarketMetadata,
+        market_metadata_by_market_id,
+        unpack_market_metadata
+    };
+    use emojicoin_arena::emojicoin_arena::{
+        ExchangeRate,
+        Exit,
+        Melee,
+        RegistryView,
+        VaultBalanceUpdate,
+        fund_vault,
+        get_DEFAULT_AVAILABLE_REWARDS,
+        get_DEFAULT_DURATION,
+        get_DEFAULT_MAX_MATCH_PERCENTAGE,
+        get_DEFAULT_MAX_MATCH_AMOUNT,
+        get_REGISTRY_SEED,
+        init_module_test_only,
+        registry,
+        set_next_melee_available_rewards,
+        set_next_melee_duration,
+        set_next_melee_max_match_amount,
+        set_next_melee_max_match_percentage,
+        unpack_exchange_rate,
+        unpack_exit,
+        unpack_melee,
+        unpack_registry_view,
+        unpack_vault_balance_update,
+        withdraw_from_vault
+    };
+    use emojicoin_dot_fun::test_acquisitions::mint_aptos_coin_to;
+    use emojicoin_dot_fun::tests as emojicoin_dot_fun_tests;
+    use std::option;
+    use std::vector;
+
+    struct MockExchangeRate has copy, drop, store {
+        base: u64,
+        quote: u64
+    }
+
+    struct MockExit has copy, drop, store {
+        user: address,
+        melee_id: u64,
+        tap_out_fee: u64,
+        emojicoin_0_proceeds: u64,
+        emojicoin_1_proceeds: u64,
+        emojicoin_0_exchange_rate: MockExchangeRate,
+        emojicoin_1_exchange_rate: MockExchangeRate
+    }
+
+    struct MockMarketMetadata has copy, drop, store {
+        market_id: u64,
+        market_address: address,
+        emoji_bytes: vector<u8>
+    }
+
+    struct MockMelee has copy, drop, store {
+        melee_id: u64,
+        emojicoin_0_market_address: address,
+        emojicoin_1_market_address: address,
+        start_time: u64,
+        duration: u64,
+        max_match_percentage: u64,
+        max_match_amount: u64,
+        available_rewards: u64
+    }
+
+    struct MockRegistryView has copy, drop, store {
+        n_melees: u64,
+        vault_address: address,
+        vault_balance: u64,
+        next_melee_duration: u64,
+        next_melee_available_rewards: u64,
+        next_melee_max_match_percentage: u64,
+        next_melee_max_match_amount: u64
+    }
+
+    struct MockVaultBalanceUpdate has copy, drop, store {
+        new_balance: u64
+    }
+
+    // Test market emoji bytes, in order of market ID.
+    const BLACK_CAT: vector<u8> = x"f09f9088e2808de2ac9b";
+    const BLACK_HEART: vector<u8> = x"f09f96a4";
+    const YELLOW_HEART: vector<u8> = x"f09f929b";
+    const YIN_YANG: vector<u8> = x"e298afefb88f";
+    const ZEBRA: vector<u8> = x"f09fa693";
+    const ZOMBIE: vector<u8> = x"f09fa79f";
+
+    public fun assert_exchange_rate(
+        self: MockExchangeRate, actual: ExchangeRate
+    ) {
+        let (base, quote) = unpack_exchange_rate(actual);
+        assert!(self.base == base);
+        assert!(self.quote == quote);
+    }
+
+    public fun assert_exit(self: MockExit, actual: Exit) {
+        let (
+            user,
+            melee_id,
+            tap_out_fee,
+            emojicoin_0_proceeds,
+            emojicoin_1_proceeds,
+            emojicoin_0_exchange_rate,
+            emojicoin_1_exchange_rate
+        ) = unpack_exit(actual);
+        assert!(self.user == user);
+        assert!(self.melee_id == melee_id);
+        assert!(self.tap_out_fee == tap_out_fee);
+        assert!(self.emojicoin_0_proceeds == emojicoin_0_proceeds);
+        assert!(self.emojicoin_1_proceeds == emojicoin_1_proceeds);
+        self.emojicoin_0_exchange_rate.assert_exchange_rate(emojicoin_0_exchange_rate);
+        self.emojicoin_1_exchange_rate.assert_exchange_rate(emojicoin_1_exchange_rate);
+    }
+
+    public fun assert_market_metadata(
+        self: MockMarketMetadata, actual: MarketMetadata
+    ) {
+        let (market_id, market_address, emoji_bytes) = unpack_market_metadata(actual);
+        assert!(self.market_id == market_id);
+        assert!(self.market_address == market_address);
+        assert!(self.emoji_bytes == emoji_bytes);
+    }
+
+    public fun assert_melee(self: MockMelee, actual: Melee) {
+        let (
+            melee_id,
+            emojicoin_0_market_address,
+            emojicoin_1_market_address,
+            start_time,
+            duration,
+            max_match_percentage,
+            max_match_amount,
+            available_rewards
+        ) = unpack_melee(actual);
+        assert!(self.melee_id == melee_id);
+        assert!(self.emojicoin_0_market_address == emojicoin_0_market_address);
+        assert!(self.emojicoin_1_market_address == emojicoin_1_market_address);
+        assert!(self.start_time == start_time);
+        assert!(self.duration == duration);
+        assert!(self.max_match_percentage == max_match_percentage);
+        assert!(self.max_match_amount == max_match_amount);
+        assert!(self.available_rewards == available_rewards);
+    }
+
+    public fun assert_registry_view(
+        self: MockRegistryView, actual: RegistryView
+    ) {
+        let (
+            n_melees,
+            vault_address,
+            vault_balance,
+            next_melee_duration,
+            next_melee_available_rewards,
+            next_melee_max_match_percentage,
+            next_melee_max_match_amount
+        ) = unpack_registry_view(actual);
+        assert!(self.n_melees == n_melees);
+        assert!(self.vault_address == vault_address);
+        assert!(self.vault_balance == vault_balance);
+        assert!(self.next_melee_duration == next_melee_duration);
+        assert!(self.next_melee_available_rewards == next_melee_available_rewards);
+        assert!(self.next_melee_max_match_percentage == next_melee_max_match_percentage);
+        assert!(self.next_melee_max_match_amount == next_melee_max_match_amount);
+    }
+
+    public fun assert_vault_balance_update(
+        self: MockVaultBalanceUpdate, actual: VaultBalanceUpdate
+    ) {
+        let new_balance = unpack_vault_balance_update(actual);
+        assert!(self.new_balance == new_balance);
+    }
+
+    public fun base_melee(): MockMelee {
+        MockMelee {
+            melee_id: 1,
+            emojicoin_0_market_address: @black_cat_market,
+            emojicoin_1_market_address: @zebra_market,
+            start_time: base_start_time(),
+            duration: get_DEFAULT_DURATION(),
+            max_match_percentage: get_DEFAULT_MAX_MATCH_PERCENTAGE(),
+            max_match_amount: get_DEFAULT_MAX_MATCH_AMOUNT(),
+            available_rewards: get_DEFAULT_AVAILABLE_REWARDS()
+        }
+    }
+
+    /// 1.5x the default melee duration.
+    public fun base_publish_time(): u64 {
+        get_DEFAULT_DURATION() + get_DEFAULT_DURATION() / 2
+    }
+
+    public fun base_registry_view(): MockRegistryView {
+        MockRegistryView {
+            n_melees: 1,
+            vault_address: base_vault_address(),
+            vault_balance: get_DEFAULT_AVAILABLE_REWARDS(),
+            next_melee_duration: get_DEFAULT_DURATION(),
+            next_melee_available_rewards: get_DEFAULT_AVAILABLE_REWARDS(),
+            next_melee_max_match_percentage: get_DEFAULT_MAX_MATCH_PERCENTAGE(),
+            next_melee_max_match_amount: get_DEFAULT_MAX_MATCH_AMOUNT()
+        }
+    }
+
+    public fun base_start_time(): u64 {
+        get_DEFAULT_DURATION()
+    }
+
+    public fun base_vault_address(): address {
+        create_resource_address(&@emojicoin_arena, get_REGISTRY_SEED())
+    }
+
+    /// Initialize emojicoin dot fun with test markets.
+    public fun init_emojicoin_dot_fun_with_test_markets() {
+        emojicoin_dot_fun_tests::init_package();
+        vector::for_each_ref(
+            &vector[BLACK_CAT, BLACK_HEART, YELLOW_HEART, YIN_YANG, ZEBRA, ZOMBIE],
+            |bytes_ref| {
+                emojicoin_dot_fun_tests::init_market(vector[*bytes_ref]);
+            }
+        );
+    }
+
+    public fun init_module_with_funded_vault() {
+        init_emojicoin_dot_fun_with_test_markets();
+
+        // Set global time to base publish time.
+        timestamp::update_global_time_for_test(base_publish_time());
+
+        // Initialize module.
+        init_module_test_only(&get_signer(@emojicoin_arena));
+
+        // Fund admin, then fund vault.
+        mint_aptos_coin_to(@emojicoin_arena, get_DEFAULT_AVAILABLE_REWARDS());
+        fund_vault(&get_signer(@emojicoin_arena), get_DEFAULT_AVAILABLE_REWARDS());
+    }
+
+    #[test]
+    public fun admin_functions() {
+        // Initialize emojicoin dot fun.
+        init_emojicoin_dot_fun_with_test_markets();
+
+        // Set global time to base publish time.
+        timestamp::update_global_time_for_test(base_publish_time());
+
+        // Initialize module.
+        init_module_test_only(&get_signer(@emojicoin_arena));
+
+        // Fund admin, then fund vault.
+        mint_aptos_coin_to(@emojicoin_arena, get_DEFAULT_AVAILABLE_REWARDS());
+        fund_vault(&get_signer(@emojicoin_arena), get_DEFAULT_AVAILABLE_REWARDS());
+
+        // Assert vault balance update event.
+        let vault_balance_update_events = emitted_events<VaultBalanceUpdate>();
+        assert!(vault_balance_update_events.length() == 1);
+        MockVaultBalanceUpdate { new_balance: get_DEFAULT_AVAILABLE_REWARDS() }.assert_vault_balance_update(
+            vault_balance_update_events[0]
+        );
+
+        // Withdraw from vault.
+        let withdrawn_octas = 1;
+        withdraw_from_vault(&get_signer(@emojicoin_arena), withdrawn_octas);
+
+        // Assert vault balance update event.
+        let vault_balance_update_events = emitted_events<VaultBalanceUpdate>();
+        assert!(vault_balance_update_events.length() == 2);
+        MockVaultBalanceUpdate {
+            new_balance: get_DEFAULT_AVAILABLE_REWARDS() - withdrawn_octas
+        }.assert_vault_balance_update(vault_balance_update_events[1]);
+
+        // Set next melee parameters.
+        let (
+            next_available_rewards,
+            next_duration,
+            next_max_match_amount,
+            next_max_match_percentage
+        ) = (2, 3, 4, 5);
+        set_next_melee_available_rewards(
+            &get_signer(@emojicoin_arena), next_available_rewards
+        );
+        set_next_melee_duration(&get_signer(@emojicoin_arena), next_duration);
+        set_next_melee_max_match_amount(
+            &get_signer(@emojicoin_arena), next_max_match_amount
+        );
+        set_next_melee_max_match_percentage(
+            &get_signer(@emojicoin_arena), next_max_match_percentage
+        );
+
+        // Verify registry view.
+        let registry_view = base_registry_view();
+        registry_view.next_melee_available_rewards = next_available_rewards;
+        registry_view.next_melee_duration = next_duration;
+        registry_view.next_melee_max_match_amount = next_max_match_amount;
+        registry_view.next_melee_max_match_percentage = next_max_match_percentage;
+        registry_view.vault_balance -= withdrawn_octas;
+        registry_view.assert_registry_view(registry());
+    }
+
+    #[test]
+    public fun init_module_base() {
+        // Initialize emojicoin dot fun.
+        init_emojicoin_dot_fun_with_test_markets();
+
+        // Set global time to base publish time.
+        timestamp::update_global_time_for_test(base_publish_time());
+
+        // Initialize module.
+        init_module_test_only(&get_signer(@emojicoin_arena));
+
+        // Assert registry view.
+        let registry_view = base_registry_view();
+        registry_view.vault_balance = 0;
+        registry_view.assert_registry_view(registry());
+
+        // Assert melee event.
+        let melee_events = emitted_events<Melee>();
+        assert!(melee_events.length() == 1);
+        base_melee().assert_melee(melee_events[0]);
+    }
+
+    #[test]
+    /// Like `init_module_base`, but generates several AUIDs before calling `init_module`,
+    /// effectively changing the pseudo-random seed. Since there are so few markets registered at
+    /// the simulated publish time, multiple calls may be required to trigger a different initial
+    /// melee than that from `init_module`, while also hitting coverage on the inner function
+    /// `sort_unique_market_ids`.
+    public fun init_module_different_seed() {
+        for (i in 0..4) {
+            transaction_context::generate_auid_address();
+        };
+
+        // Initialize emojicoin dot fun.
+        init_emojicoin_dot_fun_with_test_markets();
+
+        // Set global time to base publish time.
+        timestamp::update_global_time_for_test(base_publish_time());
+
+        // Initialize module.
+        init_module_test_only(&get_signer(@emojicoin_arena));
+
+        // Assert registry view.
+        let registry_view = base_registry_view();
+        registry_view.vault_balance = 0;
+        registry_view.assert_registry_view(registry());
+
+        // Assert melee event.
+        let melee_events = emitted_events<Melee>();
+        assert!(melee_events.length() == 1);
+        let mock_melee = base_melee();
+        mock_melee.emojicoin_0_market_address = @yin_yang_market;
+        mock_melee.emojicoin_1_market_address = @zombie_market;
+        mock_melee.assert_melee(melee_events[0]);
+    }
+
+    #[test]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_NOT_EMOJICOIN_ARENA,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun set_next_melee_available_rewards_not_arena() {
+        set_next_melee_available_rewards(&get_signer(@aptos_framework), 0);
+    }
+
+    #[test]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_NOT_EMOJICOIN_ARENA,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun set_next_melee_duration_not_arena() {
+        set_next_melee_duration(&get_signer(@aptos_framework), 0);
+    }
+
+    #[test]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_NOT_EMOJICOIN_ARENA,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun set_next_melee_max_match_amount_not_arena() {
+        set_next_melee_max_match_amount(&get_signer(@aptos_framework), 0);
+    }
+
+    #[test]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_NOT_EMOJICOIN_ARENA,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun set_next_melee_max_match_percentage_not_arena() {
+        set_next_melee_max_match_percentage(&get_signer(@aptos_framework), 0);
+    }
+
+    #[test]
+    public fun test_market_addresses() {
+        init_emojicoin_dot_fun_with_test_markets();
+        let market_addresses = vector[
+            @black_cat_market,
+            @black_heart_market,
+            @yellow_heart_market,
+            @yin_yang_market,
+            @zebra_market,
+            @zombie_market
+        ];
+        let market_emoji_bytes = vector[BLACK_CAT, BLACK_HEART, YELLOW_HEART, YIN_YANG, ZEBRA, ZOMBIE];
+        for (i in 0..market_addresses.length()) {
+            MockMarketMetadata {
+                market_id: i + 1,
+                market_address: market_addresses[i],
+                emoji_bytes: market_emoji_bytes[i]
+            }.assert_market_metadata(
+                option::destroy_some(market_metadata_by_market_id(i + 1))
+            );
+        };
+    }
+
+    #[test]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_NOT_EMOJICOIN_ARENA,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun withdraw_from_vault_not_arena() {
+        withdraw_from_vault(&get_signer(@aptos_framework), 0);
+    }
+}

--- a/src/move/test_coin_factories/yin_yang/Move.toml
+++ b/src/move/test_coin_factories/yin_yang/Move.toml
@@ -1,0 +1,12 @@
+[addresses]
+yin_yang_market = "0x6d64edcaa823d4b7bf5d98d424cc403870dd7ee4383e54ccca21d486d22a8588"
+
+[dev-dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-framework"
+
+[package]
+name = "YinYangCoinFactory"
+upgrade_policy = "immutable"
+version = "1.0.0"

--- a/src/move/test_coin_factories/yin_yang/sources/coin_factory.move
+++ b/src/move/test_coin_factories/yin_yang/sources/coin_factory.move
@@ -1,0 +1,6 @@
+#[test_only]
+module yin_yang_market::coin_factory {
+    struct Emojicoin {}
+    struct EmojicoinLP {}
+    struct BadType {}
+}

--- a/src/move/test_coin_factories/zebra/Move.toml
+++ b/src/move/test_coin_factories/zebra/Move.toml
@@ -1,0 +1,12 @@
+[addresses]
+zebra_market = "0xb87c674ff0ebff4115288bdb63a5601ed452019f00deeeb2ba848cbf37ba918a"
+
+[dev-dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-framework"
+
+[package]
+name = "ZebraCoinFactory"
+upgrade_policy = "immutable"
+version = "1.0.0"

--- a/src/move/test_coin_factories/zebra/sources/coin_factory.move
+++ b/src/move/test_coin_factories/zebra/sources/coin_factory.move
@@ -1,0 +1,6 @@
+#[test_only]
+module zebra_market::coin_factory {
+    struct Emojicoin {}
+    struct EmojicoinLP {}
+    struct BadType {}
+}

--- a/src/move/test_coin_factories/zombie/Move.toml
+++ b/src/move/test_coin_factories/zombie/Move.toml
@@ -1,0 +1,12 @@
+[addresses]
+zombie_market = "0xfd15a4d8073c1bf3d63eee43f98786a4a2ec9933df89d3cdbed7b90b5b7156ae"
+
+[dev-dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-framework"
+
+[package]
+name = "ZombieCoinFactory"
+upgrade_policy = "immutable"
+version = "1.0.0"

--- a/src/move/test_coin_factories/zombie/sources/coin_factory.move
+++ b/src/move/test_coin_factories/zombie/sources/coin_factory.move
@@ -1,0 +1,6 @@
+#[test_only]
+module zombie_market::coin_factory {
+    struct Emojicoin {}
+    struct EmojicoinLP {}
+    struct BadType {}
+}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR finalizes the Emojicoin Arena Move prototype, adding a README with a
comprehensive design overview.

Per extensive review, it adopts a lightweight data model that provides only the
minimal amount of information to required to enable comprehensive indexing,
as discussed in detail in the README.

## Logic updates

1. Add assorted inner abstractions to ease the review process.
1. Eliminate `SmartTable` structs since they can be a DoS vector.
1. Remove fields, events that are not required for lightweight data model.
1. Require that if a user has locked in since their most recent to an empty
   escrow, they must select lock in on subsequent top-off operations.
1. Allow user to elect lock-in even if they do not ultimately get matched, to
   prevent unexpected abortions.
1. Add exchange rate calculations.
1. Reset available rewards for a melee when it is cranked out.
1. Use integers instead of aggregators since exchange rate calculations require
   queries against both markets and thus inhibit parallelism within a melee
   in the general case.
1. Refactor type checking logic since exchange rate calculations do type checks.
1. Add assorted abstractions, helpers.
1. Add view functions and return unpackers for all core structs.
1. Add test-only fixturing to enable comprehensive state/event mocking.

## Test code

1. Add assorted mocking assertion functions.
1. Add additional test coin factories for `init_module` happy path tests.
1. Add `init_module` happy path tests for assorted pseudo-random seeds.
1. Add admin function happy path and expected failure tests

## Housekeeping

1. Use term `active` instead of `current` to indicate a melee that hasn't ended.
1. Update doc comments to link to actual structs, e.g. "`Escrow`" instead of
   "escrow".
1. Take out error codes used for admin-level guard rails that have since been
   removed.
1. Use compound assignment operators now that they are supported by `movefmt`
1. Change default melee time to 20 hours for new linear interpolation matching.

# Testing

From in `src/move/emojicoin_arena`:

```sh
git ls-files | entr -c sh -c " \
    aptos move compile --dev --move-2  &&
    aptos move fmt \
"
```

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?
