### PR TITLE
[ECO-2789] Update the broker image version for the `alpha` stack to use `5.0.1`: arena event emission support

### DIFF
--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  BrokerImageVersion: '5.0.0'
+  BrokerImageVersion: '5.0.1'
   DeployAlb: 'true'
   DeployAlbDnsRecord: 'true'
   DeployBastionHost: 'true'


### PR DESCRIPTION
# Description

Merely bumping the built image here so that the `alpha` stack will use the new broker version with arena event support.

See #565 

# Testing

See #567 

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
