### PR TITLE
chore(ECO-2872): Move `useLabelScrambler` to a sensible location

### DIFF
--- a/src/typescript/frontend/src/components/FormattedNumber.tsx
+++ b/src/typescript/frontend/src/components/FormattedNumber.tsx
@@ -1,5 +1,5 @@
 import type { AnyNumberString } from "@sdk-types";
-import { useLabelScrambler } from "./pages/home/components/table-card/animation-variants/event-variants";
+import { useLabelScrambler } from "@hooks/use-label-scrambler";
 import { toNominal } from "lib/utils/decimals";
 import { useEffect, useMemo } from "react";
 

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/event-variants.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/event-variants.ts
@@ -12,7 +12,6 @@ import {
   type SwapEventModel,
 } from "@sdk/indexer-v2/types";
 import { ECONIA_BLUE, GREEN, PINK, WHITE } from "theme/colors";
-import { useScramble } from "use-scramble";
 
 export const transitionIn = {
   duration: 0,
@@ -114,40 +113,6 @@ export const onlyHoverVariant = {
     borderColor: ECONIA_BLUE,
     transition: transitionIn,
   },
-};
-
-export type RangeCharCodes = {
-  0: number;
-  1: number;
-} & Array<number>;
-
-export const scrambleConfig = {
-  // ASCII numbers only.
-  range: [48, 57] as RangeCharCodes,
-  overdrive: false,
-  overflow: true,
-  speed: 0.6,
-  playOnMount: true,
-};
-
-export const useLabelScrambler = (value: string, suffix: string = "", prefix: string = "") => {
-  // Ignore all characters in the prefix and the suffix, as long as they are not numbers.
-  const ignore = ["."];
-  const numberSet = new Set("0123456789");
-  const suffixesAndPrefixes = new Set(prefix + suffix);
-  for (const char of suffixesAndPrefixes) {
-    if (!numberSet.has(char)) {
-      ignore.push(char);
-    }
-  }
-
-  const scrambler = useScramble({
-    text: prefix + value + suffix,
-    ...scrambleConfig,
-    ignore,
-  });
-
-  return scrambler;
 };
 
 export const eventToVariant = (

--- a/src/typescript/frontend/src/hooks/use-label-scrambler.ts
+++ b/src/typescript/frontend/src/hooks/use-label-scrambler.ts
@@ -1,0 +1,30 @@
+import { useScramble } from "use-scramble";
+
+const scrambleConfig = {
+  // ASCII numbers only.
+  range: [48, 57] as [number, number],
+  overdrive: false,
+  overflow: true,
+  speed: 0.6,
+  playOnMount: true,
+};
+
+export const useLabelScrambler = (value: string, suffix: string = "", prefix: string = "") => {
+  // Ignore all characters in the prefix and the suffix, as long as they are not numbers.
+  const ignore = ["."];
+  const numberSet = new Set("0123456789");
+  const suffixesAndPrefixes = new Set(prefix + suffix);
+  for (const char of suffixesAndPrefixes) {
+    if (!numberSet.has(char)) {
+      ignore.push(char);
+    }
+  }
+
+  const scrambler = useScramble({
+    text: prefix + value + suffix,
+    ...scrambleConfig,
+    ignore,
+  });
+
+  return scrambler;
+};


### PR DESCRIPTION
# Description

- [x] Move `useLabelScrambler` to a proper location in `@hooks`
- [x] Nothing changed other than removing an unnecessary type definition, just used `[number, number]` instead of `RangeCharCodes`

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

