### PR TITLE
[ECO-2658] Add emojicoin arena crank, tap out testing

### DIFF
--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -1323,6 +1323,21 @@ module emojicoin_arena::emojicoin_arena {
     }
 
     #[test_only]
+    public fun melee_ids_by_market_ids_contains_for_test(
+        sorted_unique_market_ids: vector<u64>
+    ): bool acquires Registry {
+        Registry[@emojicoin_arena].melee_ids_by_market_ids.contains(
+            sorted_unique_market_ids
+        )
+    }
+
+    #[test_only]
+    #[lint::allow_unsafe_randomness]
+    public fun random_market_id_for_test(): u64 {
+        random_market_id(get_n_registered_markets())
+    }
+
+    #[test_only]
     #[lint::allow_unsafe_randomness]
     public fun swap_for_test<Coin0, LP0, Coin1, LP1>(swapper: &signer) acquires Escrow, Registry {
         swap<Coin0, LP0, Coin1, LP1>(swapper);

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -583,11 +583,25 @@ module emojicoin_arena::tests {
         time += get_DEFAULT_DURATION();
         timestamp::update_global_time_for_test(time + 1);
 
+        // Verify that nothing can be matched since melee duration has elapsed.
+        assert!(
+            match_amount<BlackCat, BlackCatLP, Zebra, ZebraLP>(
+                PARTICIPANT, base_enter_amount_post_bonding_curve(), 1
+            ) == 0
+        );
+
         // Crank via enter API.
         enter<BlackCat, BlackCatLP, Zebra, ZebraLP, BlackCat>(
             &get_signer(PARTICIPANT),
             base_enter_amount_post_bonding_curve(),
             false
+        );
+
+        // Verify that nothing can be matched since melee is inactive.
+        assert!(
+            match_amount<BlackCat, BlackCatLP, Zebra, ZebraLP>(
+                PARTICIPANT, base_enter_amount_post_bonding_curve(), 1
+            ) == 0
         );
 
         assert_crank_global_state_and_events();


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Add test-only stubs in source code for testing crank functionality.
1. Derive randomness seed that hits all crank coverage conditions.
1. Add helpers for testing crank functionality in a melee where both markets are
   out of the bonding curve.
1. Add tap out condition to lock in and top off test.

# Testing

From `src/move/emojicoin_arena`:

```sh
git ls-files | entr -c sh -c " \
       aptos move test --coverage --dev --move-2  &&
       aptos move fmt
   "
```

Results in 97.5\% coverage.

# Checklist

- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you check all checkboxes from the linked Linear task?
