### PR TITLE
[ECO-2588] Add market page banner and navigation link to arena

### DIFF
--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -83,12 +83,13 @@ const EmojicoinPage = async (params: EmojicoinPageProps) => {
       fetchSwapEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }),
       wrappedCachedContractMarketView(marketAddress.toString()),
       getAptPrice(),
-      fetchMelee({}),
+      fetchMelee({}).then((res) => (res ? res.melee : null)),
     ]);
 
     const isInMelee =
-      melee?.arenaMelee.emojicoin0MarketAddress === state.market.marketAddress ||
-      melee?.arenaMelee.emojicoin1MarketAddress === state.market.marketAddress;
+      !!melee &&
+      (melee.emojicoin0MarketAddress === state.market.marketAddress ||
+        melee.emojicoin1MarketAddress === state.market.marketAddress);
 
     return (
       <AptPriceContextProvider aptPrice={aptPrice}>

--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -8,6 +8,7 @@ import { getMarketAddress } from "@sdk/emojicoin_dot_fun";
 import { type Metadata } from "next";
 import { getAptPrice } from "lib/queries/get-apt-price";
 import { AptPriceContextProvider } from "context/AptPrice";
+import { fetchMelee } from "@/queries/arena";
 
 export const revalidate = 2;
 
@@ -77,12 +78,17 @@ const EmojicoinPage = async (params: EmojicoinPageProps) => {
     const { marketID } = state.market;
     const marketAddress = getMarketAddress(emojis);
 
-    const [chats, swaps, marketView, aptPrice] = await Promise.all([
+    const [chats, swaps, marketView, aptPrice, melee] = await Promise.all([
       fetchChatEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }),
       fetchSwapEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }),
       wrappedCachedContractMarketView(marketAddress.toString()),
       getAptPrice(),
+      fetchMelee({}),
     ]);
+
+    const isInMelee =
+      melee?.arenaMelee.emojicoin0MarketAddress === state.market.marketAddress ||
+      melee?.arenaMelee.emojicoin1MarketAddress === state.market.marketAddress;
 
     return (
       <AptPriceContextProvider aptPrice={aptPrice}>
@@ -95,6 +101,7 @@ const EmojicoinPage = async (params: EmojicoinPageProps) => {
             marketView,
             ...state.market,
           }}
+          isInMelee={isInMelee}
         />
       </AptPriceContextProvider>
     );

--- a/src/typescript/frontend/src/components/Badge.tsx
+++ b/src/typescript/frontend/src/components/Badge.tsx
@@ -1,20 +1,20 @@
-import { useThemeContext } from "context";
+import { darkColors } from "theme";
 import type { Colors } from "theme/types";
 
-export const Badge: React.FC<React.PropsWithChildren<{ color: keyof Colors }>> = ({
-  children,
+export const Badge = ({
   color,
-}) => {
-  const { theme } = useThemeContext();
-
+  children,
+}: {
+  color: keyof Colors;
+} & React.PropsWithChildren) => {
   return (
     <div
       style={{
-        border: `1px solid ${theme.colors[color]}`,
+        border: `1px solid ${darkColors[color]}`,
         borderRadius: "8px",
-        color: theme.colors[color],
+        color: darkColors[color],
       }}
-      className="pixel-heading-4 px-[.4rem] h-min h-min"
+      className="pixel-heading-4 px-[.4rem] h-min"
     >
       {children}
     </div>

--- a/src/typescript/frontend/src/components/Badge.tsx
+++ b/src/typescript/frontend/src/components/Badge.tsx
@@ -1,0 +1,22 @@
+import { useThemeContext } from "context";
+import type { Colors } from "theme/types";
+
+export const Badge: React.FC<React.PropsWithChildren<{ color: keyof Colors }>> = ({
+  children,
+  color,
+}) => {
+  const { theme } = useThemeContext();
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${theme.colors[color]}`,
+        borderRadius: "8px",
+        color: theme.colors[color],
+      }}
+      className="pixel-heading-4 px-[.4rem] h-min h-min"
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
@@ -1,14 +1,11 @@
 import React from "react";
 import { useScramble } from "use-scramble";
-
 import { translationFunction } from "context/language-context";
-
 import { Text } from "components/text";
 import { FlexGap } from "@containers";
-
 import { type MenuItemProps } from "./types";
 
-const MenuItem: React.FC<MenuItemProps> = ({ title, onClick = () => {}, pill }) => {
+const MenuItem = ({ title, onClick = () => {}, pill }: MenuItemProps) => {
   const { t } = translationFunction();
 
   const { ref, replay } = useScramble({

--- a/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
@@ -8,7 +8,7 @@ import { FlexGap } from "@containers";
 
 import { type MenuItemProps } from "./types";
 
-const MenuItem: React.FC<MenuItemProps> = ({ title, onClick = () => {} }) => {
+const MenuItem: React.FC<MenuItemProps> = ({ title, onClick = () => {}, pill }) => {
   const { t } = translationFunction();
 
   const { ref, replay } = useScramble({
@@ -32,6 +32,7 @@ const MenuItem: React.FC<MenuItemProps> = ({ title, onClick = () => {} }) => {
         ref={ref}
         ellipsis
       />
+      {pill}
       <Text textScale="pixelHeading4" color="econiaBlue" textTransform="uppercase" fontSize="24px">
         {" }"}
       </Text>

--- a/src/typescript/frontend/src/components/header/components/menu-item/types.ts
+++ b/src/typescript/frontend/src/components/header/components/menu-item/types.ts
@@ -3,4 +3,5 @@ import { type TranslationKey } from "context/language-context/types";
 export type MenuItemProps = {
   title: TranslationKey;
   onClick?: () => void;
+  pill?: React.ReactNode;
 };

--- a/src/typescript/frontend/src/components/header/components/mobile-menu-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu-item/index.tsx
@@ -8,6 +8,7 @@ import Arrow from "components/svg/icons/Arrow";
 
 import { type MobileMenuItemProps } from "./types";
 import { StyledItemWrapper } from "./styled";
+import { cn } from "lib/utils/class-name";
 
 const MobileMenuItem: React.FC<MobileMenuItemProps> = ({
   withIcon,
@@ -26,7 +27,7 @@ const MobileMenuItem: React.FC<MobileMenuItemProps> = ({
 
   return (
     <StyledItemWrapper onMouseOver={replay} onClick={onClick} borderBottom={borderBottom}>
-      <div className={`${withIcon?.className} ${pill?.className}`}>
+      <div className={cn(withIcon?.className, pill?.className)}>
         {withIcon?.icon}
         <Text
           textScale={withIcon ? "pixelHeading4" : "pixelHeading3"}

--- a/src/typescript/frontend/src/components/header/components/mobile-menu-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu-item/index.tsx
@@ -14,6 +14,7 @@ const MobileMenuItem: React.FC<MobileMenuItemProps> = ({
   title,
   onClick = () => {},
   borderBottom = true,
+  pill,
 }) => {
   const { t } = translationFunction();
 
@@ -25,7 +26,7 @@ const MobileMenuItem: React.FC<MobileMenuItemProps> = ({
 
   return (
     <StyledItemWrapper onMouseOver={replay} onClick={onClick} borderBottom={borderBottom}>
-      <div className={withIcon?.className}>
+      <div className={`${withIcon?.className} ${pill?.className}`}>
         {withIcon?.icon}
         <Text
           textScale={withIcon ? "pixelHeading4" : "pixelHeading3"}
@@ -33,6 +34,7 @@ const MobileMenuItem: React.FC<MobileMenuItemProps> = ({
           textTransform="uppercase"
           ref={ref}
         />
+        {pill?.pill}
       </div>
       {!withIcon && <Arrow width="18px" color="black" />}
     </StyledItemWrapper>

--- a/src/typescript/frontend/src/components/header/components/mobile-menu-item/types.ts
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu-item/types.ts
@@ -8,4 +8,8 @@ export type MobileMenuItemProps = {
   title: string;
   onClick?: () => void;
   borderBottom?: boolean;
+  pill?: {
+    className: string;
+    pill: React.ReactNode;
+  };
 };

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -17,6 +17,7 @@ import { useWalletModal } from "context/wallet-context/WalletModalContext";
 import { AnimatePresence, useAnimationControls } from "framer-motion";
 import AnimatedDropdownItem from "./components/animated-dropdown-item";
 import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
+import { Badge } from "components/Badge";
 
 const IconClass = "w-[22px] h-[22px] m-auto ml-[3ch] mr-[1.5ch]";
 
@@ -146,7 +147,18 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
                 onClick={handleCloseMobileMenu}
                 width="100%"
               >
-                <MobileMenuItem title={title} borderBottom={i !== linksForCurrentPage.length - 1} />
+                <MobileMenuItem
+                  title={title}
+                  borderBottom={i !== linksForCurrentPage.length - 1}
+                  pill={
+                    title === "arena"
+                      ? {
+                          className: "flex flex-row items-center gap-[.5em]",
+                          pill: <Badge color="black">NEW</Badge>,
+                        }
+                      : undefined
+                  }
+                />
               </Link>
             );
           })}

--- a/src/typescript/frontend/src/components/header/constants.ts
+++ b/src/typescript/frontend/src/components/header/constants.ts
@@ -1,6 +1,7 @@
 import { ROUTES } from "router/routes";
 
 export const NAVIGATE_LINKS = [
+  { title: "arena", path: ROUTES.arena },
   { title: "pools", path: ROUTES.pools },
   { title: "launch", path: ROUTES.launch },
   { title: "cult", path: ROUTES.cult },

--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -19,6 +19,7 @@ import ButtonWithConnectWalletFallback from "./wallet-button/ConnectWalletButton
 import { useSearchParams } from "next/navigation";
 import Link, { type LinkProps } from "next/link";
 import { useEmojiPicker } from "context/emoji-picker-context";
+import { Badge } from "components/Badge";
 
 const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
   const { isDesktop } = useMatchBreakpoints();
@@ -90,7 +91,10 @@ const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
                     href={path}
                     target={path.startsWith("https://") ? "_blank" : undefined}
                   >
-                    <MenuItem title={title} />
+                    <MenuItem
+                      title={title}
+                      pill={title === "arena" ? <Badge color="econiaBlue">NEW</Badge> : undefined}
+                    />
                   </Link>
                 );
               })}

--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -14,9 +14,9 @@ import { marketToLatestBars } from "@/store/event/candlestick-bars";
 import Carousel from "components/carousel";
 import { Text } from "components";
 import { GlobeIcon } from "lucide-react";
-import { useThemeContext } from "context";
 import Link from "next/link";
 import { ROUTES } from "router/routes";
+import { darkColors } from "theme";
 
 const EVENT_TYPES: SubscribableBrokerEvents[] = ["Chat", "PeriodicState", "Swap"];
 
@@ -38,8 +38,6 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
 
   useReliableSubscribe({ eventTypes: EVENT_TYPES });
 
-  const { theme } = useThemeContext();
-
   return (
     <Box>
       {props.isInMelee && (
@@ -55,7 +53,7 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
                 To trade this inside the melee, go to arena
               </Text>
             </Link>
-            <GlobeIcon color={theme.colors.econiaBlue} />
+            <GlobeIcon color={darkColors.econiaBlue} />
           </div>
         </Carousel>
       )}

--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -11,6 +11,12 @@ import MainInfo from "./components/main-info/MainInfo";
 import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
 import { type SubscribableBrokerEvents } from "@/broker/types";
 import { marketToLatestBars } from "@/store/event/candlestick-bars";
+import Carousel from "components/carousel";
+import { Text } from "components";
+import { GlobeIcon } from "lucide-react";
+import { useThemeContext } from "context";
+import Link from "next/link";
+import { ROUTES } from "router/routes";
 
 const EVENT_TYPES: SubscribableBrokerEvents[] = ["Chat", "PeriodicState", "Swap"];
 
@@ -32,8 +38,27 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
 
   useReliableSubscribe({ eventTypes: EVENT_TYPES });
 
+  const { theme } = useThemeContext();
+
   return (
     <Box>
+      {props.isInMelee && (
+        <Carousel gap={16}>
+          <div className="flex flex-row items-center gap-[16px]">
+            <Link href={ROUTES.arena}>
+              <Text
+                textScale="pixelHeading3"
+                color="econiaBlue"
+                className="w-max"
+                textTransform="uppercase"
+              >
+                To trade this inside the melee, go to arena
+              </Text>
+            </Link>
+            <GlobeIcon color={theme.colors.econiaBlue} />
+          </div>
+        </Carousel>
+      )}
       <MainInfo data={props.data} />
       {isTablet || isMobile ? <MobileGrid data={props.data} /> : <DesktopGrid data={props.data} />}
     </Box>

--- a/src/typescript/frontend/src/components/pages/emojicoin/types.ts
+++ b/src/typescript/frontend/src/components/pages/emojicoin/types.ts
@@ -17,6 +17,7 @@ type DataProps = MarketMetadataModel & {
 
 export interface EmojicoinProps {
   data: DataProps;
+  isInMelee: boolean;
 }
 
 export interface MainInfoProps {

--- a/src/typescript/frontend/src/components/svg/icons/LogoIcon.tsx
+++ b/src/typescript/frontend/src/components/svg/icons/LogoIcon.tsx
@@ -4,25 +4,8 @@ import Svg from "components/svg/Svg";
 import { VERSION } from "lib/env";
 import { type SvgProps } from "../types";
 import { useThemeContext } from "context";
-import Text from "components/text";
 import type { Colors } from "theme/types";
-
-const Badge: React.FC<React.PropsWithChildren<{ color: keyof Colors }>> = ({ children, color }) => {
-  const { theme } = useThemeContext();
-
-  return (
-    <Text
-      style={{
-        border: `1px solid ${theme.colors[color]}`,
-        borderRadius: "8px",
-        color: theme.colors[color],
-      }}
-      className="!pixel-heading-4 px-[.4rem] text-[15px]"
-    >
-      {children}
-    </Text>
-  );
-};
+import { Badge } from "components/Badge";
 
 const VersionBadge: React.FC<{ color: keyof Colors }> = ({ color }) =>
   // prettier-ignore

--- a/src/typescript/frontend/src/router/routes.ts
+++ b/src/typescript/frontend/src/router/routes.ts
@@ -4,6 +4,7 @@ export const ROUTES = {
   // Alphabetized after this.
   arena: "/arena",
   api: "/api",
+  arena: "/arena",
   cult: "/cult",
   dexscreener: "/dexscreener",
   docs: "https://docs.emojicoin.fun/category/--start-here",


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds a banner on the markets where a melee is in progress.

It also adds the buttons in the mobile menu and the desktop top navigation bar that link to the arena, as the banner instructs the user to click on the latter.

# Screenshots

![image](https://github.com/user-attachments/assets/2b1d652f-c6e5-4a03-af27-921542fbbaf9)


# Testing

Go to the market page of a market that is in melee.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
