### PR TITLE
[ECO-2744] Fix swap price calculation right after bonding curve transition

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -90,12 +90,12 @@ export default function SwapComponent({
     (s) => s.getMarket(marketEmojis)?.swapEvents.length ?? initNumSwaps
   );
 
-  const lastSwapEvent = useEventStore((s) => s.getMarket(marketEmojis)?.swapEvents?.at(0));
+  const latestMarketState = useEventStore((s) => s.getMarket(marketEmojis)?.stateEvents?.at(0));
 
   const gasCost = useGetGasWithDefault({ marketAddress, inputAmount, isSell, numSwaps });
 
   const { netProceeds, error } = useCalculateSwapPrice({
-    lastSwapEvent,
+    latestMarketState,
     isSell,
     inputAmount,
     userEmojicoinBalance: emojicoinBalance,

--- a/src/typescript/frontend/src/lib/hooks/use-calculate-swap-price.ts
+++ b/src/typescript/frontend/src/lib/hooks/use-calculate-swap-price.ts
@@ -18,18 +18,18 @@ import { type AnyNumberString } from "@sdk/types/types";
  * zero error, we don't return, since that is due to invalid input amount.
  */
 export const useCalculateSwapPrice = ({
-  lastSwapEvent,
+  latestMarketState,
   isSell,
   inputAmount,
   userEmojicoinBalance,
 }: {
-  lastSwapEvent?: DatabaseModels["swap_events"];
+  latestMarketState?: DatabaseModels["market_latest_state_event"];
   isSell: boolean;
   inputAmount: AnyNumberString;
   userEmojicoinBalance: AnyNumberString;
 }) => {
   const args: SwapNetProceedsArgs = {
-    ...getReservesAndBondingCurveStateWithDefault(lastSwapEvent),
+    ...getReservesAndBondingCurveStateWithDefault(latestMarketState),
     isSell,
     inputAmount,
     userEmojicoinBalance,
@@ -55,13 +55,13 @@ export const useCalculateSwapPrice = ({
 };
 
 const getReservesAndBondingCurveStateWithDefault = (
-  lastSwapEvent?: DatabaseModels["swap_events"]
+  latestMarketState?: DatabaseModels["market_latest_state_event"]
 ) => {
-  if (lastSwapEvent) {
+  if (latestMarketState) {
     return {
-      clammVirtualReserves: lastSwapEvent.state.clammVirtualReserves,
-      cpammRealReserves: lastSwapEvent.state.cpammRealReserves,
-      startsInBondingCurve: lastSwapEvent.swap.startsInBondingCurve,
+      clammVirtualReserves: latestMarketState.state.clammVirtualReserves,
+      cpammRealReserves: latestMarketState.state.cpammRealReserves,
+      startsInBondingCurve: latestMarketState.inBondingCurve,
     };
   }
   return {


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The calculations for the swap price were using the market's last swap state incorrectly.

`startsInBondingCurve` was checking the `lastSwap` event's `startsInBondingCurve` value, which is only accurate if the `lastSwap` did *NOT* cause the market to exit the bonding curve!

In cases where that is true, the price simulation would fail, and often it'd result in "min swap output not met" errors in the txn submission flow.

To fix this, we simply pass the market's latest state and use those values to calculate the exact curve price, rather than the last swap values.

This wasn't caught in SDK tests unfortunately simply because the inputs to the function were given incorrectly- that is, "lastSwapEvent"'s state was being used, instead of the current market state's state.

# Testing

Tested manually several times in my browser to ensure it no longer fails.

Keep in mind this didn't break the application- it merely caused issues with the slippage flow.