### PR TITLE
docs(ECO-2911): Add a `README.md` to the SDK

### DIFF
--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -1,0 +1,247 @@
+# @econia-labs/emojicoin-sdk
+
+## Overview
+
+The emojicoin SDK was originally used to supplement the next.js frontend
+with server-side queries and API keys. As such, there are a few setup
+configurations and quirks to be mindful of when using the SDK.
+
+### Loading environment variables
+
+Most of the explanations for the environment variables used are in their
+respective files.
+
+**In general, if you are using the SDK but not the emojicoin indexer, you can
+simply load any of the three network environment variable configs without any
+extra setup. See below.**
+
+```shell
+# Install dotenv or some form of an environment variable loader.
+pnpm -D add dotenv-cli
+
+pnpm dotenv -e ./example.mainnet.env -- pnpm tsx ./my-script.ts
+pnpm dotenv -e ./example.testnet.env -- pnpm tsx ./my-script.ts
+pnpm dotenv -e ./example.local.env -- pnpm tsx ./my-script.ts
+```
+
+You can view the files here:
+
+- [local network]
+- [testnet network]
+- [mainnet network]
+
+NOTE: The environment variables must be defined prior to runtime, so you
+**cannot** use `dotenv.config({ path: "..." })` at runtime to load them.
+
+## Using the auto-generated Move contract APIs
+
+The `emojicoin_dot_fun` move functions have corresponding auto-generated
+transaction builder classes that you can use to interact with the contract.
+
+They are not particularly ergonomic- they are mostly just wrappers for contract
+entry and view functions; however, you can hover over each class for
+documentation based on the corresponding `*.move` function args
+and generic types.
+
+For a more ergonomic way to interact with the contract please see the
+[emojicoin client helper class](#the-emojicoinclient-helper-class).
+
+See the [contract APIs] for all of the possible smart contract functions.
+
+Here are the basic interactions with the `emojicoin_dot_fun.move` contract:
+
+### Setup an account on testnet
+
+```typescript
+// Make sure to load proper testnet environment variables. For example:
+// `pnpm dotenv -e ./example.testnet.env -- pnpm tsx ./my-script.ts`
+
+import { getAptosClient, ONE_APT } from "@econia-labs/emojicoin-sdk";
+import { Ed25519Account } from "@aptos-labs/ts-sdk";
+
+const account = Ed25519Account.generate();
+const aptos = getAptosClient();
+const accountAddress = account.accountAddress.toString();
+
+await aptos.fundAccount({ accountAddress, amount: ONE_APT });
+```
+
+### Register an emojicoin market
+
+```typescript
+// Using variables from above...
+import {
+  RegisterMarket,
+  getEvents,
+  SymbolEmoji,
+  toMarketEmojiData,
+  INTEGRATOR_ADDRESS,
+} from "@econia-labs/emojicoin-sdk";
+
+const emojis: SymbolEmoji[] = ["🍟", "💤"];
+const symbol = emojis.join("");
+const bytes = toMarketEmojiData(symbol).emojis.map((b) => b.bytes);
+
+const register = await RegisterMarket.submit({
+  aptosConfig: aptos.config,
+  registrant: account,
+  emojis: bytes,
+  integrator: INTEGRATOR_ADDRESS,
+});
+
+const registerEvents = getEvents(register);
+console.log(registerEvents.marketRegistrationEvents[0]);
+```
+
+### Swap APT for an Emojicoin
+
+<!-- markdownlint-disable MD013 -->
+
+```typescript
+// Using variables from above...
+import { getMarketAddress, toCoinTypesForEntry } from "@econia-labs/emojicoin-sdk";
+
+const marketAddress = getMarketAddress(emojis);
+const typeTags = toCoinTypesForEntry(marketAddress);
+
+await SwapWithRewards.submit({
+  aptosConfig: aptos.config,
+  swapper: account,
+  marketAddress,
+  inputAmount: 100n, // 100 octas of APT.
+  isSell: false, // Buy.
+  minOutputAmount: 1n,
+  typeTags,
+});
+```
+
+### Send a chat message for an emojicoin market
+
+```typescript
+// Using variables from above...
+
+// If you set `message` to the type `AnyEmoji[]`, you should get all valid
+// symbol and chat emojis as auto-completion suggestions inside quotes.
+const myFavoriteEmojis: AnyEmoji[] = ["🆕", "🐥", "💿"];
+const [a, b, c] = myFavoriteEmojis;
+const message = [a, a, b, a, b, c, c, b].join("");
+
+// message === "🆕🆕🐥🆕🐥💿💿🐥"
+
+const { emojiBytes, emojiIndicesSequence } = toChatMessageEntryFunctionArgs(message);
+
+await Chat.submit({
+  aptosConfig: aptos.config,
+  user: account,
+  marketAddress,
+  emojiBytes,
+  emojiIndicesSequence,
+  typeTags,
+});
+```
+
+<!-- markdownlint-enable MD013 -->
+
+## The EmojicoinClient helper class
+
+### Not intended for web applications
+
+The EmojicoinClient is primarily for local and test development. Please be
+mindful of configuration options in the client that are set by default.
+
+See [EmojicoinClient] and the [default config] for more details.
+
+You must import the `EmojicoinClient` from the SDK explicitly:
+
+```typescript
+import { EmojicoinClient } from "@econia-labs/emojicoin-sdk/client";
+```
+
+Note that the client uses indexer code, so you may run into [an import error]
+when using it.
+
+To run the equivalent of the sample code above:
+
+```typescript
+// Load environment variables for testnet:
+// `pnpm dotenv -e ./example.testnet.env -- pnpm tsx ./my-script.ts`
+
+import { EmojicoinClient } from "@econia-labs/emojicoin-sdk/client";
+
+const emojicoin = new EmojicoinClient();
+const account = Ed25519Account.generate();
+const accountAddress = account.accountAddress.toString();
+await aptos.fundAccount({ accountAddress, amount: ONE_APT });
+
+const emojis: SymbolEmoji[] = ["🍟", "💤"];
+await emojicoin.register(account, emojis);
+const amountBought = await emojicoin.rewards
+  .buy(account, emojis, 100n)
+  .then((res) => res.swap.event.netProceeds);
+await emojicoin.rewards.sell(account, emojis, amountBought);
+
+// Using an array will let you use auto-complete suggestions.
+const arr: SymbolEmoji[] = ["🆕", "🆕", "🐥", "🆕", "🐥", "💿", "💿", "🐥"];
+// You can also simply use a string: "🆕🆕🐥🆕🐥💿💿🐥🆕"
+await emojicoin.chat(account, emojis, arr);
+
+// As a bonus, check if the market exists:
+const exists = await emojicoin.view.marketExists(emojis);
+console.log(`Yes, ${emojis.join("")} exists!`);
+```
+
+## Common errors
+
+### Error: Missing environment variables \$\{key}
+
+You need to load the environment variables before running. See
+[loading-environment-variables](#loading-environment-variables).
+
+### Error: This module cannot be imported from a Client Component module
+
+```shell
+Error: This module cannot be imported from a Client Component module. It should
+only be used from a Server Component.
+```
+
+This is because you're inadvertently importing indexer queries or functions that
+import server-side environment variables. You can fix this one of two ways:
+
+#### 1. Narrow your import to avoid importing types and functions you don't need
+
+Most indexer types and helper functions are available at
+`@econia-labs/emojicoin-sdk`. You shouldn't need to import
+`@econia-labs/emojicoin-sdk/indexer-v2` to use them.
+
+Please [file an issue] if you need access to an import and it's impossible
+or difficult to use.
+
+#### 2. Satisfy the `react-server` condition
+
+If you are just using the SDK to run scripts or know what you're doing, you can
+silence the warning like so:
+
+```shell
+file="example.testnet.env"
+pnpm dotenv -v NODE_OPTIONS="--react-server" -e "$file" -- ./my-local-script.ts
+```
+
+The error arises because you've imported code that has a "server-only" import
+guard at the top of the file. Essentially, this file acts as protection against
+accidentally leaking server-side secrets like API keys client-side in browser
+based applications where the application code is sent to the client.
+
+It will always throw an error _unless_ the `NODE_OPTIONS` environment
+variable has specified the condition: `--react-server`.
+
+If you are getting this error in your frontend application, _you should
+heed its warning_ and understand the implications of not doing so!
+
+[an import error]: #error-this-module-cannot-be-imported-from-a-client-component-module
+[contract apis]: src/emojicoin_dot_fun/contract-apis/
+[default config]: https://github.com/econia-labs/emojicoin-dot-fun/blob/974e29fa607fa7d4bf391be3f8ed42e74d36cf87/src/typescript/sdk/src/client/emojicoin-client.ts#L153
+[emojicoinclient]: src/client/emojicoin-client.ts
+[file an issue]: https://github.com/econia-labs/emojicoin-dot-fun/issues
+[local network]: ../example.local.env
+[mainnet network]: ../example.mainnet.env
+[testnet network]: ../example.testnet.env

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -144,12 +144,20 @@ await Chat.submit({
 
 ## The EmojicoinClient helper class
 
+The EmojicoinClient class is a helper class primarily for local and test
+development. It facilitates terse, imperative code to interact with the
+contract's multiple entry and view functions.
+
 ### Not intended for web applications
 
-The EmojicoinClient is primarily for local and test development. Please be
-mindful of configuration options in the client that are set by default.
+The EmojicoinClient was primarily made as a utility class for local development.
+The default configuration options are not as explicit as the auto-generated
+contract classes above.
 
+Please be mindful of the default configuration options in the client.
 See [EmojicoinClient] and the [default config] for more details.
+
+### Using the EmojicoinClient
 
 You must import the `EmojicoinClient` from the SDK explicitly:
 
@@ -166,6 +174,7 @@ To run the equivalent of the sample code above:
 // Load environment variables for testnet:
 // `pnpm dotenv -e ./example.testnet.env -- pnpm tsx ./my-script.ts`
 
+import { AnyEmoji } from "@econia-labs/emojicoin-sdk";
 import { EmojicoinClient } from "@econia-labs/emojicoin-sdk/client";
 
 const emojicoin = new EmojicoinClient();
@@ -180,8 +189,8 @@ const amountBought = await emojicoin.rewards
   .then((res) => res.swap.event.netProceeds);
 await emojicoin.rewards.sell(account, emojis, amountBought);
 
-// Using an array will let you use auto-complete suggestions.
-const arr: SymbolEmoji[] = ["🆕", "🆕", "🐥", "🆕", "🐥", "💿", "💿", "🐥"];
+// Using an array will let you use auto-complete suggestions for emojis.
+const arr: AnyEmoji[] = ["🆕", "🆕", "🐥", "🆕", "🐥", "💿", "💿", "🐥"];
 // You can also simply use a string: "🆕🆕🐥🆕🐥💿💿🐥🆕"
 await emojicoin.chat(account, emojis, arr);
 

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -203,16 +203,11 @@ if (exists) {
 
 ## Using the WebSocketClient
 
-The simplest way to test the WebSocketClient and endpoint is by running a local
-network. You can do this by navigating to `src/typescript` and running:
+You can use the custom WebSocketClient class as a light wrapper around
+a simple WebSocket connection to the `broker` service. It automatically
+parses events emitted from the `broker` into emojicoin event models.
 
-```shell
-# Please note this may overwrite any existing Aptos local network data.
-pnpm run docker:up
-```
-
-Then you can interact with the contract locally and see events come in in real
-time with the code below:
+Here's a simple example of an automatically reconnecting connection:
 
 ```typescript
 import { sleep } from "@aptos-labs/ts-sdk";
@@ -225,11 +220,12 @@ import {
 } from "@econia-labs/emojicoin-sdk";
 
 export const connect = () => {
-  const client = new WebSocketClient({
-    // The WebSockets endpoint for the `broker` service. See `src/rust/broker`
-    // and `src/docker`. If you loaded an env file, you can also just use
-    // `process.env.NEXT_PUBLIC_BROKER_URL` here.
-    url: "ws://localhost:3009",
+  // The WebSockets endpoint for the `broker` service. See `src/rust/broker`
+  // and `src/docker` for more info on running the broker locally.
+  const url = "ws://localhost:3009";
+
+  new WebSocketClient({
+    url,
     listeners: {
       // Callback upon receiving any WebSocket message. `event` is automatically
       // deserialized into an emojicoin event model.

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The emojicoin SDK was originally used to supplement the next.js frontend
-with server-side queries and API keys. As such, there are a few setup
+with server-side queries that use private API keys. As such, there are a few
 configurations and quirks to be mindful of when using the SDK.
 
 ### Loading environment variables

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -282,8 +282,6 @@ Example output of a swap:
 [ '🐘' ] State
 ```
 
-<!-- markdownlint-enable MD013 -->
-
 ## Common errors
 
 ### Error: Missing environment variables \$\{key}
@@ -298,44 +296,39 @@ Error: This module cannot be imported from a Client Component module. It should
 only be used from a Server Component.
 ```
 
-This is because you're inadvertently importing indexer queries or functions that
-import server-side environment variables. You can fix this one of two ways:
+This error occurs because you've imported code that has a "server-only" import
+guard at the top of the file. See the next.js docs on
+[keeping server-only code out of the client environment] for more information.
 
-#### 1. Narrow your import to avoid importing types and functions you don't need
+It will always throw an error _unless_ the `NODE_OPTIONS` environment
+variable has specified the condition: `--react-server`.
+
+There are two ways to fix this:
+
+#### 1. Satisfy the `react-server` condition
+
+If you know what you're doing, you can silence the warning like so:
+
+```shell
+pnpm dotenv -v NODE_OPTIONS="--react-server" -e "example.testnet.env" -- ./my-local-script.ts
+```
+
+#### 2. Narrow your import to avoid importing types and functions you don't need
 
 Most indexer types and helper functions are available at
 `@econia-labs/emojicoin-sdk`. You shouldn't need to import
 `@econia-labs/emojicoin-sdk/indexer-v2` to use them.
 
-Please [file an issue] if you need access to an import and it's impossible
-or difficult to use.
+Please [file an issue] if you need access to an import that's not available!
 
-#### 2. Satisfy the `react-server` condition
-
-If you are just using the SDK to run scripts or know what you're doing, you can
-silence the warning like so:
-
-```shell
-file="example.testnet.env"
-pnpm dotenv -v NODE_OPTIONS="--react-server" -e "$file" -- ./my-local-script.ts
-```
-
-The error arises because you've imported code that has a "server-only" import
-guard at the top of the file. Essentially, this file acts as protection against
-accidentally leaking server-side secrets like API keys client-side in browser
-based applications where the application code is sent to the client.
-
-It will always throw an error _unless_ the `NODE_OPTIONS` environment
-variable has specified the condition: `--react-server`.
-
-If you are getting this error in your frontend application, _you should
-heed its warning_ and understand the implications of not doing so!
+<!-- markdownlint-enable MD013 -->
 
 [an import error]: #error-this-module-cannot-be-imported-from-a-client-component-module
 [contract apis]: src/emojicoin_dot_fun/contract-apis/
 [default config]: https://github.com/econia-labs/emojicoin-dot-fun/blob/974e29fa607fa7d4bf391be3f8ed42e74d36cf87/src/typescript/sdk/src/client/emojicoin-client.ts#L153
 [emojicoinclient]: src/client/emojicoin-client.ts
 [file an issue]: https://github.com/econia-labs/emojicoin-dot-fun/issues
+[keeping server-only code out of the client environment]: https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#keeping-server-only-code-out-of-the-client-environment
 [local network]: ../example.local.env
 [mainnet network]: ../example.mainnet.env
 [testnet network]: ../example.testnet.env

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -187,7 +187,9 @@ await emojicoin.chat(account, emojis, arr);
 
 // As a bonus, check if the market exists:
 const exists = await emojicoin.view.marketExists(emojis);
-console.log(`Yes, ${emojis.join("")} exists!`);
+if (exists) {
+  console.log(`Yes, ${emojis.join("")} exists!`);
+}
 ```
 
 ## Common errors

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -4,7 +4,7 @@
 
 The emojicoin SDK was originally used to supplement the next.js frontend
 with server-side queries that use private API keys. As such, there are a few
-configurations and quirks to be mindful of when using the SDK.
+configuration options and quirks to be mindful of when using the SDK.
 
 ### Loading environment variables
 

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -224,7 +224,7 @@ export const connect = () => {
   // and `src/docker` for more info on running the broker locally.
   const url = "ws://localhost:3009";
 
-  new WebSocketClient({
+  const client = new WebSocketClient({
     url,
     listeners: {
       // Callback upon receiving any WebSocket message. `event` is automatically
@@ -237,7 +237,7 @@ export const connect = () => {
             avgPrice: toNominalPrice(swap.avgExecutionPriceQ64).toFixed(9),
             curvePrice: calculateCurvePrice(state).toFixed(9),
           });
-
+        }
         if (isEventModelWithMarket(event)) {
           console.log(event.market.symbolEmojis, event.eventName);
         }

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -155,7 +155,8 @@ The default configuration options are not as explicit as the auto-generated
 contract classes above.
 
 Please be mindful of the default configuration options in the client.
-See [EmojicoinClient] and the [default config] for more details.
+See the [EmojicoinClient] and the default values passed to the constructor
+for more details.
 
 ### Using the EmojicoinClient
 
@@ -340,7 +341,6 @@ Please [file an issue] if you need access to an import that's not available!
 
 [an import error]: #error-this-module-cannot-be-imported-from-a-client-component-module
 [contract apis]: src/emojicoin_dot_fun/contract-apis/
-[default config]: https://github.com/econia-labs/emojicoin-dot-fun/blob/974e29fa607fa7d4bf391be3f8ed42e74d36cf87/src/typescript/sdk/src/client/emojicoin-client.ts#L153
 [emojicoinclient]: src/client/emojicoin-client.ts
 [file an issue]: https://github.com/econia-labs/emojicoin-dot-fun/issues
 [keeping server-only code out of the client environment]: https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#keeping-server-only-code-out-of-the-client-environment


### PR DESCRIPTION
# Description

It's been a long time coming! Added proper examples for using the SDK. Nothing super fancy, but we can point users at it now.

Relies on #645 to work properly.

- [x] ~Update the link to the emojicoin config in the README once #645 is merged, to get a proper pointer to the right line.~ Just remove the specific line and point them generally to the constructor where default args are set

# Testing

Ran all the examples manually, although I'll do it again before submitting.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?