### PR TITLE
Make USD market cap hide decimals when > $1M

### DIFF
--- a/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
+++ b/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
@@ -8,5 +8,12 @@ import { toNominal } from "lib/utils/decimals";
  */
 export function useUsdMarketCap(marketCapInOctas: bigint): number | undefined {
   const aptPrice = useAptPrice();
-  return aptPrice ? toNominal(marketCapInOctas) * aptPrice : undefined;
+  const aptInUsd = aptPrice ? toNominal(marketCapInOctas) * aptPrice : undefined;
+
+  // Remove decimals if market cap is over 1 million
+  if (aptInUsd && aptInUsd >= 1_000_000) {
+    return Math.floor(aptInUsd);
+  }
+
+  return aptInUsd;
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The UI gets very crowded with all the numbers, the decimals don't matter at that size market cap.

# Testing

None

# Checklist
