### PR TITLE
[ECO-2800] Fix the fallback number of markets query

### DIFF
--- a/src/typescript/frontend/src/app/home/page.tsx
+++ b/src/typescript/frontend/src/app/home/page.tsx
@@ -1,11 +1,6 @@
 import { type HomePageParams, toHomePageParamsWithDefault } from "lib/routes/home-page-params";
 import HomePageComponent from "./HomePage";
-import {
-  fetchMarkets,
-  fetchMarketsWithCount,
-  fetchNumRegisteredMarkets,
-  fetchPriceFeedWithMarketState,
-} from "@/queries/home";
+import { fetchMarkets, fetchMarketsWithCount, fetchPriceFeedWithMarketState } from "@/queries/home";
 import { symbolBytesToEmojis } from "@sdk/emoji_data";
 import { MARKETS_PER_PAGE } from "lib/queries/sorting/const";
 import { unstable_cache } from "next/cache";
@@ -16,14 +11,9 @@ import { SortMarketsBy } from "@sdk/indexer-v2/types/common";
 import { getAptPrice } from "lib/queries/get-apt-price";
 import { AptPriceContextProvider } from "context/AptPrice";
 import { ORDER_BY } from "@sdk/indexer-v2/const";
+import { getCachedNumMarketsFromAptosNode } from "lib/queries/num-market";
 
 export const revalidate = 2;
-
-const getCachedNumMarketsFromAptosNode = unstable_cache(
-  fetchNumRegisteredMarkets,
-  ["num-registered-markets"],
-  { revalidate: 10 }
-);
 
 const NUM_MARKETS_ON_PRICE_FEED = 25;
 

--- a/src/typescript/frontend/src/lib/queries/num-market.ts
+++ b/src/typescript/frontend/src/lib/queries/num-market.ts
@@ -1,0 +1,8 @@
+import { fetchNumRegisteredMarkets } from "@/queries/home";
+import { unstable_cache } from "next/cache";
+
+export const getCachedNumMarketsFromAptosNode = unstable_cache(
+  fetchNumRegisteredMarkets,
+  ["num-registered-markets"],
+  { revalidate: 10 }
+);

--- a/src/typescript/sdk/src/indexer-v2/queries/app/home.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/app/home.ts
@@ -102,8 +102,8 @@ export const fetchNumRegisteredMarkets = async () => {
   } catch (e: unknown) {
     // If the view function fails for some reason, find the largest market id in the database for a
     // cheap fetch of the number of registered markets. Also because `count: exact` does not work.
-    await postgrest
-      .from(TableName.MarketRegistrationEvents)
+    return await postgrest
+      .from(TableName.MarketLatestStateEvent)
       .select("market_id")
       .order("market_id", toOrderBy("desc"))
       .limit(1)

--- a/src/typescript/sdk/src/indexer-v2/queries/app/home.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/app/home.ts
@@ -82,7 +82,7 @@ export const fetchMarketsWithCount = queryHelperWithCount(
  * This is necessary to use because for some reason, { count: "exact", head: "true" } in the
  * postgrest-js API doesn't work when there are no rows returned and it's only counting the total
  * number of rows.
- * 
+ *
  * This is used instead of the market registration events table because `market_latest_state_event`
  * has an index on `market_id`.
  *

--- a/src/typescript/sdk/src/indexer-v2/queries/app/home.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/app/home.ts
@@ -76,6 +76,29 @@ export const fetchMarketsWithCount = queryHelperWithCount(
 );
 
 /**
+ * A manual query to get the largest market ID and thus the total number of markets registered
+ * on-chain, according to the indexer thus far.
+ *
+ * This is necessary to use because for some reason, { count: "exact", head: "true" } in the
+ * postgrest-js API doesn't work when there are no rows returned and it's only counting the total
+ * number of rows.
+ * 
+ * This is used instead of the market registration events table because `market_latest_state_event`
+ * has an index on `market_id`.
+ *
+ * @returns the largest market ID, aka the total number of markets registered
+ */
+export const fetchLargestMarketID = async () => {
+  return await postgrest
+    .from(TableName.MarketLatestStateEvent)
+    .select("market_id")
+    .order("market_id", toOrderBy("desc"))
+    .limit(1)
+    .single()
+    .then((r) => Number(r.data?.market_id) ?? 0);
+};
+
+/**
  * Retrieves the number of markets by querying the view function in the registry contract on-chain.
  * The ledger (transaction) version is specified in order to reflect the exact total number of
  * unique markets the `emojicoin-dot-fun` processor will have processed up to that version.
@@ -102,13 +125,7 @@ export const fetchNumRegisteredMarkets = async () => {
   } catch (e: unknown) {
     // If the view function fails for some reason, find the largest market id in the database for a
     // cheap fetch of the number of registered markets. Also because `count: exact` does not work.
-    return await postgrest
-      .from(TableName.MarketLatestStateEvent)
-      .select("market_id")
-      .order("market_id", toOrderBy("desc"))
-      .limit(1)
-      .single()
-      .then((r) => Number(r.data?.market_id) ?? 0);
+    return await fetchLargestMarketID();
   }
 };
 

--- a/src/typescript/sdk/tests/e2e/queries/num-markets.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/num-markets.test.ts
@@ -67,21 +67,21 @@ describe("fetches the number of registered markets based on the latest processed
 
   it("gets the number of registered markets by selecting the largest market ID", async () => {
     const largestMarketID = await fetchLargestMarketID();
-    // Now manually select the market registration event, in case the market has had activity since
-    // being registered.
-    const marketRegistrationModel = await postgrest
+    // Now manually select the market registration event's transaction version, to be specified
+    // explicitly in a `registry_view` call below to check the number of markets at that version.
+    const ledgerVersion = await postgrest
       .from(TableName.MarketRegistrationEvents)
       .select("*")
       .eq("market_id", largestMarketID)
       .single()
       .then((res) => res.data)
-      .then(toMarketRegistrationEventModel);
+      .then(toMarketRegistrationEventModel)
+      .then((res) => res.transaction.version);
 
-    const { version } = marketRegistrationModel.transaction;
     const numMarketsAtVersion = await RegistryView.view({
       aptos,
       options: {
-        ledgerVersion: version,
+        ledgerVersion,
       },
     })
       .then(toRegistryView)


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

For some reason, `count: "exact", head: "true"` with no actual rows returned does not work.

- [x] Fix it by getting the largest market ID instead, since this is actually the most reliable way to get the total number of markets registered thus far and there are indices on the fields used.

Note this query was generally not used, so it's been fine for now. I'm fixing it in case it's ever actually used in the fallback scenario.

# Testing

Added a test for equality of the two (largest market ID and # markets registered) in the SDK tests.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

<!--
    If a checklist item does not apply to your PR,
    please delete the corresponding line.
-->
