### PR TITLE
[ECO-2783] Refactor indexer for new release schedule

### DIFF
--- a/src/cloud-formation/README.md
+++ b/src/cloud-formation/README.md
@@ -237,6 +237,23 @@ indexer deployments.
    > character count limits, for example the
    > [load balancer target group name 32 character limit].
 
+## Performing a cold upgrade
+
+If you need to deploy an indexer after there have been breaking changes to the
+database you'll need to perform a "cold upgrade": first you'll need to
+de-provision the entire stack, then re-provision it and let it backfill. You can
+use `cold-upgrade.sh` to modify the [stack deployment file] `parameters`:
+
+```sh
+sh cold-upgrade.sh kill
+```
+
+then
+
+```sh
+sh cold-upgrade.sh revive
+```
+
 ## Querying endpoints
 
 ### Public endpoints

--- a/src/cloud-formation/cold-upgrade.sh
+++ b/src/cloud-formation/cold-upgrade.sh
@@ -4,8 +4,8 @@ if ! command -v yq > /dev/null 2>&1; then
 fi
 
 FILES="
+    deploy-indexer-alpha.yaml
     deploy-indexer-fallback.yaml
-    deploy-indexer-main.yaml
     deploy-indexer-production.yaml
 "
 

--- a/src/cloud-formation/cold-upgrade.sh
+++ b/src/cloud-formation/cold-upgrade.sh
@@ -1,6 +1,8 @@
-if ! command -v yq > /dev/null 2>&1; then
-    echo "Error: yq is not installed"
-    exit 1
+#!/bin/sh
+# cspell:word strenv
+if ! command -v yq >/dev/null 2>&1; then
+	echo "Error: yq is not installed"
+	exit 1
 fi
 
 FILES="
@@ -23,17 +25,17 @@ EXPRESSION='.parameters.DeployAlb = strenv(value) |
   .parameters.DeployRestApiDnsRecord = strenv(value)'
 
 case $1 in
-    "kill") value="false" ;;
-    "revive") value="true" ;;
-    *)
-        echo "Usage: $0 [kill|revive]"
-        exit 1
-        ;;
+"kill") value="false" ;;
+"revive") value="true" ;;
+*)
+	echo "Usage: $0 [kill|revive]"
+	exit 1
+	;;
 esac
 
 for file in $FILES; do
-    export value
-    yq eval -i "$EXPRESSION" "$file"
-    echo "..." >> "$file"
+	export value
+	yq eval -i "$EXPRESSION" "$file"
+	echo "..." >>"$file"
 done
 echo "Applicable deploy file parameters set to $value"

--- a/src/cloud-formation/cold-upgrade.sh
+++ b/src/cloud-formation/cold-upgrade.sh
@@ -1,0 +1,39 @@
+if ! command -v yq > /dev/null 2>&1; then
+    echo "Error: yq is not installed"
+    exit 1
+fi
+
+FILES="
+    deploy-indexer-fallback.yaml
+    deploy-indexer-main.yaml
+    deploy-indexer-production.yaml
+"
+
+EXPRESSION='.parameters.DeployAlb = strenv(value) |
+  .parameters.DeployAlbDnsRecord = strenv(value) |
+  .parameters.DeployBastionHost = strenv(value) |
+  .parameters.DeployBroker = strenv(value) |
+  .parameters.DeployContainers = strenv(value) |
+  .parameters.DeployDb = strenv(value) |
+  .parameters.DeployNlb = strenv(value) |
+  .parameters.DeployNlbVpcLink = strenv(value) |
+  .parameters.DeployPostgrest = strenv(value) |
+  .parameters.DeployProcessor = strenv(value) |
+  .parameters.DeployRestApi = strenv(value) |
+  .parameters.DeployRestApiDnsRecord = strenv(value)'
+
+case $1 in
+    "kill") value="false" ;;
+    "revive") value="true" ;;
+    *)
+        echo "Usage: $0 [kill|revive]"
+        exit 1
+        ;;
+esac
+
+for file in $FILES; do
+    export value
+    yq eval -i "$EXPRESSION" "$file"
+    echo "..." >> "$file"
+done
+echo "Applicable deploy file parameters set to $value"

--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -17,7 +17,7 @@ parameters:
   EnableWafRulesGeneral: 'false'
   EnableWafRulesRestApi: 'false'
   EnableWafRulesWebSocket: 'false'
-  Environment: 'main'
+  Environment: 'alpha'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
   ProcessorImageVersion: '5.0.0'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -16,7 +16,6 @@ parameters:
   DeployProcessor: 'true'
   DeployRestApi: 'true'
   DeployRestApiDnsRecord: 'true'
-  DeployStack: 'true'
   DeployWaf: 'false'
   EnableWafRulesGeneral: 'false'
   EnableWafRulesRestApi: 'false'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '5.0.0'
+  BrokerImageVersion: '4.0.2'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '5.0.0'
+  ProcessorImageVersion: '4.0.2'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-main.yaml
+++ b/src/cloud-formation/deploy-indexer-main.yaml
@@ -13,7 +13,6 @@ parameters:
   DeployProcessor: 'true'
   DeployRestApi: 'true'
   DeployRestApiDnsRecord: 'true'
-  DeployStack: 'true'
   DeployWaf: 'false'
   EnableWafRulesGeneral: 'false'
   EnableWafRulesRestApi: 'false'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '5.0.0'
+  BrokerImageVersion: '4.0.2'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '5.0.0'
+  ProcessorImageVersion: '4.0.2'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -16,7 +16,6 @@ parameters:
   DeployProcessor: 'true'
   DeployRestApi: 'true'
   DeployRestApiDnsRecord: 'true'
-  DeployStack: 'true'
   DeployWaf: 'false'
   EnableWafRulesGeneral: 'false'
   EnableWafRulesRestApi: 'false'

--- a/src/cloud-formation/indexer.cfn.yaml
+++ b/src/cloud-formation/indexer.cfn.yaml
@@ -181,11 +181,6 @@ Parameters:
     - 'false'
     - 'true'
     Type: 'String'
-  DeployStack:
-    AllowedValues:
-    - 'false'
-    - 'true'
-    Type: 'String'
   DeployWaf:
     AllowedValues:
     - 'false'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Delete `DeployStack` parameter since it is unused.
1. Add `cold-upgrade.sh` script with README.
1. Downgrade `production` and `fallback` binaries to current versions from
   `production` branch, `4.0.2`.
1. Change `main` environment to `alpha` to more clearly conform to standard
   release schedule nomenclature, especially since a new `emojicoin-arena`
   feature branch will be used for `alpha` indexer builds.

# Testing

1. Pending `alpha` release testing.

# Checklist

- [x] Did you update relevant documentation?
