### PR TITLE
[ECO-2725] Update `localnet` and `deployer` to use Aptos CLI `v6.0.1`

### DIFF
--- a/.github/workflows/push-deployer.yaml
+++ b/.github/workflows/push-deployer.yaml
@@ -32,7 +32,7 @@ jobs:
         context: '.'
         file: 'src/docker/deployer/Dockerfile'
         labels: '${{ steps.metadata.outputs.labels }}'
-        platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
+        platforms: 'linux/amd64'
         push: 'true'
         tags: '${{ steps.metadata.outputs.tags }}'
     timeout-minutes: 360

--- a/.github/workflows/push-deployer.yaml
+++ b/.github/workflows/push-deployer.yaml
@@ -32,7 +32,7 @@ jobs:
         context: '.'
         file: 'src/docker/deployer/Dockerfile'
         labels: '${{ steps.metadata.outputs.labels }}'
-        platforms: 'linux/amd64'
+        platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
         push: 'true'
         tags: '${{ steps.metadata.outputs.tags }}'
     timeout-minutes: 360

--- a/src/docker/deployer/Dockerfile
+++ b/src/docker/deployer/Dockerfile
@@ -5,7 +5,7 @@
 # the `yq` releases on apt are outdated and technically deprecated.
 FROM mikefarah/yq:4.44.3 AS yq
 
-FROM econialabs/aptos-cli:4.4.0
+FROM econialabs/aptos-cli:6.0.1
 
 COPY --from=yq /usr/bin/yq /usr/bin/yq
 
@@ -14,6 +14,9 @@ ENV PUBLISHER_PRIVATE_KEY=${PUBLISHER_PRIVATE_KEY}
 
 # Ensure the publisher private key is set.
 RUN test -n "${PUBLISHER_PRIVATE_KEY}"
+
+RUN apt-get update && apt-get install --no-install-recommends -y bc=1.07* \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/src/docker/deployer/sh/build-publish-payloads.sh
+++ b/src/docker/deployer/sh/build-publish-payloads.sh
@@ -31,11 +31,11 @@ aptos move build-publish-payload \
 	--skip-fetch-latest-git-deps \
 	--move-2
 
-# aptos move build-publish-payload \
-# 	--assume-yes \
-# 	--named-addresses $arena_addresses \
-# 	emojicoin_arena=$profile,integrator=$profile,emojicoin_dot_fun=$profile"
-# 	--package-dir $move_dir/emojicoin_arena/ \
-# 	--json-output-file $json_dir/emojicoin_arena.json \
-# 	--skip-fetch-latest-git-deps \
-# 	--move-2
+aptos move build-publish-payload \
+	--assume-yes \
+	--named-addresses \
+	emojicoin_arena=$profile,integrator=$profile,emojicoin_dot_fun=$profile \
+	--package-dir $move_dir/emojicoin_arena/ \
+	--json-output-file $json_dir/emojicoin_arena.json \
+	--skip-fetch-latest-git-deps \
+	--move-2

--- a/src/docker/deployer/sh/compare-addresses.sh
+++ b/src/docker/deployer/sh/compare-addresses.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Strip the leading "0x" from the address and remove all leading zeros.
+function standardize_address() {
+	local str="${1#0x}"
+	echo "obase=16; $((16#$str))" | bc
+}
+
+# Compare two addresses by standardizing them first.
+function compare_addresses() {
+	local addr1=$(standardize_address "$1")
+	local addr2=$(standardize_address "$2")
+	[[ $addr1 == $addr2 ]]
+}

--- a/src/docker/deployer/sh/compare-addresses.sh
+++ b/src/docker/deployer/sh/compare-addresses.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# cspell:word obase
 
 # Strip the leading "0x" from the address and remove all leading zeros.
 function standardize_address() {

--- a/src/docker/deployer/sh/entrypoint.sh
+++ b/src/docker/deployer/sh/entrypoint.sh
@@ -79,12 +79,12 @@ fund_and_publish() {
 		--gas-unit-price $gas_unit_price \
 		--profile $profile
 
-	# aptos move run \
-	# 	--assume-yes \
-	# 	--json-file /app/json/emojicoin_arena.json \
-	# 	--max-gas 2000000 \
-	# 	--gas-unit-price $gas_unit_price \
-	# 	--profile $profile
+	aptos move run \
+		--assume-yes \
+		--json-file /app/json/emojicoin_arena.json \
+		--max-gas 2000000 \
+		--gas-unit-price $gas_unit_price \
+		--profile $profile
 }
 
 fund_test_accounts() {

--- a/src/docker/deployer/sh/init-profile.sh
+++ b/src/docker/deployer/sh/init-profile.sh
@@ -9,6 +9,7 @@ fi
 
 source /app/sh/cli-profile.sh
 source /app/sh/colors.sh
+source /app/sh/compare-addresses.sh
 
 current_key=$(get_publisher_private_key)
 if [ "$current_key" == "$PUBLISHER_PRIVATE_KEY" ]; then
@@ -43,8 +44,11 @@ if [ -n "$result" ]; then
 	# Only throw an error if the profile wasn't initialized with the
 	# correct private key, since that's all we care about.
 	current_key=$(get_publisher_private_key)
-	if [ "$current_key" != "$PUBLISHER_PRIVATE_KEY" ]; then
+	if ! compare_addresses "$PUBLISHER_PRIVATE_KEY" "$current_key"; then
 		log_error "Failed to initialize profile \"$profile\""
+		log_error "Publisher private keys don't match."
+		log_error "Env var publisher private key: $PUBLISHER_PRIVATE_KEY"
+		log_error "Expected private key:          $current_key"
 		log_error $(echo $result | jq -r '.Error')
 		exit 1
 	fi

--- a/src/docker/deployer/sh/init-profile.sh
+++ b/src/docker/deployer/sh/init-profile.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# cspell:word obase
 
 set -e
 

--- a/src/docker/deployer/sh/init-profile.sh
+++ b/src/docker/deployer/sh/init-profile.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# cspell:word obase
 
 set -e
 

--- a/src/docker/localnet/Dockerfile
+++ b/src/docker/localnet/Dockerfile
@@ -1,6 +1,6 @@
 # cspell:word localnet
 
-FROM econialabs/aptos-cli:4.4.0
+FROM econialabs/aptos-cli:6.0.1
 
 RUN apt-get update && apt-get install --no-install-recommends -y bc=1.07* \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Description

The CLI version needs to bump now that AMD/ARM successfully built the CLI v6.0.1.

And the arena code needs to deploy for local testing because it uses `--move-2`.
