### PR TITLE
[ECO-2721] Fix SDK timeout error

### DIFF
--- a/src/typescript/sdk/src/indexer-v2/types/postgres-numeric-types.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/postgres-numeric-types.ts
@@ -96,7 +96,6 @@ export const floatColumns: Set<AnyColumnName> = new Set([
 
   // Arena
   "melee_id",
-  "start_time",
   "duration",
   "max_match_percentage",
   "max_match_amount",


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The SDK tests often fail due to a timeout.

This PR fixes that

# Testing

See SDK tests pass 100% of the time

# Checklist

- [ ] Did you check all checkboxes from the linked Linear task?
