### PR TITLE
test(ECO-2854): Add `fetchSpecificMarkets` query with chunking and unit/e2e tests

### DIFF
--- a/src/typescript/sdk/src/indexer-v2/queries/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/index.ts
@@ -1,4 +1,5 @@
 export * from "./app";
 export * from "./client";
-export * from "./utils";
+export * from "./misc";
 export * from "./query-params";
+export * from "./utils";

--- a/src/typescript/sdk/src/indexer-v2/queries/misc/fetch-specific-markets.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/misc/fetch-specific-markets.ts
@@ -56,7 +56,7 @@ const MAX_SYMBOLS_PER_FETCH = 100;
 export const fetchSpecificMarkets = async (symbols: SymbolEmoji[][]) => {
   // Log a console warning to note automatic pagination.
   if (symbols.length > MAX_SYMBOLS_PER_FETCH) {
-    console.warn(`More than ${MAX_SYMBOLS_PER_FETCH} were passed to fetchSpecificMarkets.`);
+    console.warn(`More than ${MAX_SYMBOLS_PER_FETCH} symbols were passed to fetchSpecificMarkets.`);
   }
   // Since the symbols are chunked, it's necessary to deduplicate input elements to avoid
   // erroneously returning multiple of the same row from different chunks.

--- a/src/typescript/sdk/src/indexer-v2/queries/misc/fetch-specific-markets.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/misc/fetch-specific-markets.ts
@@ -43,8 +43,10 @@ const MAX_SYMBOLS_PER_FETCH = 100;
  * NOTE: These markets are returned unsorted since they can be sorted post-fetch.
  *
  * NOTE: Due to limitations with the postgrest API, it's possible that an incorrect query value is
- * silently returned once the request URL exceed ~10-11,000 bytes. This query is automatically
- * paginated once the input symbol length exceeds 100.
+ * silently returned once the request URL exceed ~10-11,000 bytes.
+ *
+ * To avoid encountering silently incorrect query results, this function automatically paginates
+ * once the input symbol length exceeds 100.
  *
  * @see {@link toEqClause}
  * @see {@link joinEqClauses}

--- a/src/typescript/sdk/src/indexer-v2/queries/misc/fetch-specific-markets.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/misc/fetch-specific-markets.ts
@@ -1,0 +1,67 @@
+if (process.env.NODE_ENV !== "test") {
+  require("server-only");
+}
+
+import { type SymbolEmoji } from "../../../emoji_data";
+import { chunk } from "../../../utils/misc";
+import { TableName, toMarketStateModel } from "../../types";
+import { postgrest } from "../client";
+
+/**
+ * Based off this working postgrest syntax:
+ * .eq('symbol_emojis.eq.{"👀","👀"}');
+ *
+ * @param emojis ["👀", "👀"]
+ * @returns symbol_emojis.eq.{"👀","👀"}
+ */
+const toEqClause = (emojis: SymbolEmoji[]) => `symbol_emojis.eq.{"${emojis.join('","')}"}`;
+
+/**
+ * Map an array of symbol emojis representing the separated symbol emojis for a market symbol to the
+ * proper `eq.(...)` clause in postgrest.
+ *
+ * @param symbols [["👀","👀"], ["💀"], ["🎲"]]
+ * @returns symbol_emojis.eq.{"👀","👀"},symbol_emojis.eq.{"💀"},symbol_emojis.eq.{"🎲"}
+ */
+export const joinEqClauses = (symbols: SymbolEmoji[][]) => symbols.map(toEqClause).join(",");
+
+/**
+ * @see fetchSpecificMarkets for why this function on its own is potentially unsafe/incorrect.
+ */
+const fetchSpecificMarketsUnsafe = async (symbols: SymbolEmoji[][]) =>
+  await postgrest
+    .from(TableName.MarketState)
+    .select("*")
+    .or(joinEqClauses(symbols))
+    .then((res) => res.data ?? [])
+    .then((res) => res.map(toMarketStateModel));
+
+const MAX_SYMBOLS_PER_FETCH = 100;
+
+/* eslint-disable import/no-unused-modules */
+/**
+ * NOTE: These markets are returned unsorted since they can be sorted post-fetch.
+ *
+ * NOTE: Due to limitations with the postgrest API, it's possible that an incorrect query value is
+ * silently returned once the request URL exceed ~10-11,000 bytes. This query is automatically
+ * paginated once the input symbol length exceeds 100.
+ *
+ * @see {@link toEqClause}
+ * @see {@link joinEqClauses}
+ * @param symbols the market symbols to filter on
+ * @returns the *unsorted* market state data for the market symbols passed in
+ */
+export const fetchSpecificMarkets = async (symbols: SymbolEmoji[][]) => {
+  // Log a console warning to note automatic pagination.
+  if (symbols.length > MAX_SYMBOLS_PER_FETCH) {
+    console.warn(`More than ${MAX_SYMBOLS_PER_FETCH} were passed to fetchSpecificMarkets.`);
+  }
+  // Since the symbols are chunked, it's necessary to deduplicate input elements to avoid
+  // erroneously returning multiple of the same row from different chunks.
+  const mapped = new Map(symbols.map((symbol) => [symbol.join(""), symbol]));
+  const deduped = Array.from(mapped.values());
+  const chunks = chunk(deduped, MAX_SYMBOLS_PER_FETCH);
+  const promises = chunks.map((arr) => fetchSpecificMarketsUnsafe(arr));
+  const flattened = (await Promise.all(promises)).flat();
+  return flattened;
+};

--- a/src/typescript/sdk/src/indexer-v2/queries/misc/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/misc/index.ts
@@ -1,0 +1,1 @@
+export * from "./fetch-specific-markets";

--- a/src/typescript/sdk/src/utils/misc.ts
+++ b/src/typescript/sdk/src/utils/misc.ts
@@ -244,6 +244,19 @@ export function enumerate<T>(arr: T[]): Array<[T, number]> {
 }
 
 /**
+ * Simple utility function to chunk arrays.
+ *
+ * NOTE: This this mutates the array passed in.
+ */
+export function chunk<T>(arr: T[], size: number): T[][] {
+  const res: T[][] = [];
+  while (arr.length) {
+    res.push(arr.splice(0, size));
+  }
+  return res;
+}
+
+/**
  * Extracts elements from an array based on a type predicate and a type guard filter function.
  *
  * This function mutates the original array, removing elements that match

--- a/src/typescript/sdk/tests/e2e/queries/specific-markets.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/specific-markets.test.ts
@@ -1,0 +1,145 @@
+import {
+  chunk,
+  getAptosClient,
+  SYMBOL_EMOJI_DATA,
+  SYMBOL_EMOJIS,
+  toSequenceNumberOptions,
+  type SymbolEmoji,
+} from "../../../src";
+import { EmojicoinClient } from "../../../src/client/emojicoin-client";
+import { fetchSpecificMarkets, waitForEmojicoinIndexer } from "../../../src/indexer-v2";
+import { getFundedAccounts } from "../../utils/test-accounts";
+import { type Account } from "@aptos-labs/ts-sdk";
+
+jest.setTimeout(30000);
+
+/**
+ * @see {@link fetchSpecificMarkets}
+ */
+const MAX_SYMBOLS_PER_FETCH = 100;
+
+const dedupe = (symbols: SymbolEmoji[][]) => {
+  const mapped = new Map(symbols.map((symbol) => [symbol.join(""), symbol]));
+  const deduped = Array.from(mapped.values());
+  return deduped;
+};
+
+const parallelizedRegistrations = async (account: Account, symbols: SymbolEmoji[][]) => {
+  const emojicoin = new EmojicoinClient();
+  const responses = await Promise.all(
+    await getAptosClient()
+      .getAccountInfo({ accountAddress: account.accountAddress })
+      .then((res) => Number(res.sequence_number))
+      .then((sequenceNumber) =>
+        symbols.map((symbol, i) =>
+          emojicoin.register(account, symbol, toSequenceNumberOptions(sequenceNumber + i))
+        )
+      )
+  );
+  const largestVersion = responses
+    .map((v) => BigInt(v.response.version))
+    .sort()
+    .pop()!;
+  expect(largestVersion).toBeDefined();
+  await waitForEmojicoinIndexer(largestVersion);
+};
+
+describe("ensures the fetch specific markets query works as expected", () => {
+  const [acc0, acc1, acc2] = getFundedAccounts("085", "086", "087");
+  it("fetches specific markets", async () => {
+    const allSymbols: SymbolEmoji[][] = [["☝️"], ["☝🏻"], ["☝🏼"], ["☝🏽"], ["☝🏾"], ["☝🏿"]];
+    await parallelizedRegistrations(acc0, allSymbols);
+    const res = await fetchSpecificMarkets(allSymbols);
+    const responseSymbolsSorted = res.map((v) => v.market.symbolData.symbol).sort();
+    const inputSymbolsSorted = allSymbols.map((v) => v.join("")).sort();
+    expect(responseSymbolsSorted).toEqual(inputSymbolsSorted);
+  });
+
+  it("doesn't fail on input markets that don't exist", async () => {
+    const emoji = "🐈‍⬛";
+    expect(SYMBOL_EMOJI_DATA.byEmojiStrict(emoji).bytes.length).toEqual(10);
+    const invalidSymbols: SymbolEmoji[][] = Array.from({ length: 10 }).map((_, i) =>
+      Array.from({ length: i + 2 }).map((_) => emoji)
+    );
+    const res = await fetchSpecificMarkets(invalidSymbols);
+    expect(res).toBeDefined();
+    expect(res.length).toEqual(0);
+  });
+
+  it("fetches specific markets with problematic symbol emojis", async () => {
+    const problematicSymbols: SymbolEmoji[][] = [
+      ["🇺🇸"],
+      ["🇨🇳"],
+      ["#️⃣"],
+      ["0️⃣"],
+      ["9️⃣"],
+      ["©️", "®️"],
+      ["↔️"],
+    ];
+    await parallelizedRegistrations(acc1, problematicSymbols);
+    const res = await fetchSpecificMarkets(problematicSymbols);
+    const responseSymbolsSorted = res.map((v) => v.market.symbolData.symbol).sort();
+    const inputSymbolsSorted = problematicSymbols.map((v) => v.join("")).sort();
+    expect(responseSymbolsSorted).toEqual(inputSymbolsSorted);
+  });
+
+  it("properly chunks an input array with more than 100 symbols", async () => {
+    const fourByteEmojis = Object.keys(SYMBOL_EMOJIS)
+      .map((v) => SYMBOL_EMOJI_DATA.byEmoji(v))
+      .filter((v) => !!v)
+      .filter((v) => v.bytes.length === 4)
+      .map((v) => v.emoji);
+    const s1: SymbolEmoji[] = ["⚽", "✨", "⚾"];
+    const s2: SymbolEmoji[] = ["⚽", "✨", "⚾"];
+    const s3: SymbolEmoji[] = ["⚽", "✨", "⚾"];
+    expect(dedupe([s1, s2, s3])).toHaveLength(3);
+    await parallelizedRegistrations(acc2, [s1, s2, s3]);
+    expect(fourByteEmojis.length).toBeGreaterThanOrEqual(MAX_SYMBOLS_PER_FETCH);
+    // Create 300 unique symbols by appending a symbol to the end. These are invalid symbols,
+    // but they're only used to create a really large set of unique symbols for the URL.
+    const inputs = Array.from(fourByteEmojis.slice(0, MAX_SYMBOLS_PER_FETCH))
+      .map((extraEmoji) => [
+        [...s1, extraEmoji],
+        [...s2, extraEmoji],
+        [...s3, extraEmoji],
+      ])
+      .flat();
+    expect(dedupe(inputs).length).toEqual(inputs.length);
+    expect(inputs).toHaveLength(MAX_SYMBOLS_PER_FETCH * 3);
+    inputs[MAX_SYMBOLS_PER_FETCH * 0] = s1;
+    inputs[MAX_SYMBOLS_PER_FETCH * 1] = s2;
+    inputs[MAX_SYMBOLS_PER_FETCH * 2] = s3;
+    const res = await fetchSpecificMarkets(inputs);
+    expect(res).toHaveLength(3);
+  });
+
+  /**
+   * The chunking and flattening logic used in {@link fetchSpecificMarkets}.
+   */
+  it("unchunks a chunked array", () => {
+    const res = chunk([1, 2, 3, 4, 5, 6, 7], 2);
+    expect(res).toEqual([[1, 2], [3, 4], [5, 6], [7]]);
+    expect(res.flat()).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  /**
+   * The deduplication logic used in {@link fetchSpecificMarkets}.
+   */
+  it("properly deduplicates an input symbol array", () => {
+    const symbols: SymbolEmoji[][] = [
+      ["✨"],
+      ["✨", "⚽"],
+      ["✨", "⚽", "🌯"],
+      ["✨", "⚽", "🌯"],
+      ["✨"],
+      ["✨"],
+      ["✨", "✨"],
+      ["⚽", "🌯", "✨"],
+      ["⚽", "🌯", "✨"],
+    ];
+    const deduped = dedupe(symbols);
+    expect(deduped.sort()).toEqual(
+      [["✨"], ["✨", "⚽"], ["✨", "⚽", "🌯"], ["✨", "✨"], ["⚽", "🌯", "✨"]].sort()
+    );
+  });
+});

--- a/src/typescript/sdk/tests/e2e/queries/specific-markets.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/specific-markets.test.ts
@@ -46,6 +46,7 @@ const parallelizedRegistrations = async (account: Account, symbols: SymbolEmoji[
 
 describe("ensures the fetch specific markets query works as expected", () => {
   const [acc0, acc1, acc2] = getFundedAccounts("085", "086", "087");
+
   it("fetches specific markets", async () => {
     const allSymbols: SymbolEmoji[][] = [["☝️"], ["☝🏻"], ["☝🏼"], ["☝🏽"], ["☝🏾"], ["☝🏿"]];
     await parallelizedRegistrations(acc0, allSymbols);
@@ -89,11 +90,15 @@ describe("ensures the fetch specific markets query works as expected", () => {
       .filter((v) => !!v)
       .filter((v) => v.bytes.length === 4)
       .map((v) => v.emoji);
+
     const s1: SymbolEmoji[] = ["⚽", "✨", "⚾"];
     const s2: SymbolEmoji[] = ["⚽", "✨", "⚾"];
     const s3: SymbolEmoji[] = ["⚽", "✨", "⚾"];
     expect(dedupe([s1, s2, s3])).toHaveLength(3);
+
+    // Register the three markets.
     await parallelizedRegistrations(acc2, [s1, s2, s3]);
+
     expect(fourByteEmojis.length).toBeGreaterThanOrEqual(MAX_SYMBOLS_PER_FETCH);
     // Create 300 unique symbols by appending a symbol to the end. These are invalid symbols,
     // but they're only used to create a really large set of unique symbols for the URL.
@@ -106,9 +111,13 @@ describe("ensures the fetch specific markets query works as expected", () => {
       .flat();
     expect(dedupe(inputs).length).toEqual(inputs.length);
     expect(inputs).toHaveLength(MAX_SYMBOLS_PER_FETCH * 3);
+
+    // Insert the registered markets at the beginning of each eventual chunk.
     inputs[MAX_SYMBOLS_PER_FETCH * 0] = s1;
     inputs[MAX_SYMBOLS_PER_FETCH * 1] = s2;
     inputs[MAX_SYMBOLS_PER_FETCH * 2] = s3;
+
+    // Verify that the query returns exactly the 3 markets.
     const res = await fetchSpecificMarkets(inputs);
     expect(res).toHaveLength(3);
   });
@@ -139,7 +148,15 @@ describe("ensures the fetch specific markets query works as expected", () => {
     ];
     const deduped = dedupe(symbols);
     expect(deduped.sort()).toEqual(
-      [["✨"], ["✨", "⚽"], ["✨", "⚽", "🌯"], ["✨", "✨"], ["⚽", "🌯", "✨"]].sort()
+      [
+        ["✨"],
+        ["✨", "⚽"],
+        ["✨", "⚽", "🌯"],
+        ["✨", "⚽", "🌯"],
+        ["✨", "✨"],
+        ["✨", "✨"],
+        ["⚽", "🌯", "✨"],
+      ].sort()
     );
   });
 });

--- a/src/typescript/sdk/tests/e2e/queries/specific-markets.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/specific-markets.test.ts
@@ -120,6 +120,9 @@ describe("ensures the fetch specific markets query works as expected", () => {
     // Verify that the query returns exactly the 3 markets.
     const res = await fetchSpecificMarkets(inputs);
     expect(res).toHaveLength(3);
+    const uniqueSymbolsInput = dedupe([s1, s2, s3]);
+    const uniqueSymbolsReturned = dedupe(res.map((v) => v.market.symbolEmojis));
+    expect(uniqueSymbolsInput.sort()).toEqual(uniqueSymbolsReturned.sort());
   });
 
   /**

--- a/src/typescript/sdk/tests/e2e/queries/specific-markets.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/specific-markets.test.ts
@@ -92,8 +92,8 @@ describe("ensures the fetch specific markets query works as expected", () => {
       .map((v) => v.emoji);
 
     const s1: SymbolEmoji[] = ["⚽", "✨", "⚾"];
-    const s2: SymbolEmoji[] = ["⚽", "✨", "⚾"];
-    const s3: SymbolEmoji[] = ["⚽", "✨", "⚾"];
+    const s2: SymbolEmoji[] = ["✨", "⚾", "⚽"];
+    const s3: SymbolEmoji[] = ["⚾", "⚽", "✨"];
     expect(dedupe([s1, s2, s3])).toHaveLength(3);
 
     // Register the three markets.
@@ -128,7 +128,7 @@ describe("ensures the fetch specific markets query works as expected", () => {
   /**
    * The chunking and flattening logic used in {@link fetchSpecificMarkets}.
    */
-  it("unchunks a chunked array", () => {
+  it("un-chunks a chunked array", () => {
     const res = chunk([1, 2, 3, 4, 5, 6, 7], 2);
     expect(res).toEqual([[1, 2], [3, 4], [5, 6], [7]]);
     expect(res.flat()).toEqual([1, 2, 3, 4, 5, 6, 7]);
@@ -148,6 +148,8 @@ describe("ensures the fetch specific markets query works as expected", () => {
       ["✨", "✨"],
       ["⚽", "🌯", "✨"],
       ["⚽", "🌯", "✨"],
+      ["⚽", "✨"],
+      ["⚽", "✨"],
     ];
     const deduped = dedupe(symbols);
     expect(deduped.sort()).toEqual(
@@ -155,10 +157,9 @@ describe("ensures the fetch specific markets query works as expected", () => {
         ["✨"],
         ["✨", "⚽"],
         ["✨", "⚽", "🌯"],
-        ["✨", "⚽", "🌯"],
-        ["✨", "✨"],
         ["✨", "✨"],
         ["⚽", "🌯", "✨"],
+        ["⚽", "✨"],
       ].sort()
     );
   });

--- a/src/typescript/sdk/tests/unit/chunk.test.ts
+++ b/src/typescript/sdk/tests/unit/chunk.test.ts
@@ -1,0 +1,37 @@
+import { chunk } from "../../src";
+
+describe("tests simple chunk functionality", () => {
+  it("chunks a simple array correctly", () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5];
+    expect(chunk(arr, 5)).toEqual([
+      [1, 2, 3, 4, 5],
+      [6, 7, 8, 9, 8],
+      [7, 6, 5],
+    ]);
+    expect(arr.length).toBe(0);
+  });
+
+  it("chunks an empty array correctly", () => {
+    const arr: number[] = [];
+    expect(chunk(arr, 2)).toEqual([]);
+    expect(arr.length).toBe(0);
+  });
+
+  it("chunks an array of size one correctly", () => {
+    const arr = [10];
+    expect(chunk(arr, 5)).toEqual([[10]]);
+    expect(arr.length).toBe(0);
+  });
+
+  it("chunks an array with an input size greater than the array correctly", () => {
+    const arr = [1, 2, 3, 4, 5];
+    expect(chunk(arr, 6)).toEqual([[1, 2, 3, 4, 5]]);
+    expect(arr.length).toBe(0);
+  });
+
+  it("chunks lots of single values correctly", () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    expect(chunk(arr, 1)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9].map((v) => [v]));
+    expect(arr.length).toBe(0);
+  });
+});


### PR DESCRIPTION
# Description

Since this query is used in both the stats PR #574 and PR #606, I extracted it out of the stats PR and added tests for it.

@0xForkh tagging you here, feel free to review the PR or just look it over so you can use it in #606 

# Testing

Lots of testing to ensure it works as expected with no errors, even with really large query URLs (with chunking), although the console will log a warning if more than 100 market symbols are passed.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
