### PR TITLE
[ECO-2724] Hot upgrade processor and broker on `emoji-main` (testnet) to `3.0.1`; for the arena view `NUMERIC` column casts

### DIFF
--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '3.0.0'
+  BrokerImageVersion: '3.0.1'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -23,7 +23,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '3.0.0'
+  ProcessorImageVersion: '3.0.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-main.yaml
+++ b/src/cloud-formation/deploy-indexer-main.yaml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  BrokerImageVersion: '3.0.0'
+  BrokerImageVersion: '3.0.1'
   DeployAlb: 'true'
   DeployAlbDnsRecord: 'true'
   DeployBastionHost: 'true'
@@ -21,7 +21,7 @@ parameters:
   Environment: 'main'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
-  ProcessorImageVersion: '3.0.0'
+  ProcessorImageVersion: '3.0.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '3.0.0'
+  BrokerImageVersion: '3.0.1'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -23,7 +23,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '3.0.0'
+  ProcessorImageVersion: '3.0.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'


### PR DESCRIPTION
# Description

Recent migration change for a couple fields needs to be merged.

To do a hot upgrade, this simply needs to bump the version number to the newest tag (3.0.1) in the yaml config files.

- [x] Ensure the AMD binary for broker `v3.0.1` is available on Dockerhub
- [x] Ensure the AMD binary for processor `v3.0.1` is available on Dockerhub