### PR TITLE
fix(ECO-2910): Export the broker client and indexer types properly to the SDK

### DIFF
--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -117,5 +117,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.5.1"
+  "version": "0.5.2"
 }

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -117,5 +117,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -117,5 +117,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.5.2"
+  "version": "0.5.2-rc.1"
 }

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -117,5 +117,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.5.2-rc.1"
+  "version": "0.5.2"
 }

--- a/src/typescript/sdk/src/broker-v2/index.ts
+++ b/src/typescript/sdk/src/broker-v2/index.ts
@@ -1,0 +1,2 @@
+export * from "./client";
+export * from "./types";

--- a/src/typescript/sdk/src/client/emojicoin-client.ts
+++ b/src/typescript/sdk/src/client/emojicoin-client.ts
@@ -111,12 +111,7 @@ export class EmojicoinClient {
     remove: this.removeLiquidity.bind(this),
   };
 
-  public utils: {
-    emojisToHexStrings: typeof EmojicoinClient.prototype.emojisToHexStrings;
-    emojisToHexSymbol: typeof EmojicoinClient.prototype.emojisToHexSymbol;
-    getEmojicoinInfo: typeof EmojicoinClient.prototype.getEmojicoinInfo;
-    getTransactionEventData: typeof EmojicoinClient.prototype.getTransactionEventData;
-  } = {
+  public utils = {
     emojisToHexStrings: this.emojisToHexStrings.bind(this),
     emojisToHexSymbol: this.emojisToHexSymbol.bind(this),
     getEmojicoinInfo: this.getEmojicoinInfo.bind(this),
@@ -131,13 +126,7 @@ export class EmojicoinClient {
     sell: this.sellWithRewards.bind(this),
   };
 
-  public view: {
-    marketExists: typeof EmojicoinClient.prototype.isMarketRegisteredView;
-    simulateBuy: typeof EmojicoinClient.prototype.simulateBuy;
-    simulateSell: typeof EmojicoinClient.prototype.simulateSell;
-    registry: typeof EmojicoinClient.prototype.registryView;
-    market: typeof EmojicoinClient.prototype.marketView;
-  } = {
+  public view = {
     marketExists: this.isMarketRegisteredView.bind(this),
     simulateBuy: this.simulateBuy.bind(this),
     simulateSell: this.simulateSell.bind(this),

--- a/src/typescript/sdk/src/index.ts
+++ b/src/typescript/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./const";
+export * from "./broker-v2";
 export * from "./emoji_data";
 export * from "./emojicoin_dot_fun";
 export * from "./markets";

--- a/src/typescript/sdk/src/index.ts
+++ b/src/typescript/sdk/src/index.ts
@@ -2,6 +2,7 @@ export * from "./const";
 export * from "./broker-v2";
 export * from "./emoji_data";
 export * from "./emojicoin_dot_fun";
+export * from "./indexer-v2/types";
 export * from "./markets";
 export * from "./types";
 export * from "./utils";

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -6,6 +6,7 @@ import {
 } from "../../emojicoin_dot_fun";
 import {
   type AnyNumberString,
+  type EventName,
   toCumulativeStats,
   toInstantaneousStats,
   toLastSwap,
@@ -508,7 +509,7 @@ export const withArenaVaultBalanceUpdateData = curryToNamedType(
   "arenaVaultBalanceUpdate"
 );
 
-const EVENT_NAMES = {
+const EVENT_NAMES: { [key in EventName]: key } = {
   GlobalState: "GlobalState",
   PeriodicState: "PeriodicState",
   MarketRegistration: "MarketRegistration",
@@ -517,8 +518,6 @@ const EVENT_NAMES = {
   Liquidity: "Liquidity",
   State: "State",
 } as const;
-
-export type EventName = (typeof EVENT_NAMES)[keyof typeof EVENT_NAMES];
 
 const formatEmojis = <T extends { symbol_emojis: SymbolEmoji[] } | { symbolEmojis: SymbolEmoji[] }>(
   data: T
@@ -542,7 +541,7 @@ export const GuidGetters = {
     const registryNonce = "registry_nonce" in data ? data.registry_nonce : data.registryNonce;
     return {
       eventName,
-      guid: `${eventName}::${registryNonce}::` as const,
+      guid: `${eventName}::${registryNonce}` as const,
     };
   },
   periodicStateEvent: (

--- a/src/typescript/sdk/tests/unit/event-parser/get-events.test.ts
+++ b/src/typescript/sdk/tests/unit/event-parser/get-events.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // cspell:word goldens
 import {
+  type EventName,
   getEvents,
   type JsonTypes,
   MODULE_ADDRESS,
@@ -18,7 +19,6 @@ import {
   isAnEmojicoinStructName,
   toCamelCaseEventName,
 } from "../../../src/emojicoin_dot_fun/events";
-import { type EventName } from "../../../src/indexer-v2/types";
 import Data from "./json/event-data.json";
 // Note that this isn't an actual valid transaction, it's just structured like one for parsing.
 import Transaction from "./json/transaction.json";


### PR DESCRIPTION
# Description

- [x] Export the broker client and indexer types properly to the SDK
- [x] Publish to npm and test to see it works as expected
- [x] Change version to `0.5.2` and publish once this PR is merged to `main`
- [x] Fix any residual type errors
- [x] Fix the `EmojicoinClient` class bound function types not being exposed properly by letting TypeScript infer them

# Testing

Tested it while writing the README.md for the SDK in #645

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

