### PR TITLE
feat(ECO-2886): Take out dex screener from market metadata badge

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -129,8 +129,6 @@ const MainInfo = ({ data }: MainInfoProps) => {
     /* eslint-disable react-hooks/exhaustive-deps */
   }, [data.marketAddress]);
 
-  const dexscreenerButton = <LinkButton name={"dexscreener"} link={undefined} />;
-
   const telegramButton = (
     <LinkButton
       name={"telegram"}
@@ -246,7 +244,7 @@ const MainInfo = ({ data }: MainInfoProps) => {
             >
               <Button scale="lg">copy coin address</Button>
             </motion.div>
-            {dexscreenerButton}
+
             {twitterButton}
             {telegramButton}
             {websiteButton}


### PR DESCRIPTION
# Description

Simply removes dexscreener button from market page

# Testing

Not much to test. The whole top section looks better with the button off as it eliminates a row.

Here is a screenshot of the change. Left is production version, right is with changes from this branch.
<img width="2498" alt="image" src="https://github.com/user-attachments/assets/e6f86643-2231-4410-8523-dd1f565fe29b" />