### PR TITLE
feat(ECO-2874): Add arena broker events to the state store [2/4]

### DIFF
--- a/src/rust/broker/README.md
+++ b/src/rust/broker/README.md
@@ -44,14 +44,18 @@ Arena events don't follow the same rules as the other subscriptions.
 To subscribe to arena events, simply pass `{ "arena": true }`. The default value
 is `false`; i.e., no subscription to arena events.
 
+To subscribe to arena candlesticks, pass `{ "arena_candlesticks": true }`. The
+default value is `false`.
+
 ```json5
 // Subscribe to every single event type.
-{ "arena": true, "markets": [], "event_types": [] }
+{ "arena": true, "arena_candlesticks": true, "markets": [], "event_types": [] }
 
 // Subscribe to all non-arena event types.
-// Both of the JSON objects below are equivalent.
+// All of the JSON objects below are equivalent.
 { "markets": [], "event_types": [] }
 { "arena": false, "markets": [], "event_types": [] }
+{ "arena_candlesticks": false, "markets": [], "event_types": [] }
 ```
 
 ### All markets, all non-arena event types

--- a/src/rust/broker/src/types.rs
+++ b/src/rust/broker/src/types.rs
@@ -21,4 +21,6 @@ pub struct Subscription {
     pub event_types: Vec<EmojicoinDbEventType>,
     #[serde(default)]
     pub arena: bool,
+    #[serde(default)]
+    pub arena_candlesticks: bool,
 }

--- a/src/rust/broker/src/util.rs
+++ b/src/rust/broker/src/util.rs
@@ -37,6 +37,7 @@ pub fn is_match(subscription: &Subscription, event: &EmojicoinDbEvent) -> bool {
         EmojicoinDbEventType::ArenaMelee => subscription.arena,
         EmojicoinDbEventType::ArenaSwap => subscription.arena,
         EmojicoinDbEventType::ArenaVaultBalanceUpdate => subscription.arena,
+        EmojicoinDbEventType::ArenaCandlestick => subscription.arena_candlesticks,
         EmojicoinDbEventType::GlobalState => {
             subscription.event_types.is_empty() || subscription.event_types.contains(&event_type)
         }

--- a/src/typescript/frontend/src/app/api/candlesticks/search-params-schema.ts
+++ b/src/typescript/frontend/src/app/api/candlesticks/search-params-schema.ts
@@ -10,11 +10,11 @@ export const CandlesticksSearchParamsSchema = z.object({
 });
 
 /**
- * The search params used in the `GET` request at `candlesticks/api`.
+ * The search params used in the `GET` request at `/api/candlesticks`.
  *
- * @property {string} marketID      - The market ID.
- * @property {string} to            - The end time boundary.
- * @property {string} countBack     - The `countBack` value requested by the datafeed API.
- * @property {string} period        - The {@link Period}.
+ * @property {string} marketID      - A number string, as the market ID.
+ * @property {string} to            - A number string, as the end time boundary as a UNIX timestamp.
+ * @property {string} countBack     - A number string, as `countBack` requested by the datafeed API.
+ * @property {string} period        - A string representing the {@link Period}.
  */
 export type CandlesticksSearchParams = z.infer<typeof CandlesticksSearchParamsSchema>;

--- a/src/typescript/frontend/src/app/home/HomePage.tsx
+++ b/src/typescript/frontend/src/app/home/HomePage.tsx
@@ -1,3 +1,4 @@
+import { SubscribeToHomePageEvents } from "@/components/pages/home/components/SubscribeToHomePageEvents";
 import { ARENA_MODULE_ADDRESS } from "@sdk/const";
 import {
   type ArenaInfoModel,
@@ -67,6 +68,7 @@ export default async function HomePageComponent({
         sortBy={sortBy}
         searchBytes={searchBytes}
       />
+      <SubscribeToHomePageEvents info={meleeData?.melee} />
     </div>
   );
 }

--- a/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
@@ -15,6 +15,7 @@ import {
   type ArenaPositionModel,
 } from "@sdk/indexer-v2/types";
 import { ROUTES } from "router/routes";
+import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
 
 const RewardsRemainingBox = ({ rewardsRemaining }: { rewardsRemaining: bigint }) => {
   const { isMobile } = useMatchBreakpoints();
@@ -96,6 +97,8 @@ export const ArenaClient = (props: ArenaProps) => {
   // Undefined while loading. Null means no position
   const [position, setPosition] = useState<ArenaPositionModel | undefined | null>(null);
   const [history, setHistory] = useState<ArenaLeaderboardHistoryWithArenaInfoModel[]>([]);
+
+  useReliableSubscribe({ eventTypes: ["Swap"], arena: true, arenaCandlesticks: true });
 
   const r = useMemo(
     () =>

--- a/src/typescript/frontend/src/components/pages/home/components/SubscribeToHomePageEvents.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/SubscribeToHomePageEvents.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
+import { type ArenaInfoModel } from "@sdk/indexer-v2";
+import { useEventStore } from "context/event-store-context";
+import { useEffect } from "react";
+
+export const SubscribeToHomePageEvents = ({ info }: { info?: ArenaInfoModel }) => {
+  const loadArenaInfoFromServer = useEventStore((s) => s.loadArenaInfoFromServer);
+  useEffect(() => {
+    if (info) {
+      loadArenaInfoFromServer(info);
+    }
+  }, [loadArenaInfoFromServer, info]);
+
+  useReliableSubscribe({
+    arena: true,
+    eventTypes: ["MarketLatestState"],
+  });
+
+  return <></>;
+};

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
@@ -31,7 +31,6 @@ import { Text } from "components/text";
 import Link from "next/link";
 import { ROUTES } from "router/routes";
 import { type HomePageProps } from "app/home/HomePage";
-import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
 import { SortMarketsBy } from "@sdk/indexer-v2/types/common";
 import { Emoji } from "utils/emoji";
 
@@ -98,10 +97,6 @@ const EmojiTable = (props: EmojiTableProps) => {
   );
 
   const rowLength = useGridRowLength();
-
-  useReliableSubscribe({
-    eventTypes: ["MarketLatestState"],
-  });
 
   return (
     <>

--- a/src/typescript/frontend/src/hooks/use-latest-melee-id.ts
+++ b/src/typescript/frontend/src/hooks/use-latest-melee-id.ts
@@ -1,0 +1,17 @@
+import { useEventStore } from "context/event-store-context";
+import { useMemo } from "react";
+
+export const useLatestMeleeID = () => {
+  const melees = useEventStore((s) => s.meleeEvents);
+
+  const latest = useMemo(
+    () =>
+      melees
+        .map(({ melee }) => melee.meleeID)
+        .sort()
+        .at(-1) ?? -1n,
+    [melees]
+  );
+
+  return latest;
+};

--- a/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
+++ b/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
@@ -15,28 +15,18 @@ export const useReliableSubscribe = (args: ReliableSubscribeArgs) => {
   const { eventTypes, arena } = args;
   const subscribeEvents = useEventStore((s) => s.subscribeEvents);
   const unsubscribeEvents = useEventStore((s) => s.unsubscribeEvents);
-  const subscribeArena = useEventStore((s) => s.subscribeArena);
-  const unsubscribeArena = useEventStore((s) => s.unsubscribeArena);
 
   useEffect(() => {
     // Don't subscribe right away, to let other components unmounting time to unsubscribe, that way
     // components unmounting don't undo/overwrite another component subscribing.
     const timeout = window.setTimeout(() => {
-      subscribeEvents(eventTypes);
-      if (arena) {
-        subscribeArena();
-      } else {
-        unsubscribeArena();
-      }
+      subscribeEvents(eventTypes, arena);
     }, 250);
 
     // Unsubscribe from all topics passed into the hook when the component unmounts.
     return () => {
       clearTimeout(timeout);
-      unsubscribeEvents(eventTypes);
-      if (arena) {
-        unsubscribeArena();
-      }
+      unsubscribeEvents(eventTypes, arena);
     };
-  }, [eventTypes, arena, subscribeEvents, unsubscribeEvents, subscribeArena, unsubscribeArena]);
+  }, [eventTypes, arena, subscribeEvents, unsubscribeEvents]);
 };

--- a/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
+++ b/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 export type ReliableSubscribeArgs = {
   eventTypes: Array<SubscribableBrokerEvents>;
   arena?: boolean;
+  arenaCandlesticks?: boolean;
 };
 
 /**
@@ -12,7 +13,7 @@ export type ReliableSubscribeArgs = {
  * mounted. It automatically cleans up subscriptions when the component is unmounted.
  */
 export const useReliableSubscribe = (args: ReliableSubscribeArgs) => {
-  const { eventTypes, arena } = args;
+  const { eventTypes, arena, arenaCandlesticks } = args;
   const subscribeEvents = useEventStore((s) => s.subscribeEvents);
   const unsubscribeEvents = useEventStore((s) => s.unsubscribeEvents);
 
@@ -20,13 +21,19 @@ export const useReliableSubscribe = (args: ReliableSubscribeArgs) => {
     // Don't subscribe right away, to let other components unmounting time to unsubscribe, that way
     // components unmounting don't undo/overwrite another component subscribing.
     const timeout = window.setTimeout(() => {
-      subscribeEvents(eventTypes, arena);
+      subscribeEvents(eventTypes, {
+        baseEvents: arena,
+        candlesticks: arenaCandlesticks,
+      });
     }, 250);
 
     // Unsubscribe from all topics passed into the hook when the component unmounts.
     return () => {
       clearTimeout(timeout);
-      unsubscribeEvents(eventTypes, arena);
+      unsubscribeEvents(eventTypes, {
+        baseEvents: arena,
+        candlesticks: arenaCandlesticks,
+      });
     };
-  }, [eventTypes, arena, subscribeEvents, unsubscribeEvents]);
+  }, [eventTypes, arena, arenaCandlesticks, subscribeEvents, unsubscribeEvents]);
 };

--- a/src/typescript/frontend/src/lib/store/arena/store.ts
+++ b/src/typescript/frontend/src/lib/store/arena/store.ts
@@ -1,0 +1,36 @@
+import {
+  type ArenaMeleeModel,
+  type ArenaEnterModel,
+  type ArenaExitModel,
+  type ArenaSwapModel,
+  type ArenaInfoModel,
+} from "@sdk/indexer-v2";
+import { type WritableDraft } from "immer";
+
+export type MeleeState = {
+  swaps: readonly ArenaSwapModel[];
+  enters: readonly ArenaEnterModel[];
+  exits: readonly ArenaExitModel[];
+};
+
+export type ArenaState = {
+  arenaInfoFromServer?: ArenaInfoModel;
+  meleeEvents: readonly ArenaMeleeModel[];
+  melees: Readonly<Map<bigint, MeleeState>>;
+};
+
+export type ArenaActions = {
+  loadArenaInfoFromServer: (info: ArenaInfoModel) => void;
+};
+
+export const createInitialMeleeState = (): WritableDraft<MeleeState> => ({
+  swaps: [],
+  enters: [],
+  exits: [],
+});
+
+export const initializeArenaStore = (): ArenaState => ({
+  arenaInfoFromServer: undefined,
+  meleeEvents: [],
+  melees: new Map(),
+});

--- a/src/typescript/frontend/src/lib/store/arena/utils.ts
+++ b/src/typescript/frontend/src/lib/store/arena/utils.ts
@@ -1,0 +1,67 @@
+import { type MarketEmojiData, toMarketEmojiData } from "@sdk/emoji_data";
+import { type AccountAddressString } from "@sdk/emojicoin_dot_fun";
+import {
+  type ArenaEventModels,
+  type ArenaVaultBalanceUpdateModel,
+  type ArenaInfoModel,
+  type ArenaEventModelWithMeleeID,
+} from "@sdk/indexer-v2";
+import { isArenaEnterModel, isArenaExitModel, isArenaMeleeModel } from "@sdk/types/arena-types";
+
+export type ArenaMarketPair = {
+  market0: {
+    marketID: bigint;
+    marketAddress: AccountAddressString;
+    symbol: string;
+  } & MarketEmojiData;
+  market1: {
+    marketID: bigint;
+    marketAddress: AccountAddressString;
+    symbol: string;
+  } & MarketEmojiData;
+};
+
+export const toArenaMarketPair = (info: ArenaInfoModel): ArenaMarketPair => {
+  const symbol0 = info.emojicoin0Symbols.join("");
+  const symbol1 = info.emojicoin1Symbols.join("");
+  return {
+    market0: {
+      marketID: info.emojicoin0MarketID,
+      marketAddress: info.emojicoin0MarketAddress,
+      symbol: symbol0,
+      ...toMarketEmojiData(symbol0),
+    },
+    market1: {
+      marketID: info.emojicoin1MarketID,
+      marketAddress: info.emojicoin1MarketAddress,
+      symbol: symbol1,
+      ...toMarketEmojiData(symbol1),
+    },
+  };
+};
+
+export const toMappedMelees = <T extends ArenaEventModelWithMeleeID>(models: T[]) => {
+  const map = new Map<bigint, T[]>();
+
+  models.forEach((model) => {
+    const id = getMeleeIDFromArenaModel(model);
+    if (!map.has(id)) {
+      map.set(id, []);
+    }
+    map.get(id)!.push(model);
+  });
+  return map;
+};
+
+export const getMeleeIDFromArenaModel = (
+  model: Exclude<ArenaEventModels, ArenaVaultBalanceUpdateModel>
+): bigint => {
+  if (isArenaMeleeModel(model)) {
+    return model.melee.meleeID;
+  } else if (isArenaEnterModel(model)) {
+    return model.enter.meleeID;
+  } else if (isArenaExitModel(model)) {
+    return model.exit.meleeID;
+  }
+  return model.swap.meleeID;
+};

--- a/src/typescript/frontend/src/lib/store/event/types.ts
+++ b/src/typescript/frontend/src/lib/store/event/types.ts
@@ -9,6 +9,8 @@ import { type SubscribeBarsCallback } from "@static/charting_library/datafeed-ap
 import { type LatestBar } from "./candlestick-bars";
 import { type WritableDraft } from "immer";
 import { type ClientState, type ClientActions } from "../websocket/store";
+import { type ArenaActions, type ArenaState } from "../arena/store";
+import { type Flatten } from "@sdk-types";
 
 // Aliased to avoid repeating the type names over and over.
 type Swap = DatabaseModels["swap_events"];
@@ -28,8 +30,12 @@ export type CandlestickData = {
   latestBar: LatestBar | undefined;
 };
 
+export type MarketStoreMetadata = Flatten<
+  Omit<MarketMetadataModel, "time" | "marketNonce" | "trigger">
+>;
+
 export type MarketEventStore = {
-  marketMetadata: MarketMetadataModel;
+  marketMetadata: MarketStoreMetadata;
   dailyVolume?: bigint;
   swapEvents: readonly Swap[];
   liquidityEvents: readonly Liquidity[];
@@ -59,7 +65,7 @@ export type PeriodSubscription = {
 };
 
 export type SetLatestBarsArgs = {
-  marketMetadata: MarketMetadataModel;
+  marketMetadata: MarketStoreMetadata;
   latestBars: readonly LatestBar[];
 };
 
@@ -74,9 +80,13 @@ export type EventActions = {
   unsubscribeFromPeriod: ({ marketEmojis, period }: Omit<PeriodSubscription, "cb">) => void;
 };
 
-export type EventStore = EventState & EventActions;
+export type EventStore = EventState & EventActions & ArenaState & ArenaActions;
 
-export type EventAndClientStore = EventState & EventActions & ClientState & ClientActions;
+export type EventAndClientStore = EventState &
+  EventActions &
+  ClientState &
+  ClientActions &
+  ArenaState;
 
 export type ImmerSetEventAndClientStore = (
   nextStateOrUpdater:

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -1,9 +1,13 @@
 import { Period, PERIODS, periodEnumToRawDuration } from "@sdk/const";
 import { type SubscribeBarsCallback } from "@static/charting_library/datafeed-api";
 import { type WritableDraft } from "immer";
-import { type EventState, type CandlestickData, type MarketEventStore } from "./types";
 import {
-  type MarketMetadataModel,
+  type EventState,
+  type CandlestickData,
+  type MarketEventStore,
+  type MarketStoreMetadata,
+} from "./types";
+import {
   type PeriodicStateEventModel,
   type SwapEventModel,
   type DatabaseModels,
@@ -11,8 +15,8 @@ import {
 } from "@sdk/indexer-v2/types";
 import { getPeriodStartTimeFromTime } from "@sdk/utils";
 import { createBarFromPeriodicState, createBarFromSwap, type LatestBar } from "./candlestick-bars";
-import { q64ToBig } from "@sdk/utils/nominal-price";
-import { toNominal } from "@sdk/utils";
+import { q64ToBig, toNominal } from "@sdk/utils/nominal-price";
+import { type ArenaState, createInitialMeleeState } from "../arena/store";
 
 type PeriodicState = DatabaseModels["periodic_state_events"];
 
@@ -23,7 +27,7 @@ export const createInitialCandlestickData = (): WritableDraft<CandlestickData> =
 });
 
 export const createInitialMarketState = (
-  marketMetadata: MarketMetadataModel
+  marketMetadata: MarketStoreMetadata
 ): WritableDraft<MarketEventStore> => ({
   marketMetadata,
   swapEvents: [],
@@ -41,11 +45,17 @@ export const createInitialMarketState = (
 
 export const ensureMarketInStore = (
   state: WritableDraft<EventState>,
-  market: MarketMetadataModel
+  market: MarketStoreMetadata
 ) => {
   const key = market.symbolData.symbol;
   if (!state.markets.has(key)) {
     state.markets.set(key, createInitialMarketState(market));
+  }
+};
+
+export const ensureMeleeInStore = (state: WritableDraft<ArenaState>, meleeID: bigint) => {
+  if (!state.melees.has(meleeID)) {
+    state.melees.set(meleeID, createInitialMeleeState());
   }
 };
 

--- a/src/typescript/frontend/src/lib/store/websocket/store.ts
+++ b/src/typescript/frontend/src/lib/store/websocket/store.ts
@@ -19,10 +19,8 @@ export type ClientState = {
 
 export type ClientActions = {
   close: () => void;
-  subscribeEvents: (events: SubscribableBrokerEvents[]) => void;
-  unsubscribeEvents: (events: SubscribableBrokerEvents[]) => void;
-  subscribeArena: () => void;
-  unsubscribeArena: () => void;
+  subscribeEvents: (events: SubscribableBrokerEvents[], arena?: boolean) => void;
+  unsubscribeEvents: (events: SubscribableBrokerEvents[], arena?: boolean) => void;
 };
 
 export type WebSocketClientStore = ClientState & ClientActions;
@@ -83,28 +81,18 @@ export const createWebSocketClientStore = (
   close: () => {
     get().client.client.close();
   },
-  subscribeEvents: (e) => {
+  subscribeEvents: (e, arena) => {
     set((state) => {
-      state.client.subscribeEvents(e);
+      state.client.subscribeEvents(e, arena);
+      state.subscriptions.arena = !!arena;
       state.subscriptions = state.client.subscriptions;
     });
   },
-  unsubscribeEvents: (e) => {
+  unsubscribeEvents: (e, arena) => {
     set((state) => {
-      state.client.unsubscribeEvents(e);
+      state.client.unsubscribeEvents(e, arena);
+      state.subscriptions.arena = !!arena;
       state.subscriptions = state.client.subscriptions;
-    });
-  },
-  subscribeArena: () => {
-    set((state) => {
-      state.client.subscribeArena();
-      state.subscriptions.arena = true;
-    });
-  },
-  unsubscribeArena: () => {
-    set((state) => {
-      state.client.unsubscribeArena();
-      state.subscriptions.arena = false;
     });
   },
 });

--- a/src/typescript/frontend/src/lib/store/websocket/store.ts
+++ b/src/typescript/frontend/src/lib/store/websocket/store.ts
@@ -19,8 +19,14 @@ export type ClientState = {
 
 export type ClientActions = {
   close: () => void;
-  subscribeEvents: (events: SubscribableBrokerEvents[], arena?: boolean) => void;
-  unsubscribeEvents: (events: SubscribableBrokerEvents[], arena?: boolean) => void;
+  subscribeEvents: (
+    events: SubscribableBrokerEvents[],
+    arena?: { baseEvents?: boolean; candlesticks?: boolean }
+  ) => void;
+  unsubscribeEvents: (
+    events: SubscribableBrokerEvents[],
+    arena?: { baseEvents?: boolean; candlesticks?: boolean }
+  ) => void;
 };
 
 export type WebSocketClientStore = ClientState & ClientActions;
@@ -52,6 +58,7 @@ export const createWebSocketClientStore = (
     marketIDs: new Set(),
     eventTypes: new Set(),
     arena: false,
+    arenaCandlesticks: false,
   },
   received: 0,
   client: getSingletonClient({
@@ -84,14 +91,16 @@ export const createWebSocketClientStore = (
   subscribeEvents: (e, arena) => {
     set((state) => {
       state.client.subscribeEvents(e, arena);
-      state.subscriptions.arena = !!arena;
+      state.subscriptions.arena = !!arena?.baseEvents;
+      state.subscriptions.arenaCandlesticks = !!arena?.candlesticks;
       state.subscriptions = state.client.subscriptions;
     });
   },
   unsubscribeEvents: (e, arena) => {
     set((state) => {
       state.client.unsubscribeEvents(e, arena);
-      state.subscriptions.arena = !!arena;
+      state.subscriptions.arena = !!arena?.baseEvents;
+      state.subscriptions.arenaCandlesticks = !!arena?.candlesticks;
       state.subscriptions = state.client.subscriptions;
     });
   },

--- a/src/typescript/sdk/src/broker-v2/types.ts
+++ b/src/typescript/sdk/src/broker-v2/types.ts
@@ -4,6 +4,7 @@ import {
   type DatabaseJsonType,
   TableName,
 } from "../indexer-v2/types/json-types";
+import { type ARENA_CANDLESTICK_NAME } from "../types/arena-types";
 import { type AnyNumberString } from "../types/types";
 
 export type BrokerEvent = SubscribableBrokerEvents | BrokerArenaEvent;
@@ -22,7 +23,8 @@ type BrokerArenaEvent =
   | "ArenaExit"
   | "ArenaMelee"
   | "ArenaSwap"
-  | "ArenaVaultBalanceUpdate";
+  | "ArenaVaultBalanceUpdate"
+  | typeof ARENA_CANDLESTICK_NAME;
 
 const Chat = TableName.ChatEvents;
 const Swap = TableName.SwapEvents;
@@ -36,6 +38,7 @@ const ArenaExit = TableName.ArenaExitEvents;
 const ArenaMelee = TableName.ArenaMeleeEvents;
 const ArenaSwap = TableName.ArenaSwapEvents;
 const ArenaVaultBalanceUpdate = TableName.ArenaVaultBalanceUpdateEvents;
+const ArenaCandlestick = TableName.ArenaCandlesticks;
 type ChatType = DatabaseJsonType[typeof Chat];
 type SwapType = DatabaseJsonType[typeof Swap];
 type LiquidityType = DatabaseJsonType[typeof Liquidity];
@@ -48,6 +51,7 @@ type ArenaExitType = DatabaseJsonType[typeof ArenaExit];
 type ArenaMeleeType = DatabaseJsonType[typeof ArenaMelee];
 type ArenaSwapType = DatabaseJsonType[typeof ArenaSwap];
 type ArenaVaultBalanceUpdateType = DatabaseJsonType[typeof ArenaVaultBalanceUpdate];
+type ArenaCandlestickType = DatabaseJsonType[typeof ArenaCandlestick];
 
 export const brokerMessageConverter: Record<BrokerEvent, (data: unknown) => BrokerEventModels> = {
   Chat: (d) => DatabaseTypeConverter[Chat](d as ChatType),
@@ -63,6 +67,7 @@ export const brokerMessageConverter: Record<BrokerEvent, (data: unknown) => Brok
   ArenaSwap: (d) => DatabaseTypeConverter[ArenaSwap](d as ArenaSwapType),
   ArenaVaultBalanceUpdate: (d) =>
     DatabaseTypeConverter[ArenaVaultBalanceUpdate](d as ArenaVaultBalanceUpdateType),
+  ArenaCandlestick: (d) => DatabaseTypeConverter[ArenaCandlestick](d as ArenaCandlestickType),
 };
 
 /**
@@ -79,6 +84,7 @@ export type SubscriptionMessage = {
   markets: number[];
   event_types: BrokerEvent[];
   arena: boolean;
+  arena_candlesticks: boolean;
 };
 
 /* eslint-disable-next-line import/no-unused-modules */
@@ -86,4 +92,5 @@ export type WebSocketSubscriptions = {
   marketIDs: Set<AnyNumberString>;
   eventTypes: Set<BrokerEvent>;
   arena: boolean;
+  arenaCandlesticks: boolean;
 };

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -1017,7 +1017,8 @@ export type BrokerEventModels =
   | DatabaseModels[TableName.ArenaMeleeEvents]
   | DatabaseModels[TableName.ArenaExitEvents]
   | DatabaseModels[TableName.ArenaSwapEvents]
-  | DatabaseModels[TableName.ArenaVaultBalanceUpdateEvents];
+  | DatabaseModels[TableName.ArenaVaultBalanceUpdateEvents]
+  | DatabaseModels[TableName.ArenaCandlesticks];
 
 export type EventModelWithMarket =
   | DatabaseModels[TableName.SwapEvents]

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -1088,6 +1088,16 @@ export const isEventModelWithMarket = (data: BrokerEventModels): data is EventMo
   isMarketStateModel(data) ||
   isLiquidityEventModel(data);
 
+/**
+ * Event models that are emitted in a transaction and thus always have transaction metadata.
+ */
+export type TransactionEventModels = Extract<
+  BrokerEventModels,
+  { transaction: TransactionMetadata }
+>;
+export const isTransactionEventModel = (data: BrokerEventModels): data is TransactionEventModels =>
+  "transaction" in data;
+
 export * from "./common";
 export * from "./json-types";
 export * from "./postgres-numeric-types";

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -1027,6 +1027,15 @@ export type EventModelWithMarket =
   | DatabaseModels[TableName.MarketLatestStateEvent]
   | DatabaseModels[TableName.LiquidityEvents];
 
+export type ArenaEventModels =
+  | DatabaseModels[TableName.ArenaEnterEvents]
+  | DatabaseModels[TableName.ArenaMeleeEvents]
+  | DatabaseModels[TableName.ArenaExitEvents]
+  | DatabaseModels[TableName.ArenaSwapEvents]
+  | DatabaseModels[TableName.ArenaVaultBalanceUpdateEvents];
+
+export type ArenaEventModelWithMeleeID = Exclude<ArenaEventModels, ArenaVaultBalanceUpdateModel>;
+
 const extractEventType = (guid: string) => {
   const match = guid.match(/^.*::(\w+)::/u);
   return match ? match[1] : null;

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -10,7 +10,9 @@ import {
   type ArenaVaultBalanceUpdateModel,
   type ArenaEventModels,
   type ArenaEventModelWithMeleeID,
-} from "../indexer-v2";
+  type ArenaCandlestickModel,
+  // Note that if you import anything more than a type here, you'll get lots of import issues.
+} from "../indexer-v2/types";
 import { postgresTimestampToDate } from "../indexer-v2/types/json-types";
 import { dateFromMicroseconds, toAccountAddressString } from "../utils";
 import type JsonTypes from "./json-types";
@@ -360,16 +362,19 @@ export const isArenaMeleeModel = (e: BrokerEventModels): e is ArenaMeleeModel =>
 export const isArenaSwapModel = (e: BrokerEventModels): e is ArenaSwapModel =>
   e.eventName === "ArenaSwap";
 
+export const isArenaCandlestickModel = (e: BrokerEventModels): e is ArenaCandlestickModel =>
+  e.eventName === ARENA_CANDLESTICK_NAME;
+
 export const isArenaVaultBalanceUpdateModel = (
   e: BrokerEventModels
 ): e is ArenaVaultBalanceUpdateModel => e.eventName === "ArenaVaultBalanceUpdate";
-
-/* eslint-enable import/no-unused-modules */
-
-export const isArenaEventModel = (e: BrokerEventModels): e is ArenaEventModels =>
-  isArenaEventModelWithMeleeID(e) || isArenaVaultBalanceUpdateModel(e);
 
 export const isArenaEventModelWithMeleeID = (
   e: BrokerEventModels
 ): e is ArenaEventModelWithMeleeID =>
   isArenaEnterModel(e) || isArenaExitModel(e) || isArenaMeleeModel(e) || isArenaSwapModel(e);
+
+export const isArenaEventModel = (e: BrokerEventModels): e is ArenaEventModels =>
+  isArenaEventModelWithMeleeID(e) || isArenaVaultBalanceUpdateModel(e);
+
+/* eslint-enable import/no-unused-modules */

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -8,6 +8,8 @@ import {
   type ArenaMeleeModel,
   type ArenaSwapModel,
   type ArenaVaultBalanceUpdateModel,
+  type ArenaEventModels,
+  type ArenaEventModelWithMeleeID,
 } from "../indexer-v2";
 import { postgresTimestampToDate } from "../indexer-v2/types/json-types";
 import { dateFromMicroseconds, toAccountAddressString } from "../utils";
@@ -363,3 +365,11 @@ export const isArenaVaultBalanceUpdateModel = (
 ): e is ArenaVaultBalanceUpdateModel => e.eventName === "ArenaVaultBalanceUpdate";
 
 /* eslint-enable import/no-unused-modules */
+
+export const isArenaEventModel = (e: BrokerEventModels): e is ArenaEventModels =>
+  isArenaEventModelWithMeleeID(e) || isArenaVaultBalanceUpdateModel(e);
+
+export const isArenaEventModelWithMeleeID = (
+  e: BrokerEventModels
+): e is ArenaEventModelWithMeleeID =>
+  isArenaEnterModel(e) || isArenaExitModel(e) || isArenaMeleeModel(e) || isArenaSwapModel(e);

--- a/src/typescript/sdk/tests/e2e/broker/utils.ts
+++ b/src/typescript/sdk/tests/e2e/broker/utils.ts
@@ -97,12 +97,14 @@ export const subscribe = (
   client: WebSocket,
   markets: AnyNumberString[],
   eventTypes: SubscribableBrokerEvents[],
-  arena: boolean = false
+  arena: boolean = false,
+  arenaCandlesticks: boolean = false
 ) => {
   const outgoingMessage: SubscriptionMessage = {
     markets: markets.map((n) => Number(n)),
     event_types: eventTypes,
     arena,
+    arena_candlesticks: arenaCandlesticks,
   };
   const json = JSON.stringify(outgoingMessage);
   client.send(json);


### PR DESCRIPTION
# Description

This PR adds arena broker events to the global state store (`zustand` implementation).

This allows us to detect when new melees begin and in general when any arena event happens in the frontend in the form of an event-driven pubsub architecture

It also previously merged the arena candlesticks additions as well (originally a separate PR).

- [x] Add arena broker events to the global state store
- [x] Add arena candlesticks to the global state store as well
- [x] Add the ability to subscribe to arena events and arena candlesticks (separately)
- [x] Update the `README` for subscribing with the JSON message you need to send to the broker
- [x] Add a `useLatestMeleeID` hook that can help detect when a new melee has started

# Testing

Using in all my PRs, manual testing.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
