### PR TITLE
[ECO-2751] Don't let a user register if they have insufficient balance, make error message clearer; bump processor submodule

### DIFF
--- a/src/typescript/frontend/public/locales/en-US.json
+++ b/src/typescript/frontend/public/locales/en-US.json
@@ -61,5 +61,6 @@
   "Cost to deploy": "Cost to deploy",
   "Your balance": "Your balance",
   "Your transaction may fail due to gas costs.": "Your transaction may fail due to gas costs.",
-  "Balance": "Balance"
+  "Balance": "Balance",
+  "Insufficient balance": "Insufficient balance"
 }

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/components/launch-or-goto.tsx
@@ -5,15 +5,18 @@ import { translationFunction } from "context/language-context";
 import Link from "next/link";
 import path from "path";
 import { ROUTES } from "router/routes";
+import { useMemo } from "react";
 
 export const LaunchButtonOrGoToMarketLink = ({
   onWalletButtonClick,
   registered,
   invalid,
+  insufficientBalance,
 }: {
   onWalletButtonClick: () => void;
   registered?: boolean;
   invalid: boolean;
+  insufficientBalance: boolean;
 }) => {
   const emojis = useEmojiPicker((state) => state.emojis);
   const { t } = translationFunction();
@@ -22,6 +25,11 @@ export const LaunchButtonOrGoToMarketLink = ({
     overdrive: true,
     overflow: true,
   };
+
+  const disableRegister = useMemo(
+    () => invalid || insufficientBalance || typeof registered === "undefined",
+    [invalid, insufficientBalance, registered]
+  );
 
   return (
     <>
@@ -39,13 +47,19 @@ export const LaunchButtonOrGoToMarketLink = ({
           </Link>
         ) : (
           <Button
-            disabled={invalid || typeof registered === "undefined"}
+            disabled={disableRegister}
             onClick={onWalletButtonClick}
             scale="lg"
-            style={{ cursor: invalid ? "not-allowed" : "pointer" }}
+            style={{ cursor: disableRegister ? "not-allowed" : "pointer" }}
             scrambleProps={scrambleProps}
           >
-            {t(invalid ? "Invalid input" : "Launch Emojicoin")}
+            {t(
+              insufficientBalance
+                ? "Insufficient balance"
+                : invalid
+                  ? "Invalid input"
+                  : "Launch Emojicoin"
+            )}
           </Button>
         )}
       </ButtonWithConnectWalletFallback>

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
@@ -186,6 +186,7 @@ export const MemoizedLaunchAnimation = ({ loading }: { loading: boolean }) => {
           >
             <LaunchButtonOrGoToMarketLink
               invalid={invalid}
+              insufficientBalance={!sufficientBalance}
               registered={registered}
               onWalletButtonClick={() => {
                 registerMarket();


### PR DESCRIPTION
# Description

For some reason, I removed this check a while back. I'm adding it back in because it's confusing UX wise and it's an easy fix.

- [x] Don't let a user register a market if they have an insufficient balance
- [x] Indicate that it's an insufficient balance, not an `invalid` input by adding a new button error message

# Testing

Just tested on my local network with and without an insufficient balance and made sure any updates properly work.
