### PR TITLE
chore(ECO-2847): Remove disabling arena indexing override

### DIFF
--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -18,7 +18,6 @@ parameters:
   EnableWafRulesRestApi: 'false'
   EnableWafRulesWebSocket: 'false'
   Environment: 'alpha'
-  IndexArena: 'false'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
   ProcessorImageVersion: '6.0.0-alpha'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Remove the override to disable arena indexing, thus allowing a cold upgrade with fully-indexed arena data
