### PR TITLE
[ECO-2784] Add arena events to the broker, update subscription model and README to support `arena`

### DIFF
--- a/src/rust/broker/README.md
+++ b/src/rust/broker/README.md
@@ -37,12 +37,29 @@ Note that they're typed *exactly* as shown below. If you try to send the JSON
 payload over multiple lines through `websocat`, it will error out and parse
 the JSON payload incorrectly.
 
-### All markets, all event types
+### Arena events
+
+Arena events don't follow the same rules as the other subscriptions.
+
+To subscribe to arena events, simply pass `{ "arena": true }`. The default value
+is `false`; i.e., no subscription to arena events.
+
+```json5
+// Subscribe to every single event type.
+{ "arena": true, "markets": [], "event_types": [] }
+
+// Subscribe to all non-arena event types.
+// Both of the JSON objects below are equivalent.
+{ "markets": [], "event_types": [] }
+{ "arena": false, "markets": [], "event_types": [] }
+```
+
+### All markets, all non-arena event types
 
 ```json5
 // All of the below are equivalent.
 // Remember, with `websocat`, your message should be exactly one line.
-// This is four different ways to subscribe to all markets and event types.
+// This is four different ways to subscribe to all markets and non-arena events.
 {}
 { "markets": [] }
 { "event_types": [] }
@@ -51,7 +68,7 @@ the JSON payload incorrectly.
 
 ### Specific markets, all event types
 
-To subscribe to markets 4 and 5 for all event types:
+To subscribe to markets 4 and 5 for all non-arena event types:
 
 ```json
 { "markets": [4, 5] }

--- a/src/rust/broker/src/types.rs
+++ b/src/rust/broker/src/types.rs
@@ -19,4 +19,6 @@ pub struct Subscription {
     pub markets: Vec<u64>,
     #[serde(default)]
     pub event_types: Vec<EmojicoinDbEventType>,
+    #[serde(default)]
+    pub arena: bool,
 }


### PR DESCRIPTION
# Description

- [ ] Tag `arena` with the broker version `5.0.1` once this is merge to get it pushed to Dockerhub with a valid branch/commit reference
- [x] Update subscription model to allow support for subscribing to all arena events
- [x] Update the `README` to reflect the new subscription model
- [x] Emit broker event logs in JSON, not in Rust debug format, because it's much easier to read and prettify the JSON logs.

Although keep in mind this is already tested and in use for SDK tests in the coming PRs.

# Testing

Already tested in a different PR- merging to `arena` out of order for clarity's sake.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
  - Note that tests will come in a PR after this, although they've already been written and used.
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
