### PR TITLE
chore(ECO-2851): Clean up `PrivateChart.tsx` and make the inner logic more modular

### DIFF
--- a/src/typescript/frontend/src/components/charts/BrowserNotSupported.tsx
+++ b/src/typescript/frontend/src/components/charts/BrowserNotSupported.tsx
@@ -1,0 +1,39 @@
+import { cn } from "lib/utils/class-name";
+import { useState, useEffect } from "react";
+import { emoji } from "utils";
+import { Emoji } from "utils/emoji";
+
+export const BrowserNotSupported = () => {
+  const [showErrorMessage, setShowErrorMessage] = useState<boolean>(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setShowErrorMessage(true);
+    }, 3500);
+    return () => clearTimeout(timeout);
+  });
+  return (
+    <div
+      className={cn(
+        "absolute left-0 top-0 flex h-full w-full animate-fadeIn items-center justify-center text-center",
+        "font-roboto-mono text-lg font-light leading-6 text-neutral-500 opacity-0 delay-[2000]"
+      )}
+    >
+      <div>
+        {showErrorMessage ? (
+          <>
+            <div>
+              <span>{"The browser you're using isn't supported. "}</span>
+              <Emoji emojis={emoji("pensive face")} />
+            </div>
+            <div>
+              <span>{" Please try viewing in another browser."}</span>
+            </div>
+          </>
+        ) : (
+          "Loading..."
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/typescript/frontend/src/components/charts/BrowserNotSupported.tsx
+++ b/src/typescript/frontend/src/components/charts/BrowserNotSupported.tsx
@@ -7,11 +7,10 @@ export const BrowserNotSupported = () => {
   const [showErrorMessage, setShowErrorMessage] = useState<boolean>(false);
 
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      setShowErrorMessage(true);
-    }, 3500);
+    const timeout = setTimeout(() => setShowErrorMessage(true), 3500);
     return () => clearTimeout(timeout);
   });
+
   return (
     <div
       className={cn(

--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -31,10 +31,6 @@ import {
  * the `datafeed` API. It also handles resolving market symbols from user input with the market metadata passed down
  * from a server component/fetch in the form of the `EventStore["markets"]` registered market map data.
  *
- * TODO: We may want to periodically refresh the candlestick data and ensure it is valid/up to date
- * with the on-chain data by polling the `market_view` endpoint. This would ensure that in the case of a dropped
- * event or a broken websocket connection, the user would still generally have the most up-to-date data.
- *
  * Please see
  * {@link https://github.com/econia-labs/emojicoin-dot-fun/tree/main/src/typescript/frontend/src/components/charts/README.md}
  * for a more detailed explanation of the architectural data flow.

--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -1,56 +1,30 @@
-// cspell:word intraday
-// cspell:word minmov
-// cspell:word pricescale
-import { useEffect, useMemo, useRef, useState } from "react";
-
+import { useEffect, useMemo, useRef } from "react";
+import { MS_IN_ONE_DAY, ResolutionStringToPeriod, WIDGET_OPTIONS } from "./const";
 import {
-  EXCHANGE_NAME,
-  MS_IN_ONE_DAY,
-  ResolutionStringToPeriod,
-  TV_CHARTING_LIBRARY_RESOLUTIONS,
-  WIDGET_OPTIONS,
-} from "./const";
-import {
-  type Bar,
-  type DatafeedConfiguration,
   type IBasicDataFeed,
   type IChartingLibraryWidget,
-  type LibrarySymbolInfo,
-  type SearchSymbolResultItem,
   type Timezone,
   widget,
 } from "@static/charting_library";
-import { getClientTimezone, hasTradingActivity } from "lib/chart-utils";
 import { type ChartContainerProps } from "./types";
 import { useRouter } from "next/navigation";
 import { ROUTES } from "router/routes";
 import path from "path";
-import { emojisToName } from "lib/utils/emojis-to-name-or-symbol";
 import { useEventStore } from "context/event-store-context";
-import { getPeriodStartTimeFromTime } from "@sdk/utils";
-import { getSymbolEmojisInString, symbolToEmojis, toMarketEmojiData } from "@sdk/emoji_data";
-import { type PeriodicStateEventModel, type MarketMetadataModel } from "@sdk/indexer-v2/types";
-import { getMarketResource } from "@sdk/markets";
-import { periodEnumToRawDuration, Trigger } from "@sdk/const";
+import { getSymbolEmojisInString, symbolToEmojis } from "@sdk/emoji_data";
+import { periodEnumToRawDuration } from "@sdk/const";
 import {
-  type LatestBar,
-  marketToLatestBars,
-  periodicStateTrackerToLatestBar,
-  toBar,
-} from "@/store/event/candlestick-bars";
-import { emoji, parseJSON } from "utils";
-import { Emoji } from "utils/emoji";
-import { getAptosClient } from "@sdk/utils/aptos-client";
-
-const configurationData: DatafeedConfiguration = {
-  supported_resolutions: TV_CHARTING_LIBRARY_RESOLUTIONS,
-  symbols_types: [
-    {
-      name: "crypto",
-      value: "crypto",
-    },
-  ],
-};
+  CONFIGURATION_DATA,
+  constructLibrarySymbolInfo,
+  searchSymbolsFromRegisteredMarketMap,
+} from "./trading-view-utils";
+import { BrowserNotSupported } from "./BrowserNotSupported";
+import {
+  createDummyBar,
+  fetchCandlesticksForChart,
+  fetchLatestBarsFromMarketResource,
+  updateLastTwoBars,
+} from "./get-bars";
 
 /**
  * The TradingView Chart component. This component is responsible for rendering the TradingView chart with the usage of
@@ -80,69 +54,22 @@ export const Chart = (props: ChartContainerProps) => {
   const datafeed: IBasicDataFeed = useMemo(
     () => ({
       onReady: (callback) => {
-        setTimeout(() => callback(configurationData));
+        setTimeout(() => callback(CONFIGURATION_DATA));
       },
       searchSymbols: async (userInput, _exchange, _symbolType, onResultReadyCallback) => {
-        const data = Array.from(getRegisteredMarketMap().values());
-        // TODO: Use the new emoji picker search with this..?
-        const symbols = data.reduce<SearchSymbolResultItem[]>((acc, { marketMetadata }) => {
-          const marketID = marketMetadata.marketID.toString();
-          const symbol = marketMetadata.symbolData.symbol;
-          const { emojis } = marketMetadata;
-          const symbolForSearch = {
-            description: `Market #${marketID}: ${symbol}`,
-            exchange: EXCHANGE_NAME,
-            full_name: `${EXCHANGE_NAME}:${emojisToName(emojis)}`,
-            symbol,
-            ticker: symbol,
-            type: "crypto",
-          };
-          if (
-            symbolForSearch.full_name.includes(userInput) ||
-            symbolForSearch.symbol.includes(userInput) ||
-            symbolForSearch.ticker.includes(userInput) ||
-            marketID.includes(userInput) ||
-            userInput.includes(marketID)
-          ) {
-            acc.push(symbolForSearch);
-          }
-          return acc;
-        }, []);
+        const registeredMarketMap = getRegisteredMarketMap();
+        const symbols = searchSymbolsFromRegisteredMarketMap({ userInput, registeredMarketMap });
         onResultReadyCallback(symbols);
       },
       resolveSymbol: async (symbolName, onSymbolResolvedCallback, _onErrorCallback) => {
-        // Try to look up the symbol as if it were a market ID and then as if it were the actual market symbol,
-        // aka, the emoji(s) symbol string.
         const { symbol } = symbolToEmojis(symbolName);
         if (symbol !== props.symbol) {
           const newRoute = path.join(ROUTES.market, symbol);
-          console.debug(`[resolveSymbol]: Redirecting to ${newRoute}`);
           router.push(newRoute);
           router.refresh();
         }
 
-        const symbolInfo: LibrarySymbolInfo = {
-          ticker: symbol,
-          name: symbol,
-          description: symbol,
-          pricescale: 10 ** 9,
-          volume_precision: -Math.ceil(Math.log10(Number("0.00000100") * Number("100.00000000"))),
-          minmov: 1,
-          exchange: EXCHANGE_NAME,
-          listed_exchange: "",
-          session: "24x7",
-          // Note that `has_empty_bars` causes invalid `time order violation` errors if it's set to `true`.
-          // has_empty_bars: true,
-          has_seconds: false,
-          has_intraday: true,
-          has_daily: true,
-          has_weekly_and_monthly: false,
-          timezone: getClientTimezone() as Timezone,
-          type: "crypto",
-          supported_resolutions: configurationData.supported_resolutions,
-          format: "price",
-        };
-
+        const symbolInfo = constructLibrarySymbolInfo(symbolName);
         setTimeout(() => onSymbolResolvedCallback(symbolInfo), 0);
       },
       getBars: async (
@@ -152,124 +79,41 @@ export const Chart = (props: ChartContainerProps) => {
         onHistoryCallback,
         onErrorCallback
       ) => {
-        const { to, countBack } = periodParams;
+        const { to } = periodParams;
+        const period = ResolutionStringToPeriod[resolution.toString()];
+        const periodDuration = periodEnumToRawDuration(period);
 
         try {
-          const period = ResolutionStringToPeriod[resolution.toString()];
-          const periodDuration = periodEnumToRawDuration(period);
-
-          // The start timestamp is rounded so that all the people who load the webpage at a similar time get served
-          // the same cached response.
-          const params = new URLSearchParams({
+          const bars = await fetchCandlesticksForChart({
             marketID: props.marketID,
-            period: period.toString(),
-            countBack: countBack.toString(),
-            to: to.toString(),
+            periodParams,
+            period,
           });
-          const data: PeriodicStateEventModel[] = await fetch(`/candlesticks?${params.toString()}`)
-            .then((res) => res.text())
-            .then((res) => parseJSON(res));
-
-          data.sort((a, b) => Number(a.periodicMetadata.startTime - b.periodicMetadata.startTime));
-
-          const endDate = new Date(to * 1000);
-          const isFetchForMostRecentBars = endDate.getTime() - new Date().getTime() > 1000;
 
           // If the end time is in the future, it means that `getBars` is being called for the most recent candlesticks,
           // and thus we should append the latest candlestick to this dataset to ensure the chart is up to date.
-          let latestBar: LatestBar | undefined;
+          const endDate = new Date(to * 1000);
+          const isFetchForMostRecentBars = endDate.getTime() - new Date().getTime() > 1000;
           if (isFetchForMostRecentBars) {
-            // Fetch the current candlestick data from the Aptos fullnode. This fetch call should *never* be cached.
-            // Also, we specifically call this client-side because the server will get rate-limited if we call the
-            // fullnode from the server for each client.
-            const marketResource = await getMarketResource({
-              aptos: getAptosClient(),
-              marketAddress: props.marketAddress,
-            });
+            const { marketMetadata, latestBar, latestBars } =
+              await fetchLatestBarsFromMarketResource({
+                marketAddress: props.marketAddress,
+                period,
+              });
 
-            // Convert the market view data to `latestBar[]` and set the latest bars in our EventStore to those values.
-            const latestBars = marketToLatestBars(marketResource);
-            const marketEmojiData = toMarketEmojiData(marketResource.metadata.emojiBytes);
-            const marketMetadata: MarketMetadataModel = {
-              marketID: marketResource.metadata.marketID,
-              time: 0n,
-              marketNonce: marketResource.sequenceInfo.nonce,
-              trigger: Trigger.PackagePublication, // Make up some bunk trigger, since it should be clear it's made up.
-              marketAddress: marketResource.metadata.marketAddress,
-              ...marketEmojiData,
-            };
+            // Set the latest bars in the state store.
             setLatestBars({ marketMetadata, latestBars });
-
-            // Get the period-specific state tracker for the current resolution/period type and set the latest bar on
-            // the chart- *not* just in state- to the latest bar from that tracker.
-            const tracker = marketResource.periodicStateTrackers.find(
-              // These are most likely indexed in order, but in case they aren't, we use `find` here.
-              (p) => Number(p.period) === periodDuration
-            );
-            if (!tracker) {
-              throw new Error("This should never happen.");
+            if (latestBar) {
+              // Mutates the `bars` array.
+              updateLastTwoBars(bars, latestBar);
             }
-            const nonce = marketResource.sequenceInfo.nonce;
-            latestBar = periodicStateTrackerToLatestBar(tracker, nonce);
-          }
-
-          // Filter the data so that all resulting bars are within the specified time range.
-          // Also, update the `open` price to the previous bar's `close` price if it exists.
-          // NOTE: Since `getBars` is called multiple times, this will result in several
-          // bars having incorrect `open` values. This isn't a big deal but may result in
-          // some visual inconsistencies in the chart.
-          const bars: Bar[] = data.reduce((acc: Bar[], event) => {
-            const bar = toBar(event);
-            // Only exclude bars that are after `to`.
-            // see: https://www.tradingview.com/charting-library-docs/latest/connecting_data/datafeed-api/required-methods#getbars
-            const inTimeRange = bar.time <= to * 1000;
-            if (inTimeRange && hasTradingActivity(bar)) {
-              const prev = acc.at(-1);
-              if (prev) {
-                bar.open = prev.close;
-              }
-              acc.push(bar);
-            }
-            return acc;
-          }, []);
-
-          // Push the latest bar to the bars array if it exists and update its `open` value to be the previous bar's
-          // `close` if it's not the first/only bar.
-          // This logic mirrors what we use in `createBarFrom[Swap|PeriodicState]` but we need it here because we
-          // update the latest bar based on the market view every time we fetch with `getBars`, not just when a new
-          // event comes in.
-          if (latestBar) {
-            const secondLatestBar = bars.at(-1);
-            if (secondLatestBar) {
-              // If the latest bar has no trading activity, set all of its fields to the previous bar's close.
-              if (!hasTradingActivity(latestBar)) {
-                latestBar.high = secondLatestBar.close;
-                latestBar.low = secondLatestBar.close;
-                latestBar.close = secondLatestBar.close;
-              }
-              if (secondLatestBar.close !== 0) {
-                latestBar.open = secondLatestBar.close;
-              } else {
-                latestBar.open = latestBar.close;
-              }
-            }
-            bars.push(latestBar);
           }
 
           if (bars.length === 0) {
             if (isFetchForMostRecentBars) {
-              // If this is the most recent bar fetch and there is literally zero trading activity thus far,
-              // we should create a single empty bar to get rid of the `No chart data` ghost error from showing.
-              const time = BigInt(new Date().getTime()) * 1000n;
-              const timeAsPeriod = getPeriodStartTimeFromTime(time, periodDuration) / 1000n;
-              bars.push({
-                time: Number(timeAsPeriod.toString()),
-                open: 0,
-                high: 0,
-                low: 0,
-                close: 0,
-                volume: 0,
-              });
+              // Create a single empty bar if there's no trading activity, otherwise the chart shows "No chart data".
+              const dummyBar = createDummyBar(periodDuration);
+              bars.push(dummyBar);
             } else {
               onHistoryCallback([], {
                 noData: true,
@@ -278,7 +122,7 @@ export const Chart = (props: ChartContainerProps) => {
             }
           }
           onHistoryCallback(bars, {
-            noData: bars.length === 0, // && notAllEmptyBars,
+            noData: bars.length === 0,
           });
         } catch (e) {
           if (e instanceof Error) {
@@ -356,34 +200,9 @@ export const Chart = (props: ChartContainerProps) => {
     };
   }, [datafeed, symbol]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const [showErrorMessage, setShowErrorMessage] = useState<boolean>(false);
-
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      setShowErrorMessage(true);
-    }, 3500);
-    return () => clearTimeout(timeout);
-  });
-
   return (
     <div className="relative w-full h-[420px]">
-      <div className="absolute left-0 top-0 flex h-full w-full animate-fadeIn items-center justify-center text-center font-roboto-mono text-lg font-light leading-6 text-neutral-500 opacity-0 delay-[2000]">
-        <div>
-          {showErrorMessage ? (
-            <>
-              <div>
-                <span>{"The browser you're using isn't supported. "}</span>
-                <Emoji emojis={emoji("pensive face")} />
-              </div>
-              <div>
-                <span>{" Please try viewing in another browser."}</span>
-              </div>
-            </>
-          ) : (
-            "Loading..."
-          )}
-        </div>
-      </div>
+      <BrowserNotSupported />
       <div ref={ref} className="relative h-full w-full"></div>
     </div>
   );

--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -109,21 +109,14 @@ export const Chart = (props: ChartContainerProps) => {
             }
           }
 
-          if (bars.length === 0) {
-            if (isFetchForMostRecentBars) {
-              // Create a single empty bar if there's no trading activity, otherwise the chart shows "No chart data".
-              const dummyBar = createDummyBar(periodDuration);
-              bars.push(dummyBar);
-            } else {
-              onHistoryCallback([], {
-                noData: true,
-              });
-              return;
-            }
+          const noData = bars.length === 0;
+          if (noData && isFetchForMostRecentBars) {
+            // Create a single empty bar if there's no trading activity, otherwise the chart shows "No chart data".
+            const dummyBar = createDummyBar(periodDuration);
+            bars.push(dummyBar);
           }
-          onHistoryCallback(bars, {
-            noData: bars.length === 0,
-          });
+
+          onHistoryCallback(bars, { noData });
         } catch (e) {
           if (e instanceof Error) {
             console.warn("[getBars]: Get error", e);

--- a/src/typescript/frontend/src/components/charts/get-bars.ts
+++ b/src/typescript/frontend/src/components/charts/get-bars.ts
@@ -1,0 +1,168 @@
+import {
+  type LatestBar,
+  marketToLatestBars,
+  periodicStateTrackerToLatestBar,
+  toBar,
+} from "@/store/event/candlestick-bars";
+import { type Types } from "@sdk-types";
+import { Trigger, type Period, periodEnumToRawDuration, type PeriodDuration } from "@sdk/const";
+import { toMarketEmojiData } from "@sdk/emoji_data/utils";
+import { type MarketMetadataModel, type PeriodicStateEventModel } from "@sdk/indexer-v2";
+import { getMarketResource } from "@sdk/markets/utils";
+import { getAptosClient } from "@sdk/utils/aptos-client";
+import { getPeriodStartTimeFromTime } from "@sdk/utils/misc";
+import { type Bar, type PeriodParams } from "@static/charting_library";
+import { hasTradingActivity } from "lib/chart-utils";
+import { parseJSON } from "utils";
+
+export const fetchCandlesticksForChart = async ({
+  marketID,
+  periodParams,
+  period,
+}: {
+  marketID: string;
+  periodParams: PeriodParams;
+  period: Period;
+}): Promise<Bar[]> => {
+  const { to, countBack } = periodParams;
+  const params = new URLSearchParams({
+    marketID,
+    period: period.toString(),
+    countBack: countBack.toString(),
+    to: to.toString(),
+  });
+  return await fetch(`/candlesticks?${params.toString()}`)
+    .then((res) => res.text())
+    .then((res) => parseJSON<PeriodicStateEventModel[]>(res))
+    .then((res) =>
+      res
+        .sort((a, b) => Number(a.periodicMetadata.startTime - b.periodicMetadata.startTime))
+        .map(toBar)
+        .reduce(curriedBarsReducer(to), [])
+    );
+};
+
+/**
+ * The curried reducer function to filter and update all bar data.
+ *
+ * - Filter the data so that all resulting bars are within the specified time range.
+ * - Update the `open` price to the previous bar's `close` price if it exists.
+ *
+ * Only exclude bars that are after `to`.
+ * @see {@link https://www.tradingview.com/charting-library-docs/latest/connecting_data/datafeed-api/required-methods#getbars}
+ *
+ * NOTE: Since `getBars` is called multiple times, this will result in several
+ * bars having incorrect `open` values. This isn't a big deal but may result in
+ * some visual inconsistencies in the chart.
+ * @param acc
+ * @param event
+ * @returns
+ */
+const curriedBarsReducer = (to: number) => (acc: Bar[], bar: Bar) => {
+  const inTimeRange = bar.time <= to * 1000;
+  if (inTimeRange && hasTradingActivity(bar)) {
+    const prev = acc.at(-1);
+    if (prev) {
+      bar.open = prev.close;
+    }
+    acc.push(bar);
+  }
+  return acc;
+};
+
+/**
+ * Push the latest bar (the on-chain bar) to the bars array if it exists and update its `open` value
+ * to be the previous bar's `close` if it's not the first/only bar.
+ *
+ * This logic mirrors what we use in `createBarFrom[Swap|PeriodicState]` but we need it here because
+ * we need to update the latest bar based on the market view for the last call of `getBars`, not
+ * just when a new event comes in.
+ */
+export const updateLastTwoBars = (bars: Bar[], onChainLatest: Bar) => {
+  const emittedLatest = bars.at(-1);
+  if (emittedLatest) {
+    // If the latest bar has no trading activity, set all of its fields to the previous bar's close.
+    if (!hasTradingActivity(onChainLatest)) {
+      onChainLatest.high = emittedLatest.close;
+      onChainLatest.low = emittedLatest.close;
+      onChainLatest.close = emittedLatest.close;
+    }
+    if (emittedLatest.close !== 0) {
+      onChainLatest.open = emittedLatest.close;
+    } else {
+      onChainLatest.open = onChainLatest.close;
+    }
+  }
+  bars.push(onChainLatest);
+};
+
+/**
+ * Utility function to create a dummy bar from the period duration when there's zero trading
+ * activity for a market thus far.
+ */
+export const createDummyBar = (periodDuration: PeriodDuration) => {
+  const time = BigInt(new Date().getTime()) * 1000n;
+  const timeAsPeriod = getPeriodStartTimeFromTime(time, periodDuration) / 1000n;
+  return {
+    time: Number(timeAsPeriod.toString()),
+    open: 0,
+    high: 0,
+    low: 0,
+    close: 0,
+    volume: 0,
+  };
+};
+
+export const fetchLatestBarsFromMarketResource = async ({
+  marketAddress,
+  period,
+}: {
+  marketAddress: `0x${string}`;
+  period: Period;
+}): Promise<{
+  marketMetadata: MarketMetadataModel;
+  latestBar: LatestBar | undefined;
+  latestBars: LatestBar[];
+}> => {
+  // Fetch the current candlestick data from the Aptos fullnode. This fetch call should *never* be cached.
+  // Also, we specifically call this client-side because the server will get rate-limited if we call the
+  // fullnode from the server for each client.
+  const marketResource = await getMarketResource({
+    aptos: getAptosClient(),
+    marketAddress,
+  });
+
+  // Convert the market view data to `latestBar[]` and set the latest bars in our EventStore to those values.
+  const latestBars = marketToLatestBars(marketResource);
+  const marketMetadata = marketResourceToMarketMetadataModel(marketResource);
+  const latestBar = getLatestBarFromTracker(marketResource, period);
+
+  return {
+    marketMetadata,
+    latestBar,
+    latestBars,
+  };
+};
+
+const getLatestBarFromTracker = (marketResource: Types["Market"], period: Period) => {
+  const periodDuration = periodEnumToRawDuration(period);
+  // Get the period-specific state tracker for the current resolution/period type.
+  const tracker = marketResource.periodicStateTrackers.find(
+    (p) => Number(p.period) === periodDuration
+  );
+  if (!tracker) {
+    return undefined;
+  }
+  const nonce = marketResource.sequenceInfo.nonce;
+  return periodicStateTrackerToLatestBar(tracker, nonce);
+};
+
+const marketResourceToMarketMetadataModel = (market: Types["Market"]): MarketMetadataModel => ({
+  marketID: market.metadata.marketID,
+  time: 0n,
+  marketNonce: market.sequenceInfo.nonce,
+  // Make up some bunk trigger, since it should be clear it's made up.
+  trigger: Trigger.PackagePublication,
+  marketAddress: market.metadata.marketAddress,
+  ...toMarketEmojiData(market.metadata.emojiBytes),
+});

--- a/src/typescript/frontend/src/components/charts/trading-view-utils.ts
+++ b/src/typescript/frontend/src/components/charts/trading-view-utils.ts
@@ -1,0 +1,80 @@
+// cspell:word intraday
+// cspell:word minmov
+// cspell:word pricescale
+
+import { type EventStore } from "@/store/event/types";
+import {
+  type LibrarySymbolInfo,
+  type Timezone,
+  type SearchSymbolResultItem,
+  type DatafeedConfiguration,
+} from "@static/charting_library";
+import { emojisToName } from "lib/utils/emojis-to-name-or-symbol";
+import { EXCHANGE_NAME, TV_CHARTING_LIBRARY_RESOLUTIONS } from "./const";
+import { getClientTimezone } from "lib/chart-utils";
+
+export const CONFIGURATION_DATA: DatafeedConfiguration = {
+  supported_resolutions: TV_CHARTING_LIBRARY_RESOLUTIONS,
+  symbols_types: [
+    {
+      name: "crypto",
+      value: "crypto",
+    },
+  ],
+};
+
+export const searchSymbolsFromRegisteredMarketMap = ({
+  userInput,
+  registeredMarketMap,
+}: {
+  userInput: string;
+  registeredMarketMap: ReturnType<EventStore["getRegisteredMarkets"]>;
+}) =>
+  Array.from(registeredMarketMap.values()).reduce<SearchSymbolResultItem[]>(
+    (acc, { marketMetadata }) => {
+      const marketID = marketMetadata.marketID.toString();
+      const symbol = marketMetadata.symbolData.symbol;
+      const { emojis } = marketMetadata;
+      const symbolForSearch = {
+        description: `Market #${marketID}: ${symbol}`,
+        exchange: EXCHANGE_NAME,
+        full_name: `${EXCHANGE_NAME}:${emojisToName(emojis)}`,
+        symbol,
+        ticker: symbol,
+        type: "crypto",
+      };
+      if (
+        symbolForSearch.full_name.includes(userInput) ||
+        symbolForSearch.symbol.includes(userInput) ||
+        symbolForSearch.ticker.includes(userInput) ||
+        marketID.includes(userInput) ||
+        userInput.includes(marketID)
+      ) {
+        acc.push(symbolForSearch);
+      }
+      return acc;
+    },
+    []
+  );
+
+export const constructLibrarySymbolInfo = (symbol: string): LibrarySymbolInfo => ({
+  ticker: symbol,
+  name: symbol,
+  description: symbol,
+  pricescale: 10 ** 9,
+  volume_precision: -Math.ceil(Math.log10(Number("0.00000100") * Number("100.00000000"))),
+  minmov: 1,
+  exchange: EXCHANGE_NAME,
+  listed_exchange: "",
+  session: "24x7",
+  // Note that `has_empty_bars` causes invalid `time order violation` errors if it's set to `true`.
+  // has_empty_bars: true,
+  has_seconds: false,
+  has_intraday: true,
+  has_daily: true,
+  has_weekly_and_monthly: false,
+  timezone: getClientTimezone() as Timezone,
+  type: "crypto",
+  supported_resolutions: CONFIGURATION_DATA.supported_resolutions,
+  format: "price",
+});


### PR DESCRIPTION
# Description

- [x] Clean up the `PrivateChart.tsx` code.
- [x] Extract function logic to utility functions and make the chart logic/flow easier to understand and change for arena charts.

# Testing

I will compare the contents of the bars in the chart and on-state by comparing market data for the same market, both locally with mainnet indexer data on this branch, and with mainnet indexer data using the `main` branch for the private chart.

I did this by console logging the `bars` value in both builds running concurrently, one on port 3001 and another on port 3002.

I then stored them as variables by right clicking in Chrome, and clicking `Copy as object`. I stored them as `newData` and `oldData`.

Then I did a simple JSON.stringify to compare:

```typescript
JSON.stringify(newData) === JSON.stringify(oldData);
```

![image](https://github.com/user-attachments/assets/5ef5901a-2245-4a0a-8e1c-b28c9797b5c4)


# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

