### PR TITLE
[ECO-2620] View functions, preliminary testing

### DIFF
--- a/src/move/emojicoin_arena/Move.toml
+++ b/src/move/emojicoin_arena/Move.toml
@@ -11,6 +11,15 @@ emojicoin_arena = "0xaaa"
 emojicoin_dot_fun = "0xc0de"
 integrator = "0xddd"
 
+[dev-dependencies.YinYangCoinFactory]
+local = "../test_coin_factories/yin_yang"
+
+[dev-dependencies.ZebraCoinFactory]
+local = "../test_coin_factories/zebra"
+
+[dev-dependencies.ZombieCoinFactory]
+local = "../test_coin_factories/zombie"
+
 [package]
 authors = ["Econia Labs (developers@econialabs.com)"]
 name = "EmojicoinArena"

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -1109,6 +1109,31 @@ module emojicoin_arena::emojicoin_arena {
     }
 
     #[test_only]
+    public fun get_DEFAULT_AVAILABLE_REWARDS(): u64 {
+        DEFAULT_AVAILABLE_REWARDS
+    }
+
+    #[test_only]
+    public fun get_DEFAULT_DURATION(): u64 {
+        DEFAULT_DURATION
+    }
+
+    #[test_only]
+    public fun get_DEFAULT_MAX_MATCH_PERCENTAGE(): u64 {
+        DEFAULT_MAX_MATCH_PERCENTAGE
+    }
+
+    #[test_only]
+    public fun get_DEFAULT_MAX_MATCH_AMOUNT(): u64 {
+        DEFAULT_MAX_MATCH_AMOUNT
+    }
+
+    #[test_only]
+    public fun get_REGISTRY_SEED(): vector<u8> {
+        REGISTRY_SEED
+    }
+
+    #[test_only]
     public fun init_module_test_only(account: &signer) acquires Registry {
         init_module(account)
     }

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -1190,4 +1190,10 @@ module emojicoin_arena::emojicoin_arena {
             available_rewards
         )
     }
+
+    #[test_only]
+    public fun unpack_vault_balance_update(self: VaultBalanceUpdate): u64 {
+        let VaultBalanceUpdate { new_balance } = self;
+        new_balance
+    }
 }

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -1166,4 +1166,28 @@ module emojicoin_arena::emojicoin_arena {
             emojicoin_1_exchange_rate
         )
     }
+
+    #[test_only]
+    public fun unpack_melee(self: Melee): (u64, address, address, u64, u64, u64, u64, u64) {
+        let Melee {
+            melee_id,
+            emojicoin_0_market_address,
+            emojicoin_1_market_address,
+            start_time,
+            duration,
+            max_match_percentage,
+            max_match_amount,
+            available_rewards
+        } = self;
+        (
+            melee_id,
+            emojicoin_0_market_address,
+            emojicoin_1_market_address,
+            start_time,
+            duration,
+            max_match_percentage,
+            max_match_amount,
+            available_rewards
+        )
+    }
 }

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -388,18 +388,18 @@ module emojicoin_arena::emojicoin_arena {
         borrow_registry_mut_checked(emojicoin_arena).next_melee_duration = duration;
     }
 
-    public entry fun set_next_melee_max_match_percentage(
-        emojicoin_arena: &signer, max_match_percentage: u64
-    ) acquires Registry {
-        borrow_registry_mut_checked(emojicoin_arena).next_melee_max_match_percentage =
-            max_match_percentage;
-    }
-
     public entry fun set_next_melee_max_match_amount(
         emojicoin_arena: &signer, max_match_amount: u64
     ) acquires Registry {
         borrow_registry_mut_checked(emojicoin_arena).next_melee_max_match_amount =
             max_match_amount;
+    }
+
+    public entry fun set_next_melee_max_match_percentage(
+        emojicoin_arena: &signer, max_match_percentage: u64
+    ) acquires Registry {
+        borrow_registry_mut_checked(emojicoin_arena).next_melee_max_match_percentage =
+            max_match_percentage;
     }
 
     public entry fun withdraw_from_vault(

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -1,12 +1,21 @@
 #[test_only]
-// This module uses the same testing schema as the emojicoin dot fun package tests.
+// This test module uses the same design schema as the emojicoin dot fun core test module.
 module emojicoin_arena::tests {
-    use aptos_framework::account::{create_signer_for_test as get_signer};
+    use aptos_framework::account::{
+        create_resource_address,
+        create_signer_for_test as get_signer
+    };
     use emojicoin_arena::emojicoin_arena::{
         ExchangeRate,
         Exit,
         RegistryView,
+        get_DEFAULT_AVAILABLE_REWARDS,
+        get_DEFAULT_DURATION,
+        get_DEFAULT_MAX_MATCH_PERCENTAGE,
+        get_DEFAULT_MAX_MATCH_AMOUNT,
+        get_REGISTRY_SEED,
         init_module_test_only,
+        registry_view,
         unpack_exchange_rate,
         unpack_exit,
         unpack_registry_view
@@ -92,6 +101,22 @@ module emojicoin_arena::tests {
         assert!(self.next_melee_max_match_amount == next_melee_max_match_amount);
     }
 
+    public fun base_registry_view(): MockRegistryView {
+        MockRegistryView {
+            n_melees: 1,
+            vault_address: base_vault_address(),
+            vault_balance: 0,
+            next_melee_duration: get_DEFAULT_DURATION(),
+            next_melee_available_rewards: get_DEFAULT_AVAILABLE_REWARDS(),
+            next_melee_max_match_percentage: get_DEFAULT_MAX_MATCH_PERCENTAGE(),
+            next_melee_max_match_amount: get_DEFAULT_MAX_MATCH_AMOUNT()
+        }
+    }
+
+    public fun base_vault_address(): address {
+        create_resource_address(&@emojicoin_arena, get_REGISTRY_SEED())
+    }
+
     /// Initialize emojicoin dot fun with test markets.
     public fun init_emojicoin_dot_fun_with_test_markets() {
         emojicoin_dot_fun_tests::init_package();
@@ -107,5 +132,6 @@ module emojicoin_arena::tests {
     fun init_module_default() {
         init_emojicoin_dot_fun_with_test_markets();
         init_module_test_only(&get_signer(@emojicoin_arena));
+        base_registry_view().assert_registry_view(registry_view());
     }
 }

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -26,7 +26,7 @@ module emojicoin_arena::tests {
         get_DEFAULT_MAX_MATCH_AMOUNT,
         get_REGISTRY_SEED,
         init_module_test_only,
-        registry_view,
+        registry,
         set_next_melee_available_rewards,
         set_next_melee_duration,
         set_next_melee_max_match_amount,
@@ -303,7 +303,7 @@ module emojicoin_arena::tests {
         registry_view.next_melee_max_match_amount = next_max_match_amount;
         registry_view.next_melee_max_match_percentage = next_max_match_percentage;
         registry_view.vault_balance -= withdrawn_octas;
-        registry_view.assert_registry_view(registry_view());
+        registry_view.assert_registry_view(registry());
     }
 
     #[test]
@@ -320,7 +320,7 @@ module emojicoin_arena::tests {
         // Assert registry view.
         let registry_view = base_registry_view();
         registry_view.vault_balance = 0;
-        registry_view.assert_registry_view(registry_view());
+        registry_view.assert_registry_view(registry());
 
         // Assert melee event.
         let melee_events = emitted_events<Melee>();
@@ -351,7 +351,7 @@ module emojicoin_arena::tests {
         // Assert registry view.
         let registry_view = base_registry_view();
         registry_view.vault_balance = 0;
-        registry_view.assert_registry_view(registry_view());
+        registry_view.assert_registry_view(registry());
 
         // Assert melee event.
         let melee_events = emitted_events<Melee>();

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -8,6 +8,7 @@ module emojicoin_arena::tests {
     use emojicoin_arena::emojicoin_arena::{
         ExchangeRate,
         Exit,
+        Melee,
         RegistryView,
         get_DEFAULT_AVAILABLE_REWARDS,
         get_DEFAULT_DURATION,
@@ -18,6 +19,7 @@ module emojicoin_arena::tests {
         registry_view,
         unpack_exchange_rate,
         unpack_exit,
+        unpack_melee,
         unpack_registry_view
     };
     use emojicoin_dot_fun::tests as emojicoin_dot_fun_tests;
@@ -36,6 +38,17 @@ module emojicoin_arena::tests {
         emojicoin_1_proceeds: u64,
         emojicoin_0_exchange_rate: MockExchangeRate,
         emojicoin_1_exchange_rate: MockExchangeRate
+    }
+
+    struct MockMelee has copy, drop, store {
+        melee_id: u64,
+        emojicoin_0_market_address: address,
+        emojicoin_1_market_address: address,
+        start_time: u64,
+        duration: u64,
+        max_match_percentage: u64,
+        max_match_amount: u64,
+        available_rewards: u64
     }
 
     struct MockRegistryView has copy, drop, store {
@@ -78,6 +91,27 @@ module emojicoin_arena::tests {
         assert!(self.emojicoin_1_proceeds == emojicoin_1_proceeds);
         self.emojicoin_0_exchange_rate.assert_exchange_rate(emojicoin_0_exchange_rate);
         self.emojicoin_1_exchange_rate.assert_exchange_rate(emojicoin_1_exchange_rate);
+    }
+
+    public fun assert_melee(self: MockMelee, actual: Melee) {
+        let (
+            melee_id,
+            emojicoin_0_market_address,
+            emojicoin_1_market_address,
+            start_time,
+            duration,
+            max_match_percentage,
+            max_match_amount,
+            available_rewards
+        ) = unpack_melee(actual);
+        assert!(self.melee_id == melee_id);
+        assert!(self.emojicoin_0_market_address == emojicoin_0_market_address);
+        assert!(self.emojicoin_1_market_address == emojicoin_1_market_address);
+        assert!(self.start_time == start_time);
+        assert!(self.duration == duration);
+        assert!(self.max_match_percentage == max_match_percentage);
+        assert!(self.max_match_amount == max_match_amount);
+        assert!(self.available_rewards == available_rewards);
     }
 
     public fun assert_registry_view(

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -319,7 +319,7 @@ module emojicoin_arena::tests {
     /// melee than that from `init_module`, while also hitting coverage on the inner function
     /// `sort_unique_market_ids`.
     public fun init_module_different_seed() {
-        for (i in 0..3) {
+        for (i in 0..4) {
             transaction_context::generate_auid_address();
         };
 
@@ -339,6 +339,7 @@ module emojicoin_arena::tests {
         let melee_events = emitted_events<Melee>();
         assert!(melee_events.length() == 1);
         let mock_melee = base_melee();
+        mock_melee.emojicoin_0_market_address = @yin_yang_market;
         mock_melee.emojicoin_1_market_address = @zombie_market;
         mock_melee.assert_melee(melee_events[0]);
     }

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -1,15 +1,111 @@
 #[test_only]
-module arena::tests {
-    use black_cat_market::coin_factory::{
-        Emojicoin as BlackCatEmojicoin,
-        EmojicoinLP as BlackCatEmojicoinLP
+// This module uses the same testing schema as the emojicoin dot fun package tests.
+module emojicoin_arena::tests {
+    use aptos_framework::account::{create_signer_for_test as get_signer};
+    use emojicoin_arena::emojicoin_arena::{
+        ExchangeRate,
+        Exit,
+        RegistryView,
+        init_module_test_only,
+        unpack_exchange_rate,
+        unpack_exit,
+        unpack_registry_view
     };
-    use black_heart_market::coin_factory::{
-        Emojicoin as BlackHeartEmojicoin,
-        EmojicoinLP as BlackHeartEmojicoinLP
-    };
-    use coin_factory::coin_factory::{
-        Emojicoin as CoinFactoryEmojicoin,
-        EmojicoinLP as CoinFactoryEmojicoinLP
-    };
+    use emojicoin_dot_fun::tests as emojicoin_dot_fun_tests;
+    use std::vector;
+
+    struct MockExchangeRate has copy, drop, store {
+        base: u64,
+        quote: u64
+    }
+
+    struct MockExit has copy, drop, store {
+        user: address,
+        melee_id: u64,
+        tap_out_fee: u64,
+        emojicoin_0_proceeds: u64,
+        emojicoin_1_proceeds: u64,
+        emojicoin_0_exchange_rate: MockExchangeRate,
+        emojicoin_1_exchange_rate: MockExchangeRate
+    }
+
+    struct MockRegistryView has copy, drop, store {
+        n_melees: u64,
+        vault_address: address,
+        vault_balance: u64,
+        next_melee_duration: u64,
+        next_melee_available_rewards: u64,
+        next_melee_max_match_percentage: u64,
+        next_melee_max_match_amount: u64
+    }
+
+    // Test market emoji bytes.
+    const BLACK_CAT: vector<u8> = x"f09f9088e2808de2ac9b";
+    const BLACK_HEART: vector<u8> = x"f09f96a4";
+    const YELLOW_HEART: vector<u8> = x"f09f929b";
+
+    public fun assert_exchange_rate(
+        self: MockExchangeRate, actual: ExchangeRate
+    ) {
+        let (base, quote) = unpack_exchange_rate(actual);
+        assert!(self.base == base);
+        assert!(self.quote == quote);
+    }
+
+    public fun assert_exit(self: MockExit, actual: Exit) {
+        let (
+            user,
+            melee_id,
+            tap_out_fee,
+            emojicoin_0_proceeds,
+            emojicoin_1_proceeds,
+            emojicoin_0_exchange_rate,
+            emojicoin_1_exchange_rate
+        ) = unpack_exit(actual);
+        assert!(self.user == user);
+        assert!(self.melee_id == melee_id);
+        assert!(self.tap_out_fee == tap_out_fee);
+        assert!(self.emojicoin_0_proceeds == emojicoin_0_proceeds);
+        assert!(self.emojicoin_1_proceeds == emojicoin_1_proceeds);
+        self.emojicoin_0_exchange_rate.assert_exchange_rate(emojicoin_0_exchange_rate);
+        self.emojicoin_1_exchange_rate.assert_exchange_rate(emojicoin_1_exchange_rate);
+    }
+
+    public fun assert_registry_view(
+        self: MockRegistryView, actual: RegistryView
+    ) {
+        let (
+            n_melees,
+            vault_address,
+            vault_balance,
+            next_melee_duration,
+            next_melee_available_rewards,
+            next_melee_max_match_percentage,
+            next_melee_max_match_amount
+        ) = unpack_registry_view(actual);
+        assert!(self.n_melees == n_melees);
+        assert!(self.vault_address == vault_address);
+        assert!(self.vault_balance == vault_balance);
+        assert!(self.next_melee_duration == next_melee_duration);
+        assert!(self.next_melee_available_rewards == next_melee_available_rewards);
+        assert!(self.next_melee_max_match_percentage == next_melee_max_match_percentage);
+        assert!(self.next_melee_max_match_amount == next_melee_max_match_amount);
+    }
+
+    /// Initialize emojicoin dot fun with test markets.
+    public fun init_emojicoin_dot_fun_with_test_markets() {
+        emojicoin_dot_fun_tests::init_package();
+        vector::for_each_ref(
+            &vector[BLACK_CAT, BLACK_HEART, YELLOW_HEART],
+            |bytes_ref| {
+                emojicoin_dot_fun_tests::init_market(vector[*bytes_ref]);
+            }
+        );
+    }
+
+    #[test]
+    fun init_module_default() {
+        init_emojicoin_dot_fun_with_test_markets();
+        init_module_test_only(&get_signer(@emojicoin_arena));
+    }
 }

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -210,10 +210,11 @@ module emojicoin_arena::tests {
     #[test]
     /// Like `init_module_base`, but generates several AUIDs before calling `init_module`,
     /// effectively changing the pseudo-random seed. Since there are so few markets registered at
-    /// the effective publish time, multiple calls may be required to trigger a different result
-    /// from that in `init_module`.
+    /// the simulated publish time, multiple calls may be required to trigger a different initial
+    /// melee than that from `init_module`, while also hitting coverage on the inner function
+    /// `sort_unique_market_ids`.
     public fun init_module_different_seed() {
-        for (i in 0..3) {
+        for (i in 0..4) {
             transaction_context::generate_auid_address();
         };
 

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -1,0 +1,15 @@
+#[test_only]
+module arena::tests {
+    use black_cat_market::coin_factory::{
+        Emojicoin as BlackCatEmojicoin,
+        EmojicoinLP as BlackCatEmojicoinLP
+    };
+    use black_heart_market::coin_factory::{
+        Emojicoin as BlackHeartEmojicoin,
+        EmojicoinLP as BlackHeartEmojicoinLP
+    };
+    use coin_factory::coin_factory::{
+        Emojicoin as CoinFactoryEmojicoin,
+        EmojicoinLP as CoinFactoryEmojicoinLP
+    };
+}

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -188,7 +188,7 @@ module emojicoin_arena::tests {
     }
 
     #[test]
-    fun init_module_base() {
+    public fun init_module_base() {
         // Initialize emojicoin dot fun.
         init_emojicoin_dot_fun_with_test_markets();
 
@@ -212,7 +212,7 @@ module emojicoin_arena::tests {
     /// effectively changing the pseudo-random seed. Since there are so few markets registered at
     /// the effective publish time, multiple calls may be required to trigger a different result
     /// from that in `init_module`.
-    fun init_module_different_seed() {
+    public fun init_module_different_seed() {
         for (i in 0..3) {
             transaction_context::generate_auid_address();
         };

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -204,7 +204,7 @@ module emojicoin_arena::tests {
         MockRegistryView {
             n_melees: 1,
             vault_address: base_vault_address(),
-            vault_balance: 0,
+            vault_balance: get_DEFAULT_AVAILABLE_REWARDS(),
             next_melee_duration: get_DEFAULT_DURATION(),
             next_melee_available_rewards: get_DEFAULT_AVAILABLE_REWARDS(),
             next_melee_max_match_percentage: get_DEFAULT_MAX_MATCH_PERCENTAGE(),
@@ -229,6 +229,20 @@ module emojicoin_arena::tests {
                 emojicoin_dot_fun_tests::init_market(vector[*bytes_ref]);
             }
         );
+    }
+
+    public fun init_modue_with_funded_vault() {
+        init_emojicoin_dot_fun_with_test_markets();
+
+        // Set global time to base publish time.
+        timestamp::update_global_time_for_test(base_publish_time());
+
+        // Initialize module.
+        init_module_test_only(&get_signer(@emojicoin_arena));
+
+        // Fund admin, then fund vault.
+        mint_aptos_coin_to(@emojicoin_arena, get_DEFAULT_AVAILABLE_REWARDS());
+        fund_vault(&get_signer(@emojicoin_arena), get_DEFAULT_AVAILABLE_REWARDS());
     }
 
     #[test]
@@ -288,7 +302,7 @@ module emojicoin_arena::tests {
         registry_view.next_melee_duration = next_duration;
         registry_view.next_melee_max_match_amount = next_max_match_amount;
         registry_view.next_melee_max_match_percentage = next_max_match_percentage;
-        registry_view.vault_balance = get_DEFAULT_AVAILABLE_REWARDS() - withdrawn_octas;
+        registry_view.vault_balance -= withdrawn_octas;
         registry_view.assert_registry_view(registry_view());
     }
 
@@ -304,7 +318,9 @@ module emojicoin_arena::tests {
         init_module_test_only(&get_signer(@emojicoin_arena));
 
         // Assert registry view.
-        base_registry_view().assert_registry_view(registry_view());
+        let registry_view = base_registry_view();
+        registry_view.vault_balance = 0;
+        registry_view.assert_registry_view(registry_view());
 
         // Assert melee event.
         let melee_events = emitted_events<Melee>();
@@ -333,7 +349,9 @@ module emojicoin_arena::tests {
         init_module_test_only(&get_signer(@emojicoin_arena));
 
         // Assert registry view.
-        base_registry_view().assert_registry_view(registry_view());
+        let registry_view = base_registry_view();
+        registry_view.vault_balance = 0;
+        registry_view.assert_registry_view(registry_view());
 
         // Assert melee event.
         let melee_events = emitted_events<Melee>();

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -231,7 +231,7 @@ module emojicoin_arena::tests {
         );
     }
 
-    public fun init_modue_with_funded_vault() {
+    public fun init_module_with_funded_vault() {
         init_emojicoin_dot_fun_with_test_markets();
 
         // Set global time to base publish time.

--- a/src/move/test_coin_factories/yin_yang/Move.toml
+++ b/src/move/test_coin_factories/yin_yang/Move.toml
@@ -1,0 +1,12 @@
+[addresses]
+yin_yang_market = "0x6d64edcaa823d4b7bf5d98d424cc403870dd7ee4383e54ccca21d486d22a8588"
+
+[dev-dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-framework"
+
+[package]
+name = "YinYangCoinFactory"
+upgrade_policy = "immutable"
+version = "1.0.0"

--- a/src/move/test_coin_factories/yin_yang/sources/coin_factory.move
+++ b/src/move/test_coin_factories/yin_yang/sources/coin_factory.move
@@ -1,0 +1,6 @@
+#[test_only]
+module yin_yang_market::coin_factory {
+    struct Emojicoin {}
+    struct EmojicoinLP {}
+    struct BadType {}
+}

--- a/src/move/test_coin_factories/zebra/Move.toml
+++ b/src/move/test_coin_factories/zebra/Move.toml
@@ -1,0 +1,12 @@
+[addresses]
+zebra_market = "0xb87c674ff0ebff4115288bdb63a5601ed452019f00deeeb2ba848cbf37ba918a"
+
+[dev-dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-framework"
+
+[package]
+name = "ZebraCoinFactory"
+upgrade_policy = "immutable"
+version = "1.0.0"

--- a/src/move/test_coin_factories/zebra/sources/coin_factory.move
+++ b/src/move/test_coin_factories/zebra/sources/coin_factory.move
@@ -1,0 +1,6 @@
+#[test_only]
+module zebra_market::coin_factory {
+    struct Emojicoin {}
+    struct EmojicoinLP {}
+    struct BadType {}
+}

--- a/src/move/test_coin_factories/zombie/Move.toml
+++ b/src/move/test_coin_factories/zombie/Move.toml
@@ -1,0 +1,12 @@
+[addresses]
+zombie_market = "0xfd15a4d8073c1bf3d63eee43f98786a4a2ec9933df89d3cdbed7b90b5b7156ae"
+
+[dev-dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+rev = "mainnet"
+subdir = "aptos-move/framework/aptos-framework"
+
+[package]
+name = "ZombieCoinFactory"
+upgrade_policy = "immutable"
+version = "1.0.0"

--- a/src/move/test_coin_factories/zombie/sources/coin_factory.move
+++ b/src/move/test_coin_factories/zombie/sources/coin_factory.move
@@ -1,0 +1,6 @@
+#[test_only]
+module zombie_market::coin_factory {
+    struct Emojicoin {}
+    struct EmojicoinLP {}
+    struct BadType {}
+}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Background

I initially began working on this PR while its base branch from #478 was
awaiting review. In doing so I began to make some changes to production logic
that I noticed as a result of starting to write tests.

However, in parallel #478 underwent considerable review and so after finalizing
changes there, I rebased this PR so that it could merge in the logic changes
that I had started working on, which were created as a result of test fixturing.
The result is a final prototype complete with view functions, that can then be
merged in a final review of #478.

# Changes

1. Add view functions and return unpackers for all core structs.
1. Add test-only fixturing to enable comprehensive state/event mocking.

# Test code

1. Add assorted mocking assertion functions.
1. Add additional test coin factories for `init_module` happy path tests.
1. Add `init_module` happy path tests for assorted pseudo-random seeds.
1. Add admin function happy path and expected failure tests

# Testing

From in `src/move/emojicoin_arena`:

```sh
git ls-files | entr -c sh -c " \
       aptos move test --coverage --dev --move-2  &&
       aptos move fmt \
"
```