### PR TITLE
[ECO-2731] Add CoinGecko README doc and fix small API issues

### DIFF
--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -52,7 +52,7 @@ As an AMM DEX, this is N/A.
 
 ## `/historical_trades`
 
-`/historical_trades` is implemented according to the Coingecko supplied
+`/coingecko/historical_trades` is implemented according to the Coingecko supplied
 specification, with the addition of the `skip` field.
 
 `start_time` and `end_time` are unix timestamps. Using this fields will result

--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -61,7 +61,7 @@ in an inclusive search (gte for `start_time`, lte for `end_time`).
 `type` can be `buy` or `sell`.
 
 `ticker_id` must the the same format as the `ticker_id` field returned by
-`/tickers`.
+`/coingecko/tickers`.
 
 `limit` can be up to 500 (and is 500 by default).
 

--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -46,7 +46,7 @@ Get all tickers from 100 to 200: `/coingecko/tickers?skip=100`.
 ]
 ```
 
-## `/orderbook`
+## `/coingecko/orderbook`
 
 As an AMM DEX, this is N/A.
 

--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -29,7 +29,7 @@ Get all tickers from 100 to 200: `/coingecko/tickers?skip=100`.
 
 ### Example return data
 
-`/tickers?limit=1`
+`/coingecko/tickers?limit=1`
 
 ```json
 [

--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -7,7 +7,7 @@ requirements available
 [here](https://docs.google.com/document/d/1v27QFoQq1SKT3Priq3aqPgB70Xd_PnDzbOCiuoCyixw/edit?usp=sharing),
 with a few necessary changes in order to fit our product.
 
-## `/tickers`
+## `/coingecko/tickers`
 
 `/coingecko/tickers` is implemented as required, but it is paginated. As
 `emojicoin-dot-fun` can have up to 10 000 000 markets, pagination needs to be

--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -50,7 +50,7 @@ Get all tickers from 100 to 200: `/coingecko/tickers?skip=100`.
 
 As an AMM DEX, this is N/A.
 
-## `/historical_trades`
+## `/coingecko/historical_trades`
 
 `/coingecko/historical_trades` is implemented according to the Coingecko supplied
 specification, with the addition of the `skip` field.

--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -1,0 +1,97 @@
+<!-- markdownlint-disable line-length -->
+
+# Coingecko API
+
+The Coingecko API is implemented according to the Coingecko official API
+requirements available
+[here](https://docs.google.com/document/d/1v27QFoQq1SKT3Priq3aqPgB70Xd_PnDzbOCiuoCyixw/edit?usp=sharing),
+with a few necessary changes in order to fit our product.
+
+## `/tickers`
+
+`/tickers` is implemented as required, but it is paginated. As
+`emojicoin-dot-fun` can have up to 10 000 000 markets, pagination needs to be
+present.
+
+Pagination is implemented using `skip` and `limit` fields.
+
+`limit` can be up to 500 (and is 100 by default). `skip` is 0 by default.
+
+Tickers are ordered by time of market creation ascending.
+
+### Example
+
+Get all tickers from 150 to 200: `/tickers?limit=50&skip=150`.
+
+Get all tickers from 0 to 100: `/tickers`.
+
+Get all tickers from 100 to 200: `/tickers?skip=100`.
+
+### Example return data
+
+`/tickers?limit=1`
+
+```json
+[
+  {
+    "ticker_id": "0xSOME_ADDRESS::coin_factory::Emojicoin_0x1::aptos_coin::AptosCoin",
+    "base_currency": "0xSOME_ADDRESS::coin_factory::Emojicoin",
+    "target_currency": "0x1::aptos_coin::AptosCoin",
+    "pool_id": "😀",
+    "last_price": "0.001",
+    "base_volume": "1234.56",
+    "target_volume": "1.23456",
+    "liquidity_in_usd": "123.456"
+  }
+]
+```
+
+## `/orderbook`
+
+As an AMM DEX, this is N/A.
+
+## `/historical_trades`
+
+`/historical_trades` is implemented according to the Coingecko supplied
+specification, with the addition of the `skip` field.
+
+`start_time` and `end_time` are unix timestamps. Using this fields will result
+in an inclusive search (gte for `start_time`, lte for `end_time`).
+
+`type` can be `buy` or `sell`.
+
+`ticker_id` must the the same format as the `ticker_id` field returned by
+`/tickers`.
+
+`limit` can be up to 500 (and is 500 by default).
+
+`skip` is 0 by default.
+
+Trades are ordered by time of trade ascending.
+
+`trade_id` starts at 2, and are always ascending, but may not be consecutive,
+as IDs are shared with chat messages. `trade_id` are ticker specific, so
+multiple trades with the same ID can exist.
+
+### Example
+
+Get the 51st trade for ticker `TICKER` after `TIME` unix timestamp :
+`/historical_trades?ticker_id=TICKER&start_time=TIME&limit=1&skip=50`.
+
+Get the first 100 trades for ticker `TICKER` :
+`/historical_trades?ticker_id=TICKER&limit=100`.
+
+### Example return data
+
+```json
+[
+  {
+    "trade_id": "1",
+    "price": "0.01",
+    "base_volume": "123.456",
+    "target_volume": "1.23456",
+    "trade_timestamp": "1700000000",
+    "type": "buy"
+  }
+]
+```

--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -76,10 +76,10 @@ multiple trades with the same ID can exist.
 ### Example
 
 Get the 51st trade for ticker `TICKER` after `TIME` unix timestamp :
-`/historical_trades?ticker_id=TICKER&start_time=TIME&limit=1&skip=50`.
+`/coingecko/historical_trades?ticker_id=TICKER&start_time=TIME&limit=1&skip=50`.
 
 Get the first 100 trades for ticker `TICKER` :
-`/historical_trades?ticker_id=TICKER&limit=100`.
+`/coingecko/historical_trades?ticker_id=TICKER&limit=100`.
 
 ### Example return data
 

--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -21,11 +21,11 @@ Tickers are ordered by time of market creation ascending.
 
 ### Example
 
-Get all tickers from 150 to 200: `/tickers?limit=50&skip=150`.
+Get all tickers from 150 to 200: `/coingecko/tickers?limit=50&skip=150`.
 
-Get all tickers from 0 to 100: `/tickers`.
+Get all tickers from 0 to 100: `/coingecko/tickers`.
 
-Get all tickers from 100 to 200: `/tickers?skip=100`.
+Get all tickers from 100 to 200: `/coingecko/tickers?skip=100`.
 
 ### Example return data
 

--- a/src/typescript/frontend/COINGECKO.md
+++ b/src/typescript/frontend/COINGECKO.md
@@ -9,7 +9,7 @@ with a few necessary changes in order to fit our product.
 
 ## `/tickers`
 
-`/tickers` is implemented as required, but it is paginated. As
+`/coingecko/tickers` is implemented as required, but it is paginated. As
 `emojicoin-dot-fun` can have up to 10 000 000 markets, pagination needs to be
 present.
 

--- a/src/typescript/frontend/src/app/coingecko/tickers/route.ts
+++ b/src/typescript/frontend/src/app/coingecko/tickers/route.ts
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
       "market_address, symbol_emojis, lp_coin_supply, last_swap_avg_execution_price_q64, daily_volume, daily_base_volume, clamm_virtual_reserves_base, clamm_virtual_reserves_quote, cpamm_real_reserves_base, cpamm_real_reserves_quote"
     )
     .order("market_id")
-    .range(skip, skip + limit);
+    .range(skip, skip + limit - 1);
 
   const APTOS_COIN = APTOS_COIN_TYPE_TAG.toString();
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds a `COINGECKO.md` file to help CoinGecko integrate our API into their system.

It also fixes an off-by-one error in the `limit` and `skip` calculations of the tickers endoint.

It also adds the `skip` field to the historical trades field to allow querying all the trades.

# Testing

Try `/coingecko/tickers` and `/coingecko/historical_trades` with the info in `COINGECKO.md`.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
