### PR TITLE
feat(ECO-2837): Add configurable arena indexing

### DIFF
--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -18,6 +18,7 @@ parameters:
   EnableWafRulesRestApi: 'false'
   EnableWafRulesWebSocket: 'false'
   Environment: 'alpha'
+  IndexArena: 'false'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
   ProcessorImageVersion: '6.0.0-alpha'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -21,6 +21,7 @@ parameters:
   EnableWafRulesRestApi: 'false'
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
+  IndexArena: 'false'
   Network: 'mainnet'
   ProcessorImageVersion: '4.0.2'
   VpcStackName: 'emoji-vpc'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -21,6 +21,7 @@ parameters:
   EnableWafRulesRestApi: 'false'
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
+  IndexArena: 'false'
   Network: 'mainnet'
   ProcessorImageVersion: '4.0.2'
   VpcStackName: 'emoji-vpc'

--- a/src/cloud-formation/indexer.cfn.yaml
+++ b/src/cloud-formation/indexer.cfn.yaml
@@ -56,6 +56,9 @@ Conditions:
   EnableWafRulesWebSocket: !Equals
   - !Ref 'EnableWafRulesWebSocket'
   - 'true'
+  IndexArena: !Equals
+  - !Ref 'IndexArena'
+  - 'true'
 Mappings:
   Constants:
     # These compromised credentials are not a security risk because access to
@@ -202,6 +205,12 @@ Parameters:
     - 'true'
     Type: 'String'
   Environment:
+    Type: 'String'
+  IndexArena:
+    AllowedValues:
+    - 'false'
+    - 'true'
+    Default: 'true'
     Type: 'String'
   Network:
     AllowedValues:
@@ -1418,9 +1427,12 @@ Resources:
         - Name: 'EMOJICOIN_MODULE_ADDRESS'
           Value: !Sub
             '{{resolve:ssm:/emojicoin/package-address/${Network}}}'
-        - Name: 'EMOJICOIN_ARENA_MODULE_ADDRESS'
-          Value: !Sub
-            '{{resolve:ssm:/emojicoin/arena-package-address/${Network}}}'
+        - !If
+          - 'IndexArena'
+          - Name: 'EMOJICOIN_ARENA_MODULE_ADDRESS'
+            Value: !Sub
+              '{{resolve:ssm:/emojicoin/arena-package-address/${Network}}}'
+          - !Ref 'AWS::NoValue'
         - Name: 'WS_PORT'
           Value: !FindInMap
           - 'Constants'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Add `IndexArena` parameter for configurable indexing

# Testing

1. Passes `cfn-lint`
1. When this merges, the environment variable for `emoji-alpha` should be toggled off and arena events shouldn't get parsed, then with a subsequent cold upgrade and variable toggle it should be set again and index as expected
