### PR TITLE
[ECO-2727] Fix flaky websockets e2e test by explicitly not subscribing to `PeriodicStateEvents`

### DIFF
--- a/src/typescript/sdk/tests/e2e/broker/websockets.test.ts
+++ b/src/typescript/sdk/tests/e2e/broker/websockets.test.ts
@@ -392,8 +392,6 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
     const { client, events, messageEvents, brokerMessages } = await connectNewClient();
     const MARKET_INDEX = 5;
 
-    subscribe(client, [], []);
-
     const market_1 = marketsRegistered[MARKET_INDEX];
     const registerResponse = await RegisterMarket.submit({
       ...senderArgs[MARKET_INDEX],
@@ -408,6 +406,12 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
     expect(market_2).toBeDefined();
     expect(registrationStateEventForMarket_2).toBeDefined();
     expect(market_1).not.toEqual(market_2);
+
+    subscribe(
+      client,
+      [market_1.marketID, market_2.marketID],
+      ["MarketLatestState", "Chat", "Swap"]
+    );
 
     const marketMetadata_1 = marketMetadata.find((market) =>
       market.marketAddress.equals(AccountAddress.from(market_1.marketMetadata.marketAddress))

--- a/src/typescript/sdk/tests/e2e/broker/websockets.test.ts
+++ b/src/typescript/sdk/tests/e2e/broker/websockets.test.ts
@@ -492,7 +492,10 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
     await waitForEmojicoinIndexer(highestVersion);
     // Wait for the broker to send all 10 messages:
     // 1 registration, 2 swaps, 2 chats, and 5 state event models.
-    await customWaitFor(() => messageEvents.length === 10);
+    await customWaitFor(() => {
+      console.log(`# message events: ${messageEvents.length}`);
+      return messageEvents.length === 10;
+    });
     expect(messageEvents.length === 10);
     expect(brokerMessages.length === 10);
     expect(events.length === 10);


### PR DESCRIPTION
# Description

The WebSockets e2e test keeps failing. I investigated why and I believe the issue is occurring because a `PeriodicStateEvent` is emitted *sometimes*. This is because the 1-minute period boundary for the initial market registration begins at different points in the minute.

That is, if the market is registered at 5 seconds after a 1m period boundary, the full test can run in 55 seconds and not emit a periodic state event, thus succeeding, because the # of events received by the client from the broker is exactly the amount expected.

However, if the market is registered at 55 seconds after a 1m period boundary, the test may take longer than 5 seconds and thus a periodic state event is emitted alongside the swap/chat event for the market.

To fix this, I simply narrowed the event types filter in the subscription to the broker to not include periodic state events! It should never fail again.

# Testing

The SDK tests should succeed on the first time, no flakiness.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
