### PR TITLE
[ECO-2607] Bump frontend version

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -112,5 +112,5 @@
     "test:e2e": "playwright test --project=firefox",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.0.0"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Bumps the frontend version to 1.1.0, since some of the changes (like the CoinGecko API and USD denomination) are technically breaking changes in terms of the setup / infrastructure / env variables used.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
