### PR TITLE
[ECO-2641] Add top exits tracking, assorted tweaks

### DIFF
--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -303,13 +303,15 @@ module arena::emojicoin_arena {
     public entry fun set_next_melee_max_match_percentage(
         arena: &signer, max_match_percentage: u64
     ) acquires Registry {
-        borrow_registry_ref_mut_checked(arena).next_melee_max_match_percentage = max_match_percentage;
+        borrow_registry_ref_mut_checked(arena).next_melee_max_match_percentage =
+            max_match_percentage;
     }
 
     public entry fun set_next_melee_max_match_amount(
         arena: &signer, max_match_amount: u64
     ) acquires Registry {
-        borrow_registry_ref_mut_checked(arena).next_melee_max_match_amount = max_match_amount;
+        borrow_registry_ref_mut_checked(arena).next_melee_max_match_amount =
+            max_match_amount;
     }
 
     public entry fun withdraw_from_vault(arena: &signer, amount: u64) acquires Registry {
@@ -868,14 +870,14 @@ module arena::emojicoin_arena {
     inline fun escrow_n_swaps_increment<Coin0, LP0, Coin1, LP1>(
         self: &mut Escrow<Coin0, LP0, Coin1, LP1>
     ) {
-        self.n_swaps = self.n_swaps + 1;
+        self.n_swaps += 1;
     }
 
     inline fun escrow_octas_entered_increment<Coin0, LP0, Coin1, LP1>(
         self: &mut Escrow<Coin0, LP0, Coin1, LP1>,
         amount: u64
     ) {
-        self.octas_entered = self.octas_entered + amount;
+        self.octas_entered += amount;
     }
 
     inline fun escrow_octas_entered_reset<Coin0, LP0, Coin1, LP1>(
@@ -888,7 +890,7 @@ module arena::emojicoin_arena {
         self: &mut Escrow<Coin0, LP0, Coin1, LP1>,
         amount: u64
     ) {
-        self.octas_matched = self.octas_matched + amount;
+        self.octas_matched += amount;
     }
 
     inline fun escrow_octas_matched_reset<Coin0, LP0, Coin1, LP1>(
@@ -901,7 +903,7 @@ module arena::emojicoin_arena {
         self: &mut Escrow<Coin0, LP0, Coin1, LP1>,
         amount: u128
     ) {
-        self.swaps_volume = self.swaps_volume + amount;
+        self.swaps_volume += amount;
     }
 
     inline fun exchange_rate<Emojicoin, EmojicoinLP>(
@@ -925,8 +927,9 @@ module arena::emojicoin_arena {
             emojicoin_dot_fun::unpack_market_view(
                 emojicoin_dot_fun::market_view<Emojicoin, EmojicoinLP>(market_address)
             );
-        let reserves = if (in_bonding_curve) clamm_virtual_reserves
-        else cpamm_real_reserves;
+        let reserves =
+            if (in_bonding_curve) clamm_virtual_reserves
+            else cpamm_real_reserves;
         let (base, quote) = emojicoin_dot_fun::unpack_reserves(reserves);
         ExchangeRate { base, quote }
     }
@@ -1127,37 +1130,37 @@ module arena::emojicoin_arena {
     inline fun melee_available_rewards_decrement(
         self: &mut Melee, amount: u64
     ) {
-        self.available_rewards = self.available_rewards - amount;
+        self.available_rewards -= amount;
     }
 
     inline fun melee_available_rewards_increment(
         self: &mut Melee, amount: u64
     ) {
-        self.available_rewards = self.available_rewards + amount;
+        self.available_rewards += amount;
     }
 
     inline fun melee_emojicoin_0_locked_decrement(
         self: &mut Melee, amount: u64
     ) {
-        self.emojicoin_0_locked = self.emojicoin_0_locked - amount;
+        self.emojicoin_0_locked -= amount;
     }
 
     inline fun melee_emojicoin_0_locked_increment(
         self: &mut Melee, amount: u64
     ) {
-        self.emojicoin_0_locked = self.emojicoin_0_locked + amount;
+        self.emojicoin_0_locked += amount;
     }
 
     inline fun melee_emojicoin_1_locked_decrement(
         self: &mut Melee, amount: u64
     ) {
-        self.emojicoin_1_locked = self.emojicoin_1_locked - amount;
+        self.emojicoin_1_locked -= amount;
     }
 
     inline fun melee_emojicoin_1_locked_increment(
         self: &mut Melee, amount: u64
     ) {
-        self.emojicoin_1_locked = self.emojicoin_1_locked + amount;
+        self.emojicoin_1_locked += amount;
     }
 
     inline fun melee_exited_entrants_add_if_not_contains(
@@ -1185,13 +1188,13 @@ module arena::emojicoin_arena {
     }
 
     inline fun melee_n_swaps_increment(self: &mut Melee) {
-        self.n_swaps = self.n_swaps + 1;
+        self.n_swaps += 1;
     }
 
     inline fun melee_swaps_volume_increment(
         self: &mut Melee, amount: u128
     ) {
-        self.swaps_volume = self.swaps_volume + amount;
+        self.swaps_volume += amount;
     }
 
     inline fun melee_top_exits_update(self: &mut Melee, exit: &Exit) {
@@ -1254,11 +1257,12 @@ module arena::emojicoin_arena {
         let (octas_value, octas_gain, octas_loss, octas_growth_q64) = (0, 0, 0, 0);
         let octas_entered = (octas_entered as u128);
         if (octas_entered > 0) {
-            octas_value = if (emojicoin_0_holdings > 0)
-                effective_value(emojicoin_0_holdings, emojicoin_0_exchange_rate)
-            else if (emojicoin_1_holdings > 0)
-                effective_value(emojicoin_1_holdings, emojicoin_1_exchange_rate)
-            else 0;
+            octas_value =
+                if (emojicoin_0_holdings > 0)
+                    effective_value(emojicoin_0_holdings, emojicoin_0_exchange_rate)
+                else if (emojicoin_1_holdings > 0)
+                    effective_value(emojicoin_1_holdings, emojicoin_1_exchange_rate)
+                else 0;
             if (octas_value > 0) {
                 if (octas_value > octas_entered) octas_gain = octas_value
                     - octas_entered;
@@ -1343,25 +1347,25 @@ module arena::emojicoin_arena {
     }
 
     inline fun registry_n_swaps_increment(self: &mut Registry) {
-        self.n_swaps = self.n_swaps + 1;
+        self.n_swaps += 1;
     }
 
     inline fun registry_octas_matched_decrement(
         self: &mut Registry, amount: u64
     ) {
-        self.octas_matched = self.octas_matched - amount;
+        self.octas_matched -= amount;
     }
 
     inline fun registry_octas_matched_increment(
         self: &mut Registry, amount: u64
     ) {
-        self.octas_matched = self.octas_matched + amount;
+        self.octas_matched += amount;
     }
 
     inline fun registry_swaps_volume_increment(
         self: &mut Registry, amount: u128
     ) {
-        self.swaps_volume = self.swaps_volume + amount;
+        self.swaps_volume += amount;
     }
 
     inline fun registry_top_exits_update(self: &mut Registry, exit: &Exit) {

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -927,7 +927,9 @@ module arena::emojicoin_arena {
             emojicoin_dot_fun::unpack_market_view(
                 emojicoin_dot_fun::market_view<Emojicoin, EmojicoinLP>(market_address)
             );
-        let reserves = if (in_bonding_curve) clamm_virtual_reserves else cpamm_real_reserves;
+        let reserves =
+            if (in_bonding_curve) clamm_virtual_reserves
+            else cpamm_real_reserves;
         let (base, quote) = emojicoin_dot_fun::unpack_reserves(reserves);
         ExchangeRate { base, quote }
     }

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -87,7 +87,7 @@ module arena::emojicoin_arena {
         emojicoin_0_locked: u64,
         /// Amount of emojicoin 1 locked in all melee escrows for the melee.
         emojicoin_1_locked: u64,
-        /// Top exits for the melee.
+        /// `TopExits` for the `Melee`.
         top_exits: TopExits
     }
 
@@ -114,7 +114,7 @@ module arena::emojicoin_arena {
         swaps_volume: u128,
         /// Amount of octas matched. Decremented when a user taps out.
         octas_matched: u64,
-        /// Top exits across all `Melee`s.
+        /// `TopExits` across all `Melee`s.
         top_exits: TopExits
     }
 
@@ -147,7 +147,7 @@ module arena::emojicoin_arena {
         unexited_melee_ids: SmartTable<u64, Nil>
     }
 
-    /// The top `Exits` for either a `Melee` or for the entire `Registry`, depending on context:
+    /// The top `Exit`s for either a `Melee` or for all `Melee`s, depending on context:
     /// `by_octas_gain` means highest `ProfitAndLoss.octas_gain`, and `by_octas_growth_q64` means
     /// highest `ProfitAndLoss.octas_growth_q64`. Initialized via `null_top_exits`.
     struct TopExits has copy, drop, store {
@@ -927,9 +927,7 @@ module arena::emojicoin_arena {
             emojicoin_dot_fun::unpack_market_view(
                 emojicoin_dot_fun::market_view<Emojicoin, EmojicoinLP>(market_address)
             );
-        let reserves =
-            if (in_bonding_curve) clamm_virtual_reserves
-            else cpamm_real_reserves;
+        let reserves = if (in_bonding_curve) clamm_virtual_reserves else cpamm_real_reserves;
         let (base, quote) = emojicoin_dot_fun::unpack_reserves(reserves);
         ExchangeRate { base, quote }
     }

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -221,7 +221,8 @@ module arena::emojicoin_arena {
         emojicoin_0_locked: u64,
         emojicoin_1_locked: u64,
         emojicoin_0_exchange_rate: ExchangeRate,
-        emojicoin_1_exchange_rate: ExchangeRate
+        emojicoin_1_exchange_rate: ExchangeRate,
+        top_exits: TopExits
     }
 
     #[event]
@@ -239,7 +240,8 @@ module arena::emojicoin_arena {
         n_entrants: u64,
         n_swaps: u64,
         swaps_volume: u128,
-        octas_matched: u64
+        octas_matched: u64,
+        top_exits: TopExits
     }
 
     #[event]
@@ -792,7 +794,8 @@ module arena::emojicoin_arena {
                 emojicoin_0_locked: self.emojicoin_0_locked,
                 emojicoin_1_locked: self.emojicoin_1_locked,
                 emojicoin_0_exchange_rate,
-                emojicoin_1_exchange_rate
+                emojicoin_1_exchange_rate,
+                top_exits: self.top_exits
             }
         );
     }
@@ -805,7 +808,8 @@ module arena::emojicoin_arena {
                 n_entrants: self.all_entrants.length(),
                 n_swaps: self.n_swaps,
                 swaps_volume: self.swaps_volume,
-                octas_matched: self.octas_matched
+                octas_matched: self.octas_matched,
+                top_exits: self.top_exits
             }
         );
     }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Add `TopExits` onchain PnL tracking.
1. Use compound assignment operators now that they are supported by `movefmt`
1. Change default melee time to 20 hours since there is no lock-in period.

# Testing

```sh
git ls-files | entr -c sh -c " \
       aptos move compile --dev --move-2  &&
       aptos move fmt \
"
```

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?
