### PR TITLE
[ECO-2639] Fix price not getting calculated on first swap

### DIFF
--- a/src/typescript/frontend/src/lib/hooks/use-calculate-swap-price.ts
+++ b/src/typescript/frontend/src/lib/hooks/use-calculate-swap-price.ts
@@ -67,6 +67,6 @@ const getReservesAndBondingCurveStateWithDefault = (
   return {
     clammVirtualReserves: INITIAL_VIRTUAL_RESERVES,
     cpammRealReserves: INITIAL_REAL_RESERVES,
-    startsInBondingCurve: false,
+    startsInBondingCurve: true,
   };
 };


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR fixes the price not getting calculated on first swap.

If no swap existed for a market, the calculation was assuming that the swap was
NOT starting in the bonding curve. This does not seem to be accurate, as the
first swap should be in the bonding curve. Switching `startsInBondingCurve`
from `false` to `true` for the first swap seems to fix this issue.

Addresses #488.

# Testing

Register a market on testnet and try swapping.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
