### PR TITLE
fix(ECO-2848): Update `next.config.mjs` `experimental.staleTimes` to remove opinionated default caching behavior

### DIFF
--- a/src/typescript/frontend/next.config.mjs
+++ b/src/typescript/frontend/next.config.mjs
@@ -15,15 +15,12 @@ const debugConfigOptions = {
   experimental: {
     serverMinification: false,
     serverSourceMaps: true,
-    staleTimes: {
-      dynamic: 0, // Default is normally 30s.
-      static: 30, // Default is normally 180s.
-    },
   },
 };
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  ...(DEBUG ? debugConfigOptions : {}),
   crossOrigin: "use-credentials",
   typescript: {
     tsconfigPath: "tsconfig.json",
@@ -32,7 +29,16 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
-  ...(DEBUG ? debugConfigOptions : {}),
+  /**
+   * Match the new default behavior in next 15, without opinionated caching for dynamic pages.
+   * @see {@link https://nextjs.org/docs/app/api-reference/config/next-config-js/staleTimes#version-history}
+   */
+  experimental: {
+    staleTimes: {
+      dynamic: 0, // Default is normally 30s.
+      static: 60, // Default is normally 180s.
+    },
+  },
   // Log full fetch URLs if we're in a specific environment.
   logging:
     process.env.NODE_ENV === "development" ||


### PR DESCRIPTION
# Description

Remove the opinionated default `nextjs 14` caching behavior- update it to match the default behavior in `nextjs 15`: see [here](https://nextjs.org/docs/app/api-reference/config/next-config-js/staleTimes#version-history)

This change was actually supposed to be flipped on a while ago, it just never got in on accident. This will fix a lot of confusing ux/ui behavior where data seems stale from the server despite a proper caching revalidation time.

# Testing

Tested manually with the `test-utils` functions. Works pretty well.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
