### PR TITLE
test(ECO-2853): Fix object comparison in e2e tests that accidentally got merged

### DIFF
--- a/src/typescript/sdk/tests/e2e/arena/general/arena.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/general/arena.test.ts
@@ -185,8 +185,6 @@ describe("ensures an arena correctly unfolds and the processor data is accurate"
     const dbEnterEvent = arenaEnters![0];
     let position = arenaPositions![0];
 
-    console.log(dbEnterEvent.enter);
-    console.log(viewEnterEvent);
     expectObjectEqualityExceptEventIndexAndVersion(dbEnterEvent.enter, viewEnterEvent);
 
     expect(position.user).toEqual(viewEnterEvent.user);

--- a/src/typescript/sdk/tests/e2e/arena/general/arena.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/general/arena.test.ts
@@ -42,12 +42,15 @@ const waitForProcessor = <
     PROCESSING_WAIT_TIME
   );
 
-// Ignore `eventIndex` and `version`, since the db models don't have it but view models do.
 const objectKeysWithoutEventIndexAndVersion = (v: object) => {
   const set = new Set(Object.keys(v));
+  // Ignore `eventIndex`, `version`, and `eventName`. The db models don't have it but the views do.
   set.delete("eventIndex");
   set.delete("version");
-  const entries = Array.from(set).map((k) => [k, v[k as keyof typeof v]]);
+  set.delete("eventName");
+  const entries = Array.from(set)
+    .sort()
+    .map((k) => [k, v[k as keyof typeof v]]);
   return Object.fromEntries(entries);
 };
 
@@ -182,6 +185,8 @@ describe("ensures an arena correctly unfolds and the processor data is accurate"
     const dbEnterEvent = arenaEnters![0];
     let position = arenaPositions![0];
 
+    console.log(dbEnterEvent.enter);
+    console.log(viewEnterEvent);
     expectObjectEqualityExceptEventIndexAndVersion(dbEnterEvent.enter, viewEnterEvent);
 
     expect(position.user).toEqual(viewEnterEvent.user);


### PR DESCRIPTION
# Description

Didn't realize SDK tests weren't necessary for merging, so GitHub auto-merged a PR with failing tests.

- [x] Sort keys before comparing object

# Testing

Ensure tests pass, then merge.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

