### PR TITLE
[ECO-2710] Force display the "Go to emojicoin market" button on the launch emojicoin page regardless of wallet connection or being geoblocked

### DIFF
--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -16,6 +16,8 @@ export interface ConnectWalletProps extends PropsWithChildren<{ className?: stri
   onClick?: () => void;
   arrow?: boolean;
   forceAllowConnect?: boolean;
+  /** Display the button's children regardless of whether or not the user is connected. */
+  forceDisplayChildren?: boolean;
 }
 
 const CONNECT_WALLET = "Connect Wallet";
@@ -27,6 +29,7 @@ export const ButtonWithConnectWalletFallback = ({
   onClick,
   arrow = false,
   forceAllowConnect,
+  forceDisplayChildren,
 }: ConnectWalletProps) => {
   const { connected } = useWallet();
   const { openWalletModal } = useWalletModal();
@@ -76,7 +79,10 @@ export const ButtonWithConnectWalletFallback = ({
   // This component is used to display the `Connect Wallet` button and text with a scramble effect.
   // We use it in both mobile and desktop components.
   const inner =
-    !connected || !children || geoblocked ? (
+    // If the user is not connected, there's no children, or the user is geoblocked, display
+    // the "Connect Wallet" button. However, if `forceDisplayChildren === true`, display them
+    // regardless of the other parameters.
+    (!connected || !children || geoblocked) && !forceDisplayChildren ? (
       <Button
         className={
           className + (mobile ? " px-[9px] border-dashed border-b border-b-dark-gray" : "")

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
@@ -23,23 +23,20 @@ export const LaunchButtonOrGoToMarketLink = ({
     overflow: true,
   };
 
-  const link = (
-    <Link
-      className="font-pixelar text-lg uppercase text-ec-blue"
-      href={path.join(ROUTES.market, emojis.join(""))}
-    >
-      <Button scale="lg" scrambleProps={scrambleProps}>
-        {t("Go to emojicoin market")}
-      </Button>
-    </Link>
-  );
   return (
     <>
       {/* Force displaying the "Go to emojicoin market" link if the market is already registered,
           regardless of whether or not the user is connected. */}
       <ButtonWithConnectWalletFallback forceDisplayChildren={registered}>
         {registered ? (
-          link
+          <Link
+            className="font-pixelar text-lg uppercase text-ec-blue"
+            href={path.join(ROUTES.market, emojis.join(""))}
+          >
+            <Button scale="lg" scrambleProps={scrambleProps}>
+              {t("Go to emojicoin market")}
+            </Button>
+          </Link>
         ) : (
           <Button
             disabled={invalid || typeof registered === "undefined"}

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
@@ -23,18 +23,23 @@ export const LaunchButtonOrGoToMarketLink = ({
     overflow: true,
   };
 
+  const link = (
+    <Link
+      className="font-pixelar text-lg uppercase text-ec-blue"
+      href={path.join(ROUTES.market, emojis.join(""))}
+    >
+      <Button scale="lg" scrambleProps={scrambleProps}>
+        {t("Go to emojicoin market")}
+      </Button>
+    </Link>
+  );
   return (
     <>
-      <ButtonWithConnectWalletFallback>
+      {/* Force displaying the "Go to emojicoin market" link if the market is already registered,
+          regardless of whether or not the user is connected. */}
+      <ButtonWithConnectWalletFallback forceDisplayChildren={registered}>
         {registered ? (
-          <Link
-            className="font-pixelar text-lg uppercase text-ec-blue"
-            href={path.join(ROUTES.market, emojis.join(""))}
-          >
-            <Button scale="lg" scrambleProps={scrambleProps}>
-              {t("Go to emojicoin market")}
-            </Button>
-          </Link>
+          link
         ) : (
           <Button
             disabled={invalid || typeof registered === "undefined"}


### PR DESCRIPTION
# Description

The go to emojicoin market button doesn't show up if the user isn't connected with their wallet or if they're geoblocked. This can be fixed by adding a simple "forceDisplayChildren" prop to the ConnectWalletButtonFallback, with the conditional set to whether or not the market is registered already.

BEFORE CHANGE:
![image](https://github.com/user-attachments/assets/d0f686d8-4def-450f-b938-71051e16d3bf)

AFTER CHANGE (see wallet is definitively not connected in the top right):
![image](https://github.com/user-attachments/assets/cc0484e7-3e38-4c6b-9f6f-31c6d0184e35)


# Testing

Delete this sentence and provide a description of how to test the changes in
this PR.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
