### PR TITLE
ci(ECO-2482): Disable submodule check when PR not to main

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -11,7 +11,9 @@ jobs:
       working-directory: 'src/rust/processor'
 name: 'Ensure correct version of processor submodule'
 'on':
-  pull_request: null
+  pull_request:
+    branches:
+    - 'main'
   push:
     branches:
     - 'main'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Disable the submodule check for PRs that are not into `main`.

# Testing

See this PR's checks