### PR TITLE
[ECO-2659] Add final arena abstractions, tests to 100% coverage

### DIFF
--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -38,6 +38,8 @@ module emojicoin_arena::emojicoin_arena {
     const E_INVALID_MELEE_ID: u64 = 8;
     /// User has no funds in escrow to swap.
     const E_SWAP_NO_FUNDS: u64 = 9;
+    /// User can not afford tap out fee.
+    const E_EXIT_TAP_OUT_FEE: u64 = 10;
 
     const MAX_PERCENTAGE: u64 = 100;
 
@@ -797,6 +799,8 @@ module emojicoin_arena::emojicoin_arena {
                     account::get_signer_capability_address(
                         &registry_ref_mut.signer_capability
                     );
+                let user_balance = coin::balance<AptosCoin>(participant_address);
+                assert!(user_balance >= match_amount, E_EXIT_TAP_OUT_FEE);
                 aptos_account::transfer(participant, vault_address, match_amount);
                 emit_vault_balance_update_with_vault_address(vault_address);
 

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -1065,51 +1065,6 @@ module emojicoin_arena::emojicoin_arena {
         )
     }
 
-    inline fun swap_within_escrow<Coin0, LP0, Coin1, LP1>(
-        swapper: &signer,
-        swapper_address: address,
-        escrow_ref_mut: &mut Escrow<Coin0, LP0, Coin1, LP1>,
-        market_address_0: address,
-        market_address_1: address
-    ): (u64, u64, u64, u64) {
-
-        // Get balances in escrow.
-        let emojicoin_0_balance = coin::value(&escrow_ref_mut.emojicoin_0);
-        let emojicoin_1_balance = coin::value(&escrow_ref_mut.emojicoin_1);
-
-        // Initialize return values.
-        let (emojicoin_0_proceeds, emojicoin_1_proceeds) = (0, 0);
-        let (quote_volume, integrator_fee);
-
-        // Execute a swap within escrow based on the direction.
-        if (emojicoin_0_balance > 0) {
-            (quote_volume, integrator_fee, emojicoin_1_proceeds) = swap_within_escrow_for_direction<Coin0, LP0, Coin1, LP1>(
-                swapper,
-                swapper_address,
-                market_address_0,
-                market_address_1,
-                emojicoin_0_balance,
-                &mut escrow_ref_mut.emojicoin_0,
-                &mut escrow_ref_mut.emojicoin_1
-            );
-        } else {
-            // Verify that at least one emojicoin balance is nonzero.
-            assert!(emojicoin_1_balance > 0, E_SWAP_NO_FUNDS);
-
-            (quote_volume, integrator_fee, emojicoin_0_proceeds) = swap_within_escrow_for_direction<Coin1, LP1, Coin0, LP0>(
-                swapper,
-                swapper_address,
-                market_address_1,
-                market_address_0,
-                emojicoin_1_balance,
-                &mut escrow_ref_mut.emojicoin_1,
-                &mut escrow_ref_mut.emojicoin_0
-            );
-        };
-
-        (quote_volume, integrator_fee, emojicoin_0_proceeds, emojicoin_1_proceeds)
-    }
-
     inline fun swap_with_stats_for_emojicoin<Emojicoin, LP>(
         swapper: &signer,
         market_address: address,
@@ -1166,6 +1121,51 @@ module emojicoin_arena::emojicoin_arena {
         );
 
         (net_proceeds, quote_volume, integrator_fee)
+    }
+
+    inline fun swap_within_escrow<Coin0, LP0, Coin1, LP1>(
+        swapper: &signer,
+        swapper_address: address,
+        escrow_ref_mut: &mut Escrow<Coin0, LP0, Coin1, LP1>,
+        market_address_0: address,
+        market_address_1: address
+    ): (u64, u64, u64, u64) {
+
+        // Get balances in escrow.
+        let emojicoin_0_balance = coin::value(&escrow_ref_mut.emojicoin_0);
+        let emojicoin_1_balance = coin::value(&escrow_ref_mut.emojicoin_1);
+
+        // Initialize return values.
+        let (emojicoin_0_proceeds, emojicoin_1_proceeds) = (0, 0);
+        let (quote_volume, integrator_fee);
+
+        // Execute a swap within escrow based on the direction.
+        if (emojicoin_0_balance > 0) {
+            (quote_volume, integrator_fee, emojicoin_1_proceeds) = swap_within_escrow_for_direction<Coin0, LP0, Coin1, LP1>(
+                swapper,
+                swapper_address,
+                market_address_0,
+                market_address_1,
+                emojicoin_0_balance,
+                &mut escrow_ref_mut.emojicoin_0,
+                &mut escrow_ref_mut.emojicoin_1
+            );
+        } else {
+            // Verify that at least one emojicoin balance is nonzero.
+            assert!(emojicoin_1_balance > 0, E_SWAP_NO_FUNDS);
+
+            (quote_volume, integrator_fee, emojicoin_0_proceeds) = swap_within_escrow_for_direction<Coin1, LP1, Coin0, LP0>(
+                swapper,
+                swapper_address,
+                market_address_1,
+                market_address_0,
+                emojicoin_1_balance,
+                &mut escrow_ref_mut.emojicoin_1,
+                &mut escrow_ref_mut.emojicoin_0
+            );
+        };
+
+        (quote_volume, integrator_fee, emojicoin_0_proceeds, emojicoin_1_proceeds)
     }
 
     inline fun swap_within_escrow_for_direction<FromCoin, FromLP, ToCoin, ToLP>(
@@ -1334,6 +1334,11 @@ module emojicoin_arena::emojicoin_arena {
     }
 
     #[test_only]
+    public fun init_module_test_only(account: &signer) acquires Registry {
+        init_module(account)
+    }
+
+    #[test_only]
     public fun get_DEFAULT_AVAILABLE_REWARDS(): u64 {
         DEFAULT_AVAILABLE_REWARDS
     }
@@ -1378,11 +1383,6 @@ module emojicoin_arena::emojicoin_arena {
     public fun set_melee_max_match_amount(melee_id: u64, amount: u64) acquires Registry {
         Registry[@emojicoin_arena].melees_by_id.borrow_mut(melee_id).max_match_amount =
             amount;
-    }
-
-    #[test_only]
-    public fun init_module_test_only(account: &signer) acquires Registry {
-        init_module(account)
     }
 
     #[test_only]

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -36,6 +36,8 @@ module emojicoin_arena::emojicoin_arena {
     const E_MELEE_ID_MISMATCH: u64 = 7;
     /// Melee ID does not correspond to a melee that has been registered.
     const E_INVALID_MELEE_ID: u64 = 8;
+    /// User has no funds in escrow to swap.
+    const E_SWAP_NO_FUNDS: u64 = 9;
 
     const MAX_PERCENTAGE: u64 = 100;
 
@@ -1075,7 +1077,7 @@ module emojicoin_arena::emojicoin_arena {
             );
         } else {
             // Verify that at least one emojicoin balance is nonzero.
-            assert!(emojicoin_1_balance > 0, E_EXIT_NO_FUNDS);
+            assert!(emojicoin_1_balance > 0, E_SWAP_NO_FUNDS);
 
             (quote_volume, integrator_fee, emojicoin_0_proceeds) = swap_within_escrow_for_direction<Coin1, LP1, Coin0, LP0>(
                 swapper,

--- a/src/move/emojicoin_arena/sources/emojicoin_arena.move
+++ b/src/move/emojicoin_arena/sources/emojicoin_arena.move
@@ -839,10 +839,6 @@ module emojicoin_arena::emojicoin_arena {
         // Withdraw emojicoin balance from escrow.
         let (emojicoin_0_proceeds, emojicoin_1_proceeds) =
             try_withdraw_from_escrow_both_coins(participant_address, escrow_ref_mut);
-        assert!(
-            emojicoin_0_proceeds > 0 || emojicoin_1_proceeds > 0,
-            E_EXIT_NO_FUNDS
-        );
 
         // Emit exit event.
         event::emit(

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -1602,6 +1602,25 @@ module emojicoin_arena::tests {
     }
 
     #[test]
+    #[lint::allow_unsafe_randomness]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_EXIT_TAP_OUT_FEE,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun exit_exit_tap_out_fee() {
+        init_module_with_funded_vault_and_participant(); // Fund just enough to enter.
+        enter<BlackCat, BlackCatLP, Zebra, ZebraLP, BlackCat>(
+            &get_signer(PARTICIPANT),
+            base_enter_amount(),
+            true
+        );
+        assert!(coin::balance<AptosCoin>(PARTICIPANT) == 0);
+        exit<BlackCat, BlackCatLP, Zebra, ZebraLP>(&get_signer(PARTICIPANT));
+    }
+
+    #[test]
     public fun init_module_base() {
         // Initialize emojicoin dot fun.
         init_emojicoin_dot_fun_with_test_markets();

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -1605,6 +1605,25 @@ module emojicoin_arena::tests {
     #[lint::allow_unsafe_randomness]
     #[
         expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_EXIT_NO_FUNDS,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun exit_exit_no_funds() {
+        init_module_with_funded_vault_and_participant();
+        enter<BlackCat, BlackCatLP, Zebra, ZebraLP, BlackCat>(
+            &get_signer(PARTICIPANT),
+            base_enter_amount(),
+            false
+        );
+        exit<BlackCat, BlackCatLP, Zebra, ZebraLP>(&get_signer(PARTICIPANT));
+        exit<BlackCat, BlackCatLP, Zebra, ZebraLP>(&get_signer(PARTICIPANT));
+    }
+
+    #[test]
+    #[lint::allow_unsafe_randomness]
+    #[
+        expected_failure(
             abort_code = emojicoin_arena::emojicoin_arena::E_EXIT_TAP_OUT_FEE,
             location = emojicoin_arena::emojicoin_arena
         )

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -1840,6 +1840,25 @@ module emojicoin_arena::tests {
     }
 
     #[test]
+    #[lint::allow_unsafe_randomness]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_SWAP_NO_FUNDS,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun swap_swap_no_funds() {
+        init_module_with_funded_vault_and_participant();
+        enter<BlackCat, BlackCatLP, Zebra, ZebraLP, BlackCat>(
+            &get_signer(PARTICIPANT),
+            base_enter_amount(),
+            false
+        );
+        exit<BlackCat, BlackCatLP, Zebra, ZebraLP>(&get_signer(PARTICIPANT));
+        swap<BlackCat, BlackCatLP, Zebra, ZebraLP>(&get_signer(PARTICIPANT));
+    }
+
+    #[test]
     public fun test_market_addresses() {
         init_emojicoin_dot_fun_with_test_markets();
         let market_addresses = vector[

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -1621,6 +1621,18 @@ module emojicoin_arena::tests {
     }
 
     #[test]
+    #[lint::allow_unsafe_randomness]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_NO_ESCROW,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun exit_no_escrow() {
+        exit<BlackCat, BlackCatLP, Zebra, ZebraLP>(&get_signer(PARTICIPANT));
+    }
+
+    #[test]
     public fun init_module_base() {
         // Initialize emojicoin dot fun.
         init_emojicoin_dot_fun_with_test_markets();
@@ -1856,6 +1868,18 @@ module emojicoin_arena::tests {
     ]
     public fun set_next_melee_max_match_percentage_not_arena() {
         set_next_melee_max_match_percentage(&get_signer(@aptos_framework), 0);
+    }
+
+    #[test]
+    #[lint::allow_unsafe_randomness]
+    #[
+        expected_failure(
+            abort_code = emojicoin_arena::emojicoin_arena::E_NO_ESCROW,
+            location = emojicoin_arena::emojicoin_arena
+        )
+    ]
+    public fun swap_no_escrow() {
+        swap<BlackCat, BlackCatLP, Zebra, ZebraLP>(&get_signer(PARTICIPANT));
     }
 
     #[test]

--- a/src/move/emojicoin_arena/tests/tests.move
+++ b/src/move/emojicoin_arena/tests/tests.move
@@ -186,25 +186,29 @@ module emojicoin_arena::tests {
         assert!(self.match_amount == match_amount);
     }
 
-    public fun assert_crank_global_state_and_events() {
-        // Assert state.
+    public fun assert_crank_global_state_and_events(rewards_claimed: u64) {
+        // Assert registry state.
         let registry_view = base_registry_view();
         registry_view.n_melees = 2;
+        registry_view.vault_balance -= rewards_claimed;
         registry_view.assert_registry_view(registry());
+
+        // Assert emitted melee events.
         let melee_view_1 = base_melee();
-        melee_view_1.assert_melee(melee(melee_view_1.melee_id));
         let melee_view_2 = melee_view_1;
         melee_view_2.melee_id = 2;
         melee_view_2.emojicoin_0_market_address = @black_heart_market;
         melee_view_2.emojicoin_1_market_address = @yellow_heart_market;
         melee_view_2.start_time = base_start_time() + get_DEFAULT_DURATION();
-        melee_view_2.assert_melee(melee(melee_view_2.melee_id));
-
-        // Assert emitted melee events.
         let melee_events = emitted_events<Melee>();
         assert!(melee_events.length() == 2);
         melee_view_1.assert_melee(melee_events[0]);
         melee_view_2.assert_melee(melee_events[1]);
+
+        // Assert melee views.
+        melee_view_1.available_rewards -= rewards_claimed;
+        melee_view_1.assert_melee(melee(melee_view_1.melee_id));
+        melee_view_2.assert_melee(melee(melee_view_2.melee_id));
     }
 
     public fun assert_exchange_rate(
@@ -512,24 +516,44 @@ module emojicoin_arena::tests {
         SimulatedSwapStats { quote_volume, integrator_fee, net_proceeds }
     }
 
-    public fun simulate_enter_post_bonding_curve():
-        (
-        MockEscrowView, MockEnter, SimulatedSwapStats
-    ) {
+    public fun simulate_enter_post_bonding_curve(
+        emojicoin_0: bool, lock_in: bool
+    ): (MockEscrowView, MockEnter, SimulatedSwapStats) {
+
+        // Get local variables based on market, lock-in status.
+        let market_address =
+            if (emojicoin_0) {
+                @black_cat_market
+            } else {
+                @zebra_market
+            };
+        let match_amount =
+            if (lock_in) {
+                match_amount<BlackCat, BlackCatLP, Zebra, ZebraLP>(
+                    PARTICIPANT, base_enter_amount_post_bonding_curve(), 1
+                )
+            } else { 0 };
 
         // Simulate swap into escrow.
         let swap_inputs_enter = SimulatedSwapInputs {
-            market_address: @black_cat_market,
-            input_amount: base_enter_amount_post_bonding_curve(),
+            market_address,
+            input_amount: base_enter_amount_post_bonding_curve() + match_amount,
             selling_emojicoins: false,
             integrator_fee_rate: get_INTEGRATOR_FEE_RATE_BPS_SINGLE_ROUTE()
         };
         let swap_stats_enter =
-            simulated_swap_stats<BlackCat, BlackCatLP>(swap_inputs_enter);
+            if (emojicoin_0) simulated_swap_stats<BlackCat, BlackCatLP>(swap_inputs_enter)
+            else simulated_swap_stats<Zebra, ZebraLP>(swap_inputs_enter);
 
         // Get escrow view.
         let escrow_view = base_escrow_view();
-        escrow_view.emojicoin_0_balance = swap_stats_enter.net_proceeds;
+        escrow_view.match_amount = match_amount;
+
+        if (emojicoin_0) {
+            escrow_view.emojicoin_0_balance = swap_stats_enter.net_proceeds;
+        } else {
+            escrow_view.emojicoin_1_balance = swap_stats_enter.net_proceeds;
+        };
 
         // Construct enter event.
         let enter_event = MockEnter {
@@ -538,9 +562,9 @@ module emojicoin_arena::tests {
             input_amount: base_enter_amount_post_bonding_curve(),
             quote_volume: swap_stats_enter.quote_volume,
             integrator_fee: swap_stats_enter.integrator_fee,
-            match_amount: 0,
-            emojicoin_0_proceeds: swap_stats_enter.net_proceeds,
-            emojicoin_1_proceeds: 0,
+            match_amount,
+            emojicoin_0_proceeds: escrow_view.emojicoin_0_balance,
+            emojicoin_1_proceeds: escrow_view.emojicoin_1_balance,
             // Must be updated after actual enter.
             emojicoin_0_exchange_rate: exchange_rate<BlackCat, BlackCatLP>(
                 @black_cat_market
@@ -658,7 +682,7 @@ module emojicoin_arena::tests {
         );
 
         // Assert global state and crank events.
-        assert_crank_global_state_and_events();
+        assert_crank_global_state_and_events(0);
     }
 
     #[test]
@@ -668,15 +692,19 @@ module emojicoin_arena::tests {
             init_module_with_funded_vault_and_participant_post_bonding_curve();
         set_randomness_seed_for_crank_coverage();
 
+        // Declare which market to enter and if locking in.
+        let emojicoin_0 = true;
+        let lock_in = false;
+
         // Get escrow view and enter event post-enter.
         let (escrow_view, enter_event, swap_stats_enter) =
-            simulate_enter_post_bonding_curve();
+            simulate_enter_post_bonding_curve(emojicoin_0, lock_in);
 
         // Enter.
         enter<BlackCat, BlackCatLP, Zebra, ZebraLP, BlackCat>(
             &get_signer(PARTICIPANT),
             base_enter_amount_post_bonding_curve(),
-            false
+            lock_in
         );
 
         // Update exchange rates in enter event to be real-time.
@@ -736,7 +764,7 @@ module emojicoin_arena::tests {
         };
         exit_event.assert_exit(exit_events[0]);
 
-        assert_crank_global_state_and_events();
+        assert_crank_global_state_and_events(0);
     }
 
     #[test]
@@ -746,15 +774,19 @@ module emojicoin_arena::tests {
             init_module_with_funded_vault_and_participant_post_bonding_curve();
         set_randomness_seed_for_crank_coverage();
 
+        // Declare which market to enter and if locking in.
+        let emojicoin_0 = true;
+        let lock_in = false;
+
         // Get escrow view and enter event post-enter.
         let (escrow_view, enter_event, swap_stats_enter) =
-            simulate_enter_post_bonding_curve();
+            simulate_enter_post_bonding_curve(emojicoin_0, lock_in);
 
         // Enter.
         enter<BlackCat, BlackCatLP, Zebra, ZebraLP, BlackCat>(
             &get_signer(PARTICIPANT),
             base_enter_amount_post_bonding_curve(),
-            false
+            lock_in
         );
 
         // Update exchange rates in enter event to be real-time.
@@ -850,7 +882,126 @@ module emojicoin_arena::tests {
         };
         exit_event.assert_exit(exit_events[0]);
 
-        assert_crank_global_state_and_events();
+        assert_crank_global_state_and_events(0);
+    }
+
+    #[test]
+    #[lint::allow_unsafe_randomness]
+    public fun crank_by_swap_locked_in_opposite_side() {
+        let (emojicoin_0_balance, emojicoin_1_balance) =
+            init_module_with_funded_vault_and_participant_post_bonding_curve();
+        set_randomness_seed_for_crank_coverage();
+
+        // Declare which market to enter and if locking in.
+        let emojicoin_0 = false;
+        let lock_in = true;
+
+        // Get escrow view and enter event post-enter.
+        let (escrow_view, enter_event, swap_stats_enter) =
+            simulate_enter_post_bonding_curve(emojicoin_0, lock_in);
+
+        // Enter, locking in.
+        enter<BlackCat, BlackCatLP, Zebra, ZebraLP, Zebra>(
+            &get_signer(PARTICIPANT),
+            base_enter_amount_post_bonding_curve(),
+            lock_in
+        );
+
+        // Update exchange rates in enter event to be real-time.
+        enter_event.emojicoin_0_exchange_rate = exchange_rate<BlackCat, BlackCatLP>(
+            @black_cat_market
+        );
+        enter_event.emojicoin_1_exchange_rate = exchange_rate<Zebra, ZebraLP>(
+            @zebra_market
+        );
+
+        // Assert user state.
+        escrow_view.assert_escrow_view(
+            escrow<BlackCat, BlackCatLP, Zebra, ZebraLP>(PARTICIPANT)
+        );
+        assert!(coin::balance<AptosCoin>(PARTICIPANT) == 0);
+        assert!(coin::balance<BlackCat>(PARTICIPANT) == emojicoin_0_balance);
+        assert!(coin::balance<Zebra>(PARTICIPANT) == emojicoin_1_balance);
+
+        // Assert enter event.
+        let enter_events = emitted_events<Enter>();
+        assert!(enter_events.length() == 1);
+        enter_event.assert_enter(enter_events[0]);
+
+        // Set time to middle of a new melee.
+        let time = base_publish_time();
+        time += get_DEFAULT_DURATION();
+        timestamp::update_global_time_for_test(time + 1);
+
+        // Simulate swap within escrow.
+        let swap_inputs_swap_route_0 = SimulatedSwapInputs {
+            market_address: @zebra_market,
+            input_amount: swap_stats_enter.net_proceeds,
+            selling_emojicoins: true,
+            integrator_fee_rate: get_INTEGRATOR_FEE_RATE_BPS_DOUBLE_ROUTE()
+        };
+        let swap_stats_swap_route_0 =
+            simulated_swap_stats<Zebra, ZebraLP>(swap_inputs_swap_route_0);
+        let swap_inputs_swap_route_1 = SimulatedSwapInputs {
+            market_address: @black_cat_market,
+            input_amount: swap_stats_swap_route_0.net_proceeds,
+            selling_emojicoins: false,
+            integrator_fee_rate: get_INTEGRATOR_FEE_RATE_BPS_DOUBLE_ROUTE()
+        };
+        let swap_stats_swap_route_1 =
+            simulated_swap_stats<BlackCat, BlackCatLP>(swap_inputs_swap_route_1);
+
+        // Crank via swap API.
+        swap<BlackCat, BlackCatLP, Zebra, ZebraLP>(&get_signer(PARTICIPANT));
+
+        // Assert user state.
+        escrow_view.emojicoin_1_balance = 0;
+        escrow_view.match_amount = 0;
+        escrow_view.assert_escrow_view(
+            escrow<BlackCat, BlackCatLP, Zebra, ZebraLP>(PARTICIPANT)
+        );
+        assert!(coin::balance<AptosCoin>(PARTICIPANT) == 0);
+        assert!(
+            coin::balance<BlackCat>(PARTICIPANT)
+                == emojicoin_0_balance + swap_stats_swap_route_1.net_proceeds
+        );
+        assert!(coin::balance<Zebra>(PARTICIPANT) == emojicoin_1_balance);
+
+        // Assert emitted swap event.
+        let swap_events = emitted_events<Swap>();
+        assert!(swap_events.length() == 1);
+        let swap_event = MockSwap {
+            user: PARTICIPANT,
+            melee_id: 1,
+            quote_volume: swap_stats_swap_route_1.quote_volume,
+            integrator_fee: swap_stats_swap_route_0.integrator_fee
+                + swap_stats_swap_route_1.integrator_fee,
+            emojicoin_0_proceeds: swap_stats_swap_route_1.net_proceeds,
+            emojicoin_1_proceeds: 0,
+            emojicoin_0_exchange_rate: exchange_rate<BlackCat, BlackCatLP>(
+                @black_cat_market
+            ),
+            emojicoin_1_exchange_rate: exchange_rate<Zebra, ZebraLP>(@zebra_market)
+        };
+        swap_event.assert_swap(swap_events[0]);
+
+        // Assert emitted exit event.
+        let exit_events = emitted_events<Exit>();
+        assert!(exit_events.length() == 1);
+        let exit_event = MockExit {
+            user: PARTICIPANT,
+            melee_id: 1,
+            tap_out_fee: 0,
+            emojicoin_0_proceeds: swap_stats_swap_route_1.net_proceeds,
+            emojicoin_1_proceeds: 0,
+            emojicoin_0_exchange_rate: exchange_rate<BlackCat, BlackCatLP>(
+                @black_cat_market
+            ),
+            emojicoin_1_exchange_rate: exchange_rate<Zebra, ZebraLP>(@zebra_market)
+        };
+        exit_event.assert_exit(exit_events[0]);
+
+        assert_crank_global_state_and_events(enter_event.match_amount);
     }
 
     #[test]


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

## Source code

1. Implement abortion for no funds when swapping, exiting.
1. Abstract prologue function for local variable setup in `swap`, `exit` APIs.
done and why they were necessary.
1. Refactor epilogue abstraction for exiting escrow.
1. Abstract tap out fee assessment.
1. Abstract withdrawing coins from escrow.
1. Alphabetize functions.

## Test code

1. Update crank helper functions to support locking in, melee side. 
1. Add test for cranking via a locked swap, on opposite side from existing test.
1. Add assorted minor expected failure tests.
1. Add test for setting new durations on successive melees.

# Testing

Tested to 100% coverage from within `src/move/emojicoin_arena`:


```sh
git ls-files | entr -c sh -c " \
    aptos move test --coverage --dev --move-2 &&                              
    aptos move fmt
"
```

# Checklist

- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you check all checkboxes from the linked Linear task?