### PR TITLE
[ECO-2651] Add emojicoin arena initial happy path testing

### DIFF
--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -767,14 +767,14 @@ module emojicoin_arena::emojicoin_arena {
         (registry_ref_mut, melee_is_active, participant_address, escrow_ref_mut, melee_id)
     }
 
-    fun exit_inner<Coin0, LP0, Coin1, LP1>(
+    inline fun exit_inner<Coin0, LP0, Coin1, LP1>(
         registry_ref_mut: &mut Registry,
         escrow_ref_mut: &mut Escrow<Coin0, LP0, Coin1, LP1>,
         participant: &signer,
         participant_address: address,
         melee_is_active: bool,
         melee_id: u64
-    ) {
+    ) acquires Registry {
         // Get mutable reference to melee and its market addresses.
         let (exited_melee_ref_mut, market_address_0, market_address_1) =
             borrow_melee_mut_with_market_addresses(registry_ref_mut, melee_id);

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -382,8 +382,9 @@ module emojicoin_arena::emojicoin_arena {
     }
 
     #[view]
-    /// Uses mutable references since inner call requires them to prevent issues in core APIs,
-    /// even though no data gets mutated.
+    /// Uses mutable references since inner match amount call requires them to prevent issues in
+    /// core APIs, even though no data gets mutated. Does not crank schedule since this requires
+    /// randomness, which is not safely supported in public functions.
     public fun match_amount<Coin0, LP0, Coin1, LP1>(
         participant: address, input_amount: u64, melee_id: u64
     ): u64 acquires Escrow, Registry {

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -261,8 +261,12 @@ module emojicoin_arena::emojicoin_arena {
                 match_amount,
                 emojicoin_0_proceeds,
                 emojicoin_1_proceeds,
-                emojicoin_0_exchange_rate: exchange_rate<Coin0, LP0>(market_address_0),
-                emojicoin_1_exchange_rate: exchange_rate<Coin1, LP1>(market_address_1)
+                emojicoin_0_exchange_rate: exchange_rate_inner<Coin0, LP0>(
+                    market_address_0
+                ),
+                emojicoin_1_exchange_rate: exchange_rate_inner<Coin1, LP1>(
+                    market_address_1
+                )
             }
         );
 
@@ -298,8 +302,12 @@ module emojicoin_arena::emojicoin_arena {
                 integrator_fee,
                 emojicoin_0_proceeds,
                 emojicoin_1_proceeds,
-                emojicoin_0_exchange_rate: exchange_rate<Coin0, LP0>(market_address_0),
-                emojicoin_1_exchange_rate: exchange_rate<Coin1, LP1>(market_address_1)
+                emojicoin_0_exchange_rate: exchange_rate_inner<Coin0, LP0>(
+                    market_address_0
+                ),
+                emojicoin_1_exchange_rate: exchange_rate_inner<Coin1, LP1>(
+                    market_address_1
+                )
             }
         );
 
@@ -354,7 +362,19 @@ module emojicoin_arena::emojicoin_arena {
     }
 
     #[view]
-    public fun melee<Coin0, LP0, Coin1, LP1>(melee_id: u64): Melee acquires Registry {
+    public fun exchange_rate<Emojicoin, EmojicoinLP>(
+        market_address: address
+    ): ExchangeRate {
+        exchange_rate_inner<Emojicoin, EmojicoinLP>(market_address)
+    }
+
+    public fun unpack_exchange_rate(self: ExchangeRate): (u64, u64) {
+        let ExchangeRate { base, quote } = self;
+        (base, quote)
+    }
+
+    #[view]
+    public fun melee(melee_id: u64): Melee acquires Registry {
         *Registry[@emojicoin_arena].melees_by_id.borrow(melee_id)
     }
 
@@ -624,7 +644,7 @@ module emojicoin_arena::emojicoin_arena {
         entrant_address
     }
 
-    inline fun exchange_rate<Emojicoin, EmojicoinLP>(
+    inline fun exchange_rate_inner<Emojicoin, EmojicoinLP>(
         market_address: address
     ): ExchangeRate {
 
@@ -736,8 +756,12 @@ module emojicoin_arena::emojicoin_arena {
                 emojicoin_0_proceeds,
                 emojicoin_1_proceeds,
                 tap_out_fee,
-                emojicoin_0_exchange_rate: exchange_rate<Coin0, LP0>(market_address_0),
-                emojicoin_1_exchange_rate: exchange_rate<Coin1, LP1>(market_address_1)
+                emojicoin_0_exchange_rate: exchange_rate_inner<Coin0, LP0>(
+                    market_address_0
+                ),
+                emojicoin_1_exchange_rate: exchange_rate_inner<Coin1, LP1>(
+                    market_address_1
+                )
             }
         );
     }
@@ -1219,12 +1243,6 @@ module emojicoin_arena::emojicoin_arena {
             emojicoin_0_exchange_rate,
             emojicoin_1_exchange_rate
         )
-    }
-
-    #[test_only]
-    public fun unpack_exchange_rate(self: ExchangeRate): (u64, u64) {
-        let ExchangeRate { base, quote } = self;
-        (base, quote)
     }
 
     #[test_only]

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -8,10 +8,7 @@ module emojicoin_arena::tests {
     use aptos_framework::event::{emitted_events};
     use aptos_framework::timestamp;
     use aptos_framework::transaction_context;
-    use black_cat_market::coin_factory::{
-        Emojicoin as BlackCat,
-        EmojicoinLP as BlackCatLP
-    };
+    use black_cat_market::coin_factory::{Emojicoin as BlackCat, EmojicoinLP as BlackCatLP};
     use emojicoin_dot_fun::emojicoin_dot_fun::{
         MarketMetadata,
         get_BASE_VIRTUAL_CEILING,
@@ -52,10 +49,7 @@ module emojicoin_arena::tests {
     use emojicoin_dot_fun::tests as emojicoin_dot_fun_tests;
     use std::option;
     use std::vector;
-    use zebra_market::coin_factory::{
-        Emojicoin as Zebra,
-        EmojicoinLP as ZebraLP
-    };
+    use zebra_market::coin_factory::{Emojicoin as Zebra, EmojicoinLP as ZebraLP};
 
     struct MockExchangeRate has copy, drop, store {
         base: u64,

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -9,8 +9,8 @@ module emojicoin_arena::tests {
     use aptos_framework::timestamp;
     use aptos_framework::transaction_context;
     use black_cat_market::coin_factory::{
-        Emojicoin as BlackCatEmojicoin,
-        EmojicoinLP as BlackCatEmojicoinLP
+        Emojicoin as BlackCat,
+        EmojicoinLP as BlackCatLP
     };
     use emojicoin_dot_fun::emojicoin_dot_fun::{
         MarketMetadata,
@@ -27,6 +27,7 @@ module emojicoin_arena::tests {
         Melee,
         RegistryView,
         VaultBalanceUpdate,
+        escrow,
         exchange_rate,
         fund_vault,
         get_DEFAULT_AVAILABLE_REWARDS,
@@ -51,6 +52,10 @@ module emojicoin_arena::tests {
     use emojicoin_dot_fun::tests as emojicoin_dot_fun_tests;
     use std::option;
     use std::vector;
+    use zebra_market::coin_factory::{
+        Emojicoin as Zebra,
+        EmojicoinLP as ZebraLP
+    };
 
     struct MockExchangeRate has copy, drop, store {
         base: u64,
@@ -316,12 +321,23 @@ module emojicoin_arena::tests {
     }
 
     #[test]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_NO_ESCROW,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun escrow_no_escrow() {
+        escrow<BlackCat, BlackCatLP, Zebra, ZebraLP>(@0x0);
+    }
+
+    #[test]
     public fun exchange_rate_exact_transition() {
         emojicoin_dot_fun_tests::init_package_then_exact_transition();
 
         let (base, quote) =
             unpack_exchange_rate(
-                exchange_rate<BlackCatEmojicoin, BlackCatEmojicoinLP>(@black_cat_market)
+                exchange_rate<BlackCat, BlackCatLP>(@black_cat_market)
             );
         assert!(base == get_EMOJICOIN_REMAINDER());
         assert!(quote == get_QUOTE_REAL_CEILING());
@@ -333,7 +349,7 @@ module emojicoin_arena::tests {
 
         let (base, quote) =
             unpack_exchange_rate(
-                exchange_rate<BlackCatEmojicoin, BlackCatEmojicoinLP>(@black_cat_market)
+                exchange_rate<BlackCat, BlackCatLP>(@black_cat_market)
             );
         assert!(base == get_BASE_VIRTUAL_CEILING());
         assert!(quote == get_QUOTE_VIRTUAL_FLOOR());

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -8,8 +8,16 @@ module emojicoin_arena::tests {
     use aptos_framework::event::{emitted_events};
     use aptos_framework::timestamp;
     use aptos_framework::transaction_context;
+    use black_cat_market::coin_factory::{
+        Emojicoin as BlackCatEmojicoin,
+        EmojicoinLP as BlackCatEmojicoinLP
+    };
     use emojicoin_dot_fun::emojicoin_dot_fun::{
         MarketMetadata,
+        get_BASE_VIRTUAL_CEILING,
+        get_EMOJICOIN_REMAINDER,
+        get_QUOTE_REAL_CEILING,
+        get_QUOTE_VIRTUAL_FLOOR,
         market_metadata_by_market_id,
         unpack_market_metadata
     };
@@ -19,6 +27,7 @@ module emojicoin_arena::tests {
         Melee,
         RegistryView,
         VaultBalanceUpdate,
+        exchange_rate,
         fund_vault,
         get_DEFAULT_AVAILABLE_REWARDS,
         get_DEFAULT_DURATION,
@@ -304,6 +313,30 @@ module emojicoin_arena::tests {
         registry_view.next_melee_max_match_percentage = next_max_match_percentage;
         registry_view.vault_balance -= withdrawn_octas;
         registry_view.assert_registry_view(registry());
+    }
+
+    #[test]
+    public fun exchange_rate_exact_transition() {
+        emojicoin_dot_fun_tests::init_package_then_exact_transition();
+
+        let (base, quote) =
+            unpack_exchange_rate(
+                exchange_rate<BlackCatEmojicoin, BlackCatEmojicoinLP>(@black_cat_market)
+            );
+        assert!(base == get_EMOJICOIN_REMAINDER());
+        assert!(quote == get_QUOTE_REAL_CEILING());
+    }
+
+    #[test]
+    public fun exchange_rate_fresh_market() {
+        init_emojicoin_dot_fun_with_test_markets();
+
+        let (base, quote) =
+            unpack_exchange_rate(
+                exchange_rate<BlackCatEmojicoin, BlackCatEmojicoinLP>(@black_cat_market)
+            );
+        assert!(base == get_BASE_VIRTUAL_CEILING());
+        assert!(quote == get_QUOTE_VIRTUAL_FLOOR());
     }
 
     #[test]


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

## Logic changes

1. Add view function for inspecting match amount when locking in, associated
   aborts and inline refactors.
1. Make exchange rate view function public.
1. Add aborts for escrow and melee views.
1. Consolidate logic for checking if melee is active.
1. Clarify constant names for single/double route fee rates.

## Tests

1. Test exchange rate helper.
1. Test expected failure for escrow note existing.
1. Add happy path test for entering, swapping inside of, and exiting a melee.
1. Add helper for simulating a swap before executing an escrow operation.

# Testing

Tested to ~50% coverage per running in `src/move/emojicoin_arena`:

```sh
git ls-files | entr -c sh -c " \
       aptos move test --coverage --dev --move-2  &&
       aptos move fmt \
"
```

# Checklist

- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
