### PR TITLE
[ECO-2738] Bump SDK package version to `0.4.0`; processor submodule to `4.0.1`

### DIFF
--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -118,5 +118,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.3.0"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
# Description

Didn't realize `0.3.0` had already been published, so bump to `0.4.0`, merge and publish it

- [ ] Publish to `npm` registry once this is merged