### PR TITLE
feat(ECO-2813): Add a `/test-utils` page for local/testnet utilities

### DIFF
--- a/src/typescript/frontend/src/app/test-utils/page.tsx
+++ b/src/typescript/frontend/src/app/test-utils/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { MarketAddressConversionForm } from "@/components/pages/test-utils/market-address-conversion";
+import { SetMeleeDurationForm } from "@/components/pages/test-utils/SetNewMeleeDuration";
+import { Network } from "@aptos-labs/ts-sdk";
+import { APTOS_NETWORK } from "@sdk/const";
+
+export default function TestUtilsPage() {
+  return (
+    <>
+      {APTOS_NETWORK !== Network.MAINNET && (
+        <div className="w-full h-full flex flex-col">
+          {APTOS_NETWORK === Network.LOCAL && <SetMeleeDurationForm className="" />}
+          <MarketAddressConversionForm />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/typescript/frontend/src/components/pages/test-utils/SetNewMeleeDuration.tsx
+++ b/src/typescript/frontend/src/components/pages/test-utils/SetNewMeleeDuration.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { cn } from "lib/utils/class-name";
+import { useState } from "react";
+import { Ed25519PrivateKey, Hex, Account, Network } from "@aptos-labs/ts-sdk";
+import { EmojicoinArena } from "@/contract-apis";
+import { useAptos } from "context/wallet-context/AptosContextProvider";
+import { isNumberInConstruction } from "@sdk/utils";
+import { Label } from "@/components/ui/Label";
+import { successfulTransactionToast } from "@/components/wallet/toasts";
+import { toast } from "react-toastify";
+
+const publisher = (() => {
+  // This is the publisher private key used in test.
+  const privateKeyString =
+    process.env.PUBLISHER_PRIVATE_KEY ??
+    "eaa964d1353b075ac63b0c5a0c1e92aa93355be1402f6077581e37e2a846105e";
+  const privateKey = new Ed25519PrivateKey(Hex.fromHexString(privateKeyString).toUint8Array());
+  return Account.fromPrivateKey({ privateKey });
+})();
+
+const MICROSECONDS_PER_MINUTE = 60 * 1000 * 1000;
+
+export const SetMeleeDurationForm = ({ className }: React.HTMLAttributes<HTMLDivElement>) => {
+  const [duration, setDuration] = useState("");
+  const { aptos } = useAptos();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => setDuration(e.target.value);
+
+  const handleClick = () => {
+    const dur = Number.parseFloat(duration);
+    const asMicroseconds = dur * MICROSECONDS_PER_MINUTE;
+    const floored = Math.floor(asMicroseconds);
+    const durationAsMicroseconds = BigInt(floored);
+    EmojicoinArena.SetNextMeleeDuration.submit({
+      aptosConfig: aptos.config,
+      emojicoinArena: publisher,
+      duration: durationAsMicroseconds,
+    }).then((res) => {
+      if (res.success) {
+        successfulTransactionToast(res, { name: Network.LOCAL });
+      } else {
+        toast.error("Fail.");
+      }
+    });
+  };
+
+  return (
+    <div
+      className={cn("flex flex-col w-full max-w-48 m-auto space-x-2 gap-1 font-forma", className)}
+    >
+      <div className="grid w-full max-w-sm items-center gap-1.5">
+        <Label className="text-white font-forma" htmlFor="duration">
+          {"Duration (minutes)"}
+        </Label>
+        <Input
+          id="duration"
+          value={duration}
+          className="text-lighter-gray"
+          type="text"
+          placeholder="in minutes"
+          onChange={handleChange}
+        />
+      </div>
+      <Button
+        className="m-auto"
+        disabled={!isNumberInConstruction(duration)}
+        onClick={handleClick}
+        type="submit"
+      >
+        {"set next melee duration"}
+      </Button>
+    </div>
+  );
+};

--- a/src/typescript/frontend/src/components/pages/test-utils/index.ts
+++ b/src/typescript/frontend/src/components/pages/test-utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./market-address-conversion";
+export * from "./SetNewMeleeDuration";

--- a/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/MarketAddressConversion.tsx
+++ b/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/MarketAddressConversion.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import EmojiPickerWithInput from "@/components/emoji-picker/EmojiPickerWithInput";
+import { Input } from "@/components/ui/Input";
+import { type SymbolEmoji } from "@sdk/emoji_data";
+import { getMarketAddress } from "@sdk/emojicoin_dot_fun";
+import { useEmojiPicker } from "context/emoji-picker-context";
+import { useCallback, useMemo, useState } from "react";
+import { useEffectOnce } from "react-use";
+import { cn } from "lib/utils/class-name";
+import { useFetchSymbol } from "./use-market-address-view";
+import { Label } from "@/components/ui/Label";
+import { ROUTES } from "router/routes";
+import { Emoji } from "utils/emoji";
+
+const addressTextClass = cn(
+  "font-forma w-[66ch] text-center border border-solid border-light-gray",
+  "radii-xs relative text-left p-2"
+);
+
+export const MarketAddressConversionForm = () => {
+  const [queryAddress, setQueryAddress] = useState("");
+  const emojis = useEmojiPicker((s) => s.emojis);
+  const setMode = useEmojiPicker((s) => s.setMode);
+  const fetchedSymbolEmojis = useFetchSymbol({ addressIn: queryAddress });
+  const fetchedSymbol = useMemo(() => fetchedSymbolEmojis?.join("") ?? "", [fetchedSymbolEmojis]);
+  useEffectOnce(() => setMode("register"));
+
+  const handleAddressChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setQueryAddress(e.target.value);
+  }, []);
+
+  return (
+    <div className="flex flex-col relative m-auto w-fit gap-10 text-white text-sm font-forma">
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="address-input">{"check if registered market"}</Label>
+        <Input
+          id="address-input"
+          value={queryAddress}
+          onChange={handleAddressChange}
+          className={addressTextClass}
+        />
+        <div className="flex h-[2em] text-[1em] w-[18ch] border border-solid border-light-gray">
+          {fetchedSymbol && (
+            <a href={`${ROUTES.market}/${fetchedSymbol}`} className="p-[2px] mt-[1px] ml-1">
+              <Emoji emojis={fetchedSymbol} />
+            </a>
+          )}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="emoji-picker-text-area">{"emojis => address"}</Label>
+        <div className="w-[18ch] border border-solid border-light-gray">
+          <EmojiPickerWithInput handleClick={async () => {}} />
+        </div>
+        <span className={addressTextClass}>
+          {emojis.length ? getMarketAddress(emojis as SymbolEmoji[]).toString() : "0x"}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/index.ts
+++ b/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/index.ts
@@ -1,0 +1,2 @@
+export * from "./MarketAddressConversion";
+export * from "./use-market-address-view";

--- a/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/use-market-address-view.ts
+++ b/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/use-market-address-view.ts
@@ -1,0 +1,33 @@
+import { MarketMetadataByMarketAddress } from "@/contract-apis";
+import { type Aptos } from "@aptos-labs/ts-sdk";
+import { symbolBytesToEmojis } from "@sdk/emoji_data";
+import { REGISTRY_ADDRESS } from "@sdk/emojicoin_dot_fun";
+import { useQuery } from "@tanstack/react-query";
+import { useAptos } from "context/wallet-context/AptosContextProvider";
+import { withResponseError } from "lib/hooks/queries/client";
+import { useMemo } from "react";
+
+export const fetchSymbol = async (args: { aptos: Aptos; marketAddress: string }) =>
+  await withResponseError(
+    MarketMetadataByMarketAddress.view(args)
+      .then(async ({ vec }) => vec.pop())
+      .then((res) => (res ? symbolBytesToEmojis(res.emoji_bytes).emojis.map((v) => v.emoji) : null))
+  );
+
+export const useFetchSymbol = ({ addressIn }: { addressIn: string }) => {
+  const { aptos } = useAptos();
+  const addressInputSanitized = useMemo(() => {
+    const input = addressIn.startsWith("0x") ? addressIn.substring(2) : addressIn;
+    const anyInvalid = Array.from(input).some((c) => !/[a-f]|[A-F]|[0-9]/.test(c));
+    return anyInvalid || !input ? "" : `0x${input}`;
+  }, [addressIn]);
+
+  const { data: emojis } = useQuery({
+    queryKey: [addressInputSanitized, REGISTRY_ADDRESS.toString()],
+    queryFn: () =>
+      addressInputSanitized ? fetchSymbol({ aptos, marketAddress: addressInputSanitized }) : null,
+    staleTime: Infinity,
+  });
+
+  return emojis;
+};

--- a/src/typescript/frontend/src/lib/store/server-to-client/StoreOnClient.tsx
+++ b/src/typescript/frontend/src/lib/store/server-to-client/StoreOnClient.tsx
@@ -1,89 +1,102 @@
-"use client";
-import { useWallet, type WalletName } from "@aptos-labs/wallet-adapter-react";
 // cspell:word mkts
+"use client";
 
+import { EmojicoinArena } from "@/contract-apis";
+import { type AccountInfo, useWallet, type WalletName } from "@aptos-labs/wallet-adapter-react";
 import { ONE_APT } from "@sdk/const";
-import { CloseIconWithHover } from "components/svg";
+import { type SymbolEmoji } from "@sdk/emoji_data";
+import { fetchAllCurrentMeleeData, toArenaCoinTypes } from "@sdk/markets";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
-import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { APTOS_NETWORK } from "lib/env";
+import { cn } from "lib/utils/class-name";
+import { Minus, X } from "lucide-react";
+import { useCallback, useState } from "react";
+import { ROUTES } from "router/routes";
 import { emoji } from "utils";
+import { Network } from "@aptos-labs/ts-sdk";
+
+const iconClassName = "p-2 !text-white cursor-pointer !h-[40px] !w-[40px]";
+const debugButtonClassName =
+  "flex p-3 !text-white h-auto m-auto border border-sky-100 border-solid uppercase min-w-[15ch] hover:bg-dark-gray";
 
 export const StoreOnClient = () => {
   const { account, connect, connected, wallet } = useWallet();
-  const { aptos, forceRefetch } = useAptos();
-  const storeMarkets = useEventStore((s) => s.markets);
-  const subscriptions = useEventStore((s) => s.subscriptions);
-  const pathname = usePathname();
+  const { aptos, forceRefetch, submit } = useAptos();
   const [showDebugger, setShowDebugger] = useState(false);
   const registeredMarkets = useEventStore((s) => s.markets);
+  const handleCrank = (definedAccount: AccountInfo) => {
+    // Use fire and water if on the local network, otherwise get the actual melee data.
+    (APTOS_NETWORK === Network.LOCAL
+      ? Promise.resolve([["🔥"], ["💧"]] as SymbolEmoji[][])
+      : fetchAllCurrentMeleeData().then(({ market1, market2 }) => [
+          market1.symbolEmojis,
+          market2.symbolEmojis,
+        ])
+    ).then(([symbol1, symbol2]) => {
+      const [c0, lp0, c1, lp1] = toArenaCoinTypes({ symbol1, symbol2 });
+      EmojicoinArena.Enter.builder({
+        aptosConfig: aptos.config,
+        entrant: definedAccount.address,
+        inputAmount: 1n,
+        lockIn: false,
+        // Mismatched but existing coin types to short-circuit the `enter` function if the crank isn't pulled.
+        typeTags: [c0, lp1, c1, lp0, c0],
+      })
+        .then((builder) => builder.payloadBuilder.toInputPayload())
+        .then(submit);
+    });
+  };
 
-  const [_events, setEvents] = useState(storeMarkets.get(pathname.split("/market/")?.[1] ?? ""));
-
-  useEffect(() => {
-    setEvents(storeMarkets.get(pathname.split("/market/")?.[1]));
-  }, [pathname, storeMarkets]);
+  // Curry a function to force a connection if the wallet isn't connected or call the original function otherwise.
+  const forceConnectOrRunFunction = useCallback(
+    (functionToCallIfConnected: (definedAccount: AccountInfo) => void) => () =>
+      account && connected
+        ? functionToCallIfConnected(account)
+        : connect(wallet?.name ?? ("Petra" as WalletName)),
+    [account, connect, connected, wallet]
+  );
 
   return (
     <>
       <div className="fixed flex bottom-0 right-0 p-2 bg-black text-green text-xl">
         <div className="m-auto">{registeredMarkets.size} mkts</div>
       </div>
-
-      <div className="flex flex-col gap-1 fixed top-0 left-0 z-[50]">
-        <CloseIconWithHover
-          className="p-2 !text-white cursor-pointer !h-[40px] !w-[40px]"
-          onClick={() => setShowDebugger((v) => !v)}
-        />
-        {showDebugger && subscriptions && (
-          <div
-            className={
-              "fixed flex flex-col top-0 left-0 bg-transparent " +
-              "text-xl max-h-[500px] w-[600px] overflow-x-clip overflow-y-scroll " +
-              "border-white border-solid border"
-            }
-          >
-            <div className="mt-[36px]">
-              <div className="relative left-[3ch] flex flex-row items-center bg-black">
-                <div className="text-green">
-                  {"marketIDs:"}&nbsp;{Array.from(subscriptions.marketIDs).join(", ")}
-                </div>
-                <div className="text-green">
-                  {"eventTypes:"}&nbsp;{Array.from(subscriptions.eventTypes).join(", ")}
-                </div>
-              </div>
-            </div>
-          </div>
+      <div className="flex flex-col gap-1 fixed top-0 left-0 z-[50] bg-black">
+        {showDebugger ? (
+          <X onClick={() => setShowDebugger((v) => !v)} className={iconClassName} />
+        ) : (
+          <Minus onClick={() => setShowDebugger((v) => !v)} className={iconClassName} />
         )}
-        <button
-          className="p-3 !text-white h-auto w-auto m-auto border border-sky-100 border-solid uppercase"
-          onClick={async () => {
-            if (!account || !connected) {
-              if (wallet) {
-                connect("Petra" as WalletName);
-              } else {
-                try {
-                  connect("Petra" as WalletName);
-                } catch (e) {
-                  try {
-                    connect("Connect with Google" as WalletName);
-                  } catch (e) {
-                    alert("No valid wallet to connect to.");
-                  }
-                }
-              }
-            } else {
-              await aptos.fundAccount({
-                accountAddress: account.address,
-                amount: ONE_APT * 10000000,
-              });
-              forceRefetch("apt");
-            }
-          }}
-        >
-          {"Fund me"} {emoji("money bag")}
-        </button>
+        {showDebugger && (
+          <>
+            <button
+              className={debugButtonClassName}
+              onClick={forceConnectOrRunFunction((definedAccount) => {
+                aptos
+                  .fundAccount({
+                    accountAddress: definedAccount.address,
+                    amount: ONE_APT * 10000000,
+                  })
+                  .then(() => forceRefetch("apt"));
+              })}
+            >
+              <span className="justify-start">
+                {"Fund me"} {emoji("money bag")}
+              </span>
+            </button>
+            <a className={cn(debugButtonClassName, "justify-start")} href={ROUTES["test-utils"]}>
+              <span className="rotate-[-22.5deg]">{"/"}</span>
+              <span className="lowercase">{"test-utils"}</span>
+            </a>
+            <button
+              onClick={forceConnectOrRunFunction(handleCrank)}
+              className={debugButtonClassName}
+            >
+              {"Crank melee"}
+            </button>
+          </>
+        )}
       </div>
     </>
   );

--- a/src/typescript/frontend/src/router/routes.ts
+++ b/src/typescript/frontend/src/router/routes.ts
@@ -16,5 +16,6 @@ export const ROUTES = {
   market: "/market",
   notFound: "/not-found",
   pools: "/pools",
+  "test-utils": "/test-utils",
   verify: "/verify",
 } as const;

--- a/src/typescript/sdk/src/markets/arena-utils.ts
+++ b/src/typescript/sdk/src/markets/arena-utils.ts
@@ -103,3 +103,18 @@ export const fetchMeleeEmojiData = async (
 };
 
 export type MeleeEmojiData = Awaited<ReturnType<typeof fetchMeleeEmojiData>>;
+
+/**
+ * Helper function to fetch all current melee data in a single call.
+ */
+export const fetchAllCurrentMeleeData = async () => {
+  const registry = await fetchArenaRegistryView();
+  const melee = await fetchArenaMeleeView(registry.currentMeleeID);
+  const { market1, market2 } = await fetchMeleeEmojiData(melee);
+  return {
+    registry,
+    melee,
+    market1,
+    market2,
+  };
+};

--- a/src/typescript/sdk/src/markets/index.ts
+++ b/src/typescript/sdk/src/markets/index.ts
@@ -1,1 +1,2 @@
+export * from "./arena-utils";
 export * from "./utils";


### PR DESCRIPTION
# Description

Entirely just test stuff and component prototyping, most of the PR lines changed comes from `pnpm-lock.yaml`.

- [x] Adds the ability to update the melee duration with a very simple UI on a local network
- [x] Adds the ability to crank the melee very quickly without having to go through the UI to do it
- [x] Adds a simple market lookup form (market address => emojis)
- [x] Adds a symbol emojis => market address form

https://github.com/user-attachments/assets/0e530e22-3730-460e-9ec0-3728d8943cf5

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

