### PR TITLE
ci(ECO-2840): Add conventional commit check

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -13,7 +13,6 @@ jobs:
         requireScope: true
         scopes: '^ECO-[0-9]+$'
         subjectPattern: '^[A-Z].*$'
-        subjectPatternError: 'Subject must start with a capital letter'
         validateSingleCommit: true
         validateSingleCommitMatchesPrTitle: true
 name: 'Verify conventional commit PR title'

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,25 @@
+# cspell:word amannn
+---
+env:
+  GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+jobs:
+  conventional-commits:
+    name: 'Verify PR title uses a conventional commit message'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'amannn/action-semantic-pull-request@v5'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      with:
+        requireScope: true
+        scope: |
+          arena
+          ci
+        subjectPattern: '^\[ECO-[0-9]+\] [A-Z].*$'
+        subjectPatternError: 'The subject must be `[ECO-XXX] Do something`.'
+        validateSingleCommit: true
+        validateSingleCommitMatchesPrTitle: true
+name: 'conventional-commits'
+'on':
+  pull_request: null
+...

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -20,5 +20,10 @@ jobs:
         validateSingleCommitMatchesPrTitle: true
 name: 'Verify conventional commit PR title'
 'on':
-  pull_request: null
+  pull_request:
+    types:
+    - 'opened'
+    - 'edited'
+    - 'synchronize'
+    - 'reopened'
 ...

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -11,11 +11,10 @@ jobs:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       with:
         requireScope: true
-        scope: |
-          arena
-          ci
-        subjectPattern: '^\[ECO-[0-9]+\] [A-Z].*$'
-        subjectPatternError: 'The subject must be `[ECO-XXX] Do something`.'
+        scopePattern: '^ECO-[0-9]+$'
+        scopePatternError: 'Scope must be an ECO tag (e.g., ECO-2840)'
+        subjectPattern: '^[A-Z].*$'
+        subjectPatternError: 'Subject must start with a capital letter'
         validateSingleCommit: true
         validateSingleCommitMatchesPrTitle: true
 name: 'Verify conventional commit PR title'

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -6,9 +6,9 @@ jobs:
   conventional-commit:
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'amannn/action-semantic-pull-request@v5'
-      env:
+    - env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      uses: 'amannn/action-semantic-pull-request@v5'
       with:
         requireScope: true
         scopes: '^ECO-[0-9]+$'
@@ -19,8 +19,8 @@ name: 'Verify conventional commit PR title'
 'on':
   pull_request:
     types:
-    - 'opened'
     - 'edited'
-    - 'synchronize'
+    - 'opened'
     - 'reopened'
+    - 'synchronize'
 ...

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -11,8 +11,7 @@ jobs:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       with:
         requireScope: true
-        scopePattern: '^ECO-[0-9]+$'
-        scopePatternError: 'Scope must be an ECO tag (e.g., ECO-2840)'
+        scopes: '^ECO-[0-9]+$'
         subjectPattern: '^[A-Z].*$'
         subjectPatternError: 'Subject must start with a capital letter'
         validateSingleCommit: true

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -3,8 +3,7 @@
 env:
   GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 jobs:
-  conventional-commits:
-    name: 'Verify PR title uses a conventional commit message'
+  conventional-commit:
     runs-on: 'ubuntu-latest'
     steps:
     - uses: 'amannn/action-semantic-pull-request@v5'

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -19,7 +19,7 @@ jobs:
         subjectPatternError: 'The subject must be `[ECO-XXX] Do something`.'
         validateSingleCommit: true
         validateSingleCommitMatchesPrTitle: true
-name: 'conventional-commits'
+name: 'Verify conventional commit PR title'
 'on':
   pull_request: null
 ...


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Add a GitHub action to verify that PR messages conform to conventional commits with an `ECO-XXXX` tag for the scope

# Testing

GitHub checks verified for pushing changes as well as for changing the PR title
