### PR TITLE
[ECO-2747] Refactor header items for new cult page

### DIFF
--- a/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
@@ -8,7 +8,7 @@ import { FlexGap } from "@containers";
 
 import { type MenuItemProps } from "./types";
 
-const MenuItem: React.FC<MenuItemProps> = ({ title, width, onClick = () => {} }) => {
+const MenuItem: React.FC<MenuItemProps> = ({ title, onClick = () => {} }) => {
   const { t } = translationFunction();
 
   const { ref, replay } = useScramble({
@@ -25,8 +25,8 @@ const MenuItem: React.FC<MenuItemProps> = ({ title, width, onClick = () => {} })
       <Text
         textScale="pixelHeading4"
         color="econiaBlue"
-        width={width}
-        maxWidth={width}
+        width={"auto"}
+        maxWidth={"auto"}
         textTransform="uppercase"
         fontSize="24px"
         ref={ref}

--- a/src/typescript/frontend/src/components/header/components/menu-item/types.ts
+++ b/src/typescript/frontend/src/components/header/components/menu-item/types.ts
@@ -2,6 +2,5 @@ import { type TranslationKey } from "context/language-context/types";
 
 export type MenuItemProps = {
   title: TranslationKey;
-  width: string;
   onClick?: () => void;
 };

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -95,7 +95,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
         <MobileMenuInner>
           {!geoblocked && (
             <ButtonWithConnectWalletFallback
-              className={"w-full !px-0"}
+              className={"w-full pl-0"}
               mobile={true}
               onClick={subMenuOnClick}
               arrow

--- a/src/typescript/frontend/src/components/header/constants.ts
+++ b/src/typescript/frontend/src/components/header/constants.ts
@@ -1,8 +1,8 @@
 import { ROUTES } from "router/routes";
 
 export const NAVIGATE_LINKS = [
-  { title: "home", path: ROUTES.home, width: "45px" },
-  { title: "pools", path: ROUTES.pools, width: "52px" },
-  { title: "launch emojicoin", path: ROUTES.launch, width: "158px" },
-  { title: "docs", path: ROUTES.docs, width: "42px" },
+  { title: "pools", path: ROUTES.pools },
+  { title: "launch", path: ROUTES.launch },
+  { title: "cult", path: ROUTES.cult },
+  { title: "docs", path: ROUTES.docs },
 ];

--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -24,7 +24,6 @@ const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
   const { isDesktop } = useMatchBreakpoints();
   const { t } = translationFunction();
   const searchParams = useSearchParams();
-  const linksForCurrentPage = NAVIGATE_LINKS;
   const clear = useEmojiPicker((s) => s.clear);
 
   const [offsetHeight, setOffsetHeight] = useState(0);
@@ -84,14 +83,14 @@ const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
 
           {isDesktop && (
             <FlexGap marginRight="50px" gap="24px" alignItems="center">
-              {linksForCurrentPage.map(({ title, path, width }) => {
+              {NAVIGATE_LINKS.map(({ title, path }) => {
                 return (
                   <Link
                     key={title}
                     href={path}
                     target={path.startsWith("https://") ? "_blank" : undefined}
                   >
-                    <MenuItem width={width} title={title} />
+                    <MenuItem title={title} />
                   </Link>
                 );
               })}
@@ -108,7 +107,7 @@ const Header = ({ isOpen, setIsOpen }: HeaderProps) => {
           )}
         </Flex>
       </Container>
-      <MobileMenu isOpen={isOpen} setIsOpen={setIsOpen} linksForCurrentPage={linksForCurrentPage} />
+      <MobileMenu isOpen={isOpen} setIsOpen={setIsOpen} linksForCurrentPage={NAVIGATE_LINKS} />
     </StyledContainer>
   );
 };

--- a/src/typescript/frontend/src/middleware.ts
+++ b/src/typescript/frontend/src/middleware.ts
@@ -12,11 +12,11 @@ import { normalizePossibleMarketPath } from "utils/pathname-helpers";
 
 export default async function middleware(request: NextRequest) {
   const pathname = new URL(request.url).pathname;
-  if (pathname === ROUTES.launching) {
+  if (pathname === ROUTES.launching_soon) {
     return NextResponse.next();
   }
-  if (PRE_LAUNCH_TEASER && pathname !== ROUTES.launching) {
-    return NextResponse.redirect(new URL(ROUTES.launching, request.url));
+  if (PRE_LAUNCH_TEASER && pathname !== ROUTES.launching_soon) {
+    return NextResponse.redirect(new URL(ROUTES.launching_soon, request.url));
   }
   if (MAINTENANCE_MODE && pathname !== ROUTES.maintenance) {
     return NextResponse.redirect(new URL(ROUTES.maintenance, request.url));

--- a/src/typescript/frontend/src/router/routes.ts
+++ b/src/typescript/frontend/src/router/routes.ts
@@ -1,15 +1,17 @@
 // cspell:word dexscreener
 export const ROUTES = {
   root: "/",
+  // Alphabetized after this.
   api: "/api",
+  cult: "/cult",
+  dexscreener: "/dexscreener",
+  docs: "https://docs.emojicoin.fun/category/--start-here",
   home: "/home",
-  market: "/market",
   launch: "/launch",
+  launching_soon: "/launching",
+  maintenance: "/maintenance",
+  market: "/market",
+  notFound: "/not-found",
   pools: "/pools",
   verify: "/verify",
-  docs: "https://docs.emojicoin.fun/category/--start-here",
-  notFound: "/not-found",
-  maintenance: "/maintenance",
-  launching: "/launching",
-  dexscreener: "/dexscreener",
 } as const;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

- [X] Take out `home` header
- [X] Change `Launch emojicoin` to `launch`
- [X] Add `cult` header
- [X] Have responsive switch over to menu sooner on resize (per Kirsten feedback 2025-02-03)
  - Note that this wasn't necessary, since everything fits at the smallest width where the header items are displayed now. See below.
- [x] Fix left padding for Connect Wallet in mobile menu

# Preview

![image](https://github.com/user-attachments/assets/feec3526-4b8f-4436-a46a-304de15fe22d)
![image](https://github.com/user-attachments/assets/d0366c06-df74-4ba7-80ce-3f9c1f59270a)

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
