### PR TITLE
[ECO-2757] Fix arena deployment for the `deployer` localnet service; bump processor submodule

### DIFF
--- a/src/docker/deployer/Dockerfile
+++ b/src/docker/deployer/Dockerfile
@@ -5,7 +5,7 @@
 # the `yq` releases on apt are outdated and technically deprecated.
 FROM mikefarah/yq:4.44.3 AS yq
 
-FROM econialabs/aptos-cli:6.0.1
+FROM econialabs/aptos-cli:6.0.2
 
 COPY --from=yq /usr/bin/yq /usr/bin/yq
 

--- a/src/docker/deployer/sh/build-publish-payloads.sh
+++ b/src/docker/deployer/sh/build-publish-payloads.sh
@@ -32,6 +32,15 @@ aptos move build-publish-payload \
 	--move-2
 
 aptos move build-publish-payload \
+    --assume-yes \
+	--named-addresses \
+	emojicoin_dot_fun=$profile,market_metadata=$profile \
+	--package-dir $move_dir/market_metadata/ \
+	--json-output-file $json_dir/market_metadata.json \
+	--skip-fetch-latest-git-deps \
+	--move-2
+
+aptos move build-publish-payload \
 	--assume-yes \
 	--named-addresses \
 	emojicoin_arena=$profile,integrator=$profile,emojicoin_dot_fun=$profile \

--- a/src/docker/deployer/sh/entrypoint.sh
+++ b/src/docker/deployer/sh/entrypoint.sh
@@ -79,6 +79,31 @@ fund_and_publish() {
 		--gas-unit-price $gas_unit_price \
 		--profile $profile
 
+    water_bytes="f09f92a7" # For 💧.
+	fire_bytes="f09f94a5" # For 🔥.
+    # Alternatively, you could pass "raw:0104f09f92a7" to properly serialize
+	# a vector<vector<u8>> like [[ 0xf09f92a7 ]]
+	water_vec_vec_u8_arg="hex:[\"$water_bytes\"]" 
+	fire_vec_vec_u8_arg="hex:[\"$fire_bytes\"]" 
+	
+	# Register two markets so it's possible to publish the arena module.
+	# Otherwise `init_module` loops infinitely and times out.
+	aptos move run \
+	  --assume-yes \
+	  --function-id "$profile::emojicoin_dot_fun::register_market" \
+	  --args $water_vec_vec_u8_arg address:$profile \
+	  --max-gas 2000000 \
+	  --gas-unit-price $gas_unit_price \
+	  --profile $profile
+	
+	aptos move run \
+	  --assume-yes \
+	  --function-id "$profile::emojicoin_dot_fun::register_market" \
+	  --args $fire_vec_vec_u8_arg address:$profile \
+	  --max-gas 2000000 \
+	  --gas-unit-price $gas_unit_price \
+	  --profile $profile
+
 	aptos move run \
 		--assume-yes \
 		--json-file /app/json/emojicoin_arena.json \

--- a/src/docker/localnet/Dockerfile
+++ b/src/docker/localnet/Dockerfile
@@ -1,6 +1,6 @@
 # cspell:word localnet
 
-FROM econialabs/aptos-cli:6.0.1
+FROM econialabs/aptos-cli:6.0.2
 
 RUN apt-get update && apt-get install --no-install-recommends -y bc=1.07* \
     && rm -rf /var/lib/apt/lists/*

--- a/src/typescript/sdk/src/client/emojicoin-client.ts
+++ b/src/typescript/sdk/src/client/emojicoin-client.ts
@@ -100,7 +100,6 @@ const waitForEventProcessed = async (
  */
 export class EmojicoinClient {
   public aptos: Aptos;
-  public alwaysWaitForIndexer: boolean;
 
   public register = this.registerInternal.bind(this);
   public chat = this.chatInternal.bind(this);
@@ -145,6 +144,8 @@ export class EmojicoinClient {
     registry: this.registryView.bind(this),
     market: this.marketView.bind(this),
   };
+
+  private alwaysWaitForIndexer: boolean;
 
   private integrator: AccountAddress;
 

--- a/src/typescript/sdk/tests/e2e/ensure-arena-markets-registered.test.ts
+++ b/src/typescript/sdk/tests/e2e/ensure-arena-markets-registered.test.ts
@@ -1,0 +1,19 @@
+import { ARENA_MODULE_ADDRESS, EmojicoinArena, getAptosClient } from "../../src";
+import { EmojicoinClient } from "../../src/client/emojicoin-client";
+
+describe("ensures the two arena markets and the arena module are on-chain", () => {
+  const emojicoin = new EmojicoinClient();
+  const aptos = getAptosClient();
+  it("verifies that the arena module is already published on-chain", async () => {
+    const res = await aptos.getAccountModule({
+      accountAddress: ARENA_MODULE_ADDRESS,
+      moduleName: EmojicoinArena.Enter.prototype.moduleName,
+    });
+    expect(res.bytecode).toBeTruthy();
+  });
+
+  it("verifies that both arena markets in the `deployer` service are registered on-chain", async () => {
+    await emojicoin.view.marketExists(["💧"]).then((exists) => expect(exists).toBe(true));
+    await emojicoin.view.marketExists(["🔥"]).then((exists) => expect(exists).toBe(true));
+  });
+});

--- a/src/typescript/sdk/tests/pre-test.ts
+++ b/src/typescript/sdk/tests/pre-test.ts
@@ -5,6 +5,10 @@ import { DockerTestHarness } from "./utils/docker/docker-test-harness";
 // process.env.NO_TEST_SETUP => to skip the docker container test setup, like for unit tests.
 // process.env.FILTER_TEST_LOGS => quiet mode, don't output logs that print to the console a lot.
 
+// Please note that prior to the tests, the `deployer` Docker service registers two markets, ["💧"],
+// and ["🔥"], to ensure that it's possible to publish the emojicoin arena module.
+// Without these two, the `init_module` function will loop infinitely and time out.
+// You can find the relevant publication code in `deployer/sh`.
 export default async function preTest() {
   // @ts-expect-error Using `globalThis` as any for a polyfill for `WebSocket` in node.js.
   globalThis.WebSocket = WebSocket;


### PR DESCRIPTION
# Description

Localnet needs to have two markets registered prior to publishing the arena module or it will loop infinitely in `init_module`

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
