### PR TITLE
fix(ECO-2845): Don't try to parse user agent string if it's empty

### DIFF
--- a/src/typescript/frontend/src/lib/utils/user-agent-selectors.ts
+++ b/src/typescript/frontend/src/lib/utils/user-agent-selectors.ts
@@ -49,6 +49,9 @@ const booleanSelectors = new Set(Object.keys(booleanUserAgentSelectors) as Keys[
 
 export const getBooleanUserAgentSelectors = (userAgent: string): Selectors => {
   try {
+    if (!userAgent) {
+      return {};
+    }
     const selectors = getSelectorsByUserAgent(userAgent) ?? {};
     const res: Selectors = {};
     Object.keys(selectors)
@@ -59,7 +62,6 @@ export const getBooleanUserAgentSelectors = (userAgent: string): Selectors => {
       .forEach((k) => (res[k] = true));
     return res;
   } catch (e) {
-    console.error(e);
     return {};
   }
 };


### PR DESCRIPTION
# Description

This removes like 40,000 console errors in local development. Otherwise, functionally exactly the same.

# Testing

Tested locally. Makes no difference functionally ultimately.

