### PR TITLE
[ECO-2771] Exclusively enable the `/cult` page in `development` and `preview` Vercel environments

### DIFF
--- a/src/typescript/frontend/src/app/cult/page.tsx
+++ b/src/typescript/frontend/src/app/cult/page.tsx
@@ -1,5 +1,7 @@
 import { type Metadata } from "next";
 import CultClientPage from "components/pages/cult/CultClientPage";
+import { VERCEL_TARGET_ENV } from "@sdk/const";
+import LaunchingPage from "app/launching/page";
 
 export const dynamic = "force-static";
 
@@ -8,6 +10,7 @@ export const metadata: Metadata = {
   description: `Explore the emojicoin cult`,
 };
 
-export default function LaunchEmojicoinPage() {
-  return <CultClientPage />;
+export default function CultPage() {
+  // Temporarily disable in production and show the Coming Soon page instead.
+  VERCEL_TARGET_ENV === "production" ? <LaunchingPage /> : <CultClientPage />;
 }

--- a/src/typescript/frontend/src/app/cult/page.tsx
+++ b/src/typescript/frontend/src/app/cult/page.tsx
@@ -1,6 +1,5 @@
 import { type Metadata } from "next";
 import CultClientPage from "components/pages/cult/CultClientPage";
-import { VERCEL_TARGET_ENV } from "@sdk/const";
 import LaunchingPage from "app/launching/page";
 
 export const dynamic = "force-static";
@@ -11,6 +10,6 @@ export const metadata: Metadata = {
 };
 
 export default function CultPage() {
-  // Temporarily disable in production and show the Coming Soon page instead.
-  VERCEL_TARGET_ENV === "production" ? <LaunchingPage /> : <CultClientPage />;
+  // Add the ability to temporarily disable the page with a Coming Soon page.
+  process.env.ENABLE_CULT_PAGE ? <LaunchingPage /> : <CultClientPage />;
 }

--- a/src/typescript/frontend/src/app/cult/page.tsx
+++ b/src/typescript/frontend/src/app/cult/page.tsx
@@ -1,6 +1,7 @@
 import { type Metadata } from "next";
 import CultClientPage from "components/pages/cult/CultClientPage";
 import LaunchingPage from "app/launching/page";
+import { VERCEL_TARGET_ENV } from "@sdk/const";
 
 export const dynamic = "force-static";
 
@@ -10,6 +11,10 @@ export const metadata: Metadata = {
 };
 
 export default function CultPage() {
-  // Add the ability to temporarily disable the page with a Coming Soon page.
-  process.env.ENABLE_CULT_PAGE === "true" ? <CultClientPage/> : <LaunchingPage />;
+  // Temporarily disable the page in non-development/non-preview modes and show the Launching Soon page instead.
+  return VERCEL_TARGET_ENV === "development" || VERCEL_TARGET_ENV === "preview" ? (
+    <CultClientPage />
+  ) : (
+    <LaunchingPage />
+  );
 }

--- a/src/typescript/frontend/src/app/cult/page.tsx
+++ b/src/typescript/frontend/src/app/cult/page.tsx
@@ -11,5 +11,5 @@ export const metadata: Metadata = {
 
 export default function CultPage() {
   // Add the ability to temporarily disable the page with a Coming Soon page.
-  process.env.ENABLE_CULT_PAGE ? <LaunchingPage /> : <CultClientPage />;
+  process.env.ENABLE_CULT_PAGE === "true" ? <CultClientPage/> : <LaunchingPage />;
 }


### PR DESCRIPTION
# Description

Exclusively enable the `/cult` page in development and preview Vercel environments

# Testing

Try visiting it
# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
