### PR TITLE
ci(ECO-2870): Update docs site build to run each PR

### DIFF
--- a/.github/workflows/verify-doc-site-build.yaml
+++ b/.github/workflows/verify-doc-site-build.yaml
@@ -16,9 +16,6 @@ jobs:
 name: 'Verify docs site build'
 'on':
   merge_group: null
-  pull_request:
-    paths:
-    - 'doc/doc-site/**'
-    - '.github/workflows/verify-doc-site-build.yaml'
+  pull_request: null
   workflow_dispatch: null
 ...


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Update the docs site build to run on each PR, so it can easily be used as a required status check. It still takes less time than SDK/pre-commit actions which run in parallel, so it should not inhibit overall CI time.

# Testing

CI
