### PR TITLE
chore(ECO-2914): Use different accounts for different leaderboard tests

### DIFF
--- a/src/typescript/sdk/src/indexer-v2/queries/app/arena.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/app/arena.ts
@@ -14,6 +14,7 @@ import {
 } from "../../types";
 import { ORDER_BY } from "../../const";
 import { toAccountAddressString } from "../../../utils/account-address";
+import { type AccountAddressInput } from "@aptos-labs/ts-sdk";
 
 const selectMelee = () =>
   postgrest
@@ -31,19 +32,19 @@ const selectArenaInfo = () =>
     .limit(1)
     .single();
 
-const selectPosition = ({ user, meleeID }: { user: string; meleeID: bigint }) =>
+const selectPosition = ({ user, meleeID }: { user: AccountAddressInput; meleeID: bigint }) =>
   postgrest
     .from(TableName.ArenaPosition)
     .select("*")
-    .eq("user", user)
+    .eq("user", toAccountAddressString(user))
     .eq("melee_id", meleeID)
     .maybeSingle();
 
-const selectLatestPosition = ({ user }: { user: string }) =>
+const selectLatestPosition = ({ user }: { user: AccountAddressInput }) =>
   postgrest
     .from(TableName.ArenaPosition)
     .select("*")
-    .eq("user", user)
+    .eq("user", toAccountAddressString(user))
     .order("melee_id", ORDER_BY.DESC)
     .limit(1)
     .maybeSingle();
@@ -53,7 +54,7 @@ const selectArenaLeaderboardHistoryWithInfo = ({
   page = 1,
   pageSize,
 }: {
-  user: string;
+  user: AccountAddressInput;
   page: number;
   pageSize: number;
 }) =>
@@ -69,7 +70,7 @@ const selectMarketStateByAddress = ({ address }: { address: string }) =>
   postgrest
     .from(TableName.MarketState)
     .select("*")
-    .eq("market_address", address)
+    .eq("market_address", toAccountAddressString(address))
     .limit(1)
     .maybeSingle();
 

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -25,7 +25,7 @@ import {
   type BlockAndEventIndexMetadata,
 } from "./json-types";
 import { type MarketEmojiData, type SymbolEmoji, toMarketEmojiData } from "../../emoji_data";
-import { toPeriod, toTrigger, type Period, type Trigger } from "../../const";
+import { toArenaPeriod, toPeriod, toTrigger, type Period, type Trigger } from "../../const";
 import { toAccountAddressString } from "../../utils";
 import Big from "big.js";
 import { q64ToBig } from "../../utils/nominal-price";
@@ -158,6 +158,7 @@ const toArenaExitFromDatabase = (
   emojicoin0ExchangeRateQuote: BigInt(data.emojicoin_0_exchange_rate_quote),
   emojicoin1ExchangeRateBase: BigInt(data.emojicoin_1_exchange_rate_base),
   emojicoin1ExchangeRateQuote: BigInt(data.emojicoin_1_exchange_rate_quote),
+  duringMelee: data.during_melee,
 });
 
 const toArenaSwapFromDatabase = (
@@ -173,6 +174,7 @@ const toArenaSwapFromDatabase = (
   emojicoin0ExchangeRateQuote: BigInt(data.emojicoin_0_exchange_rate_quote),
   emojicoin1ExchangeRateBase: BigInt(data.emojicoin_1_exchange_rate_base),
   emojicoin1ExchangeRateQuote: BigInt(data.emojicoin_1_exchange_rate_quote),
+  duringMelee: data.during_melee,
 });
 
 const toArenaVaultBalanceUpdateFromDatabase = (
@@ -255,11 +257,10 @@ const toArenaCandlestickFromDatabase = (
   volume: BigInt(data.volume),
   period: toArenaPeriod(data.period),
   startTime: safeParseBigIntOrPostgresTimestamp(data.start_time),
-  openPrice: data.open_price === null ? null : Number(data.open_price),
-  closePrice: data.close_price === null ? null : Number(data.close_price),
-  highPrice: data.high_price === null ? null : Number(data.high_price),
-  lowPrice: data.low_price === null ? null : Number(data.low_price),
-  integratorFees: BigInt(data.integrator_fees),
+  openPrice: Number(data.open_price),
+  closePrice: Number(data.close_price),
+  highPrice: Number(data.high_price),
+  lowPrice: Number(data.low_price),
   nSwaps: BigInt(data.n_swaps),
 });
 

--- a/src/typescript/sdk/src/indexer-v2/types/json-types.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/json-types.ts
@@ -273,8 +273,11 @@ type ArenaMeleeEventData = Flatten<
 type ArenaEnterEventData = FlattenedExchangeRateWithEventIndex<"ArenaEnterEvent">;
 type ArenaExitEventData = FlattenedExchangeRateWithEventIndex<"ArenaExitEvent"> & {
   apt_proceeds: Uint64String;
+  during_melee: boolean;
 };
-type ArenaSwapEventData = FlattenedExchangeRateWithEventIndex<"ArenaSwapEvent">;
+type ArenaSwapEventData = FlattenedExchangeRateWithEventIndex<"ArenaSwapEvent"> & {
+  during_melee: boolean;
+};
 
 type ArenaVaultBalanceUpdateEventData = {
   event_index: Uint64String;
@@ -360,13 +363,12 @@ type ArenaCandlestickData = {
   period: PeriodTypeFromDatabase | PeriodTypeFromBroker;
   start_time: PostgresTimestamp;
 
-  open_price: number | null;
-  close_price: number | null;
-  high_price: number | null;
-  low_price: number | null;
+  open_price: number;
+  close_price: number;
+  high_price: number;
+  low_price: number;
 
   volume: Uint64String;
-  integrator_fees: Uint64String;
   n_swaps: Uint64String;
 };
 

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -59,6 +59,7 @@ export type ArenaTypes = {
     emojicoin0ExchangeRateQuote: bigint;
     emojicoin1ExchangeRateBase: bigint;
     emojicoin1ExchangeRateQuote: bigint;
+    duringMelee: boolean;
     eventName: "ArenaExit";
   } & WithVersionAndEventIndex;
 
@@ -73,6 +74,7 @@ export type ArenaTypes = {
     emojicoin0ExchangeRateQuote: bigint;
     emojicoin1ExchangeRateBase: bigint;
     emojicoin1ExchangeRateQuote: bigint;
+    duringMelee: boolean;
     eventName: "ArenaSwap";
   } & WithVersionAndEventIndex;
 
@@ -161,13 +163,12 @@ export type ArenaTypes = {
     period: ArenaPeriod;
     startTime: Date;
 
-    openPrice: number | null;
-    closePrice: number | null;
-    highPrice: number | null;
-    lowPrice: number | null;
+    openPrice: number;
+    closePrice: number;
+    highPrice: number;
+    lowPrice: number;
 
     volume: bigint;
-    integratorFees: bigint;
     nSwaps: bigint;
   };
 };
@@ -271,6 +272,7 @@ export const toArenaExitEvent = (
   ...toExchangeRate(data),
   eventName: "ArenaExit" as const,
   ...withVersionAndEventIndex({ version, eventIndex }),
+  duringMelee: true,
 });
 
 export const toArenaSwapEvent = (
@@ -287,6 +289,7 @@ export const toArenaSwapEvent = (
   ...toExchangeRate(data),
   eventName: "ArenaSwap" as const,
   ...withVersionAndEventIndex({ version, eventIndex }),
+  duringMelee: true,
 });
 
 export const toArenaVaultBalanceUpdateEvent = (

--- a/src/typescript/sdk/tests/e2e/arena/candlesticks.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/candlesticks.test.ts
@@ -1,13 +1,12 @@
-import { ArenaPeriod, ONE_APT_BIGINT, sleep, SymbolEmoji } from "../../../src";
+import { ArenaPeriod, calculateCurvePrice, ONE_APT_BIGINT, sleep, type SymbolEmoji } from "../../../src";
 import { EmojicoinClient } from "../../../src/client/emojicoin-client";
 import {
-  ArenaCandlestickModel,
-  ORDER_BY,
+  type ArenaCandlestickModel,
+  type MarketLatestStateEventModel,
   postgrest,
-  SwapEventModel,
   TableName,
   toArenaCandlestickModel,
-  toSwapEventModel,
+  toMarketLatestStateEventModel,
   waitForEmojicoinIndexer,
 } from "../../../src/indexer-v2";
 import {
@@ -15,7 +14,7 @@ import {
   fetchMeleeEmojiData,
   type MeleeEmojiData,
 } from "../../../src/markets/arena-utils";
-import { FundedAccountIndex, getFundedAccount } from "../../utils/test-accounts";
+import { type FundedAccountIndex, getFundedAccount } from "../../utils/test-accounts";
 import {
   ONE_SECOND_MICROSECONDS,
   setNextMeleeDurationAndEnsureCrank,
@@ -24,8 +23,7 @@ import {
   waitForProcessor,
 } from "./utils";
 import { getPublisher } from "../../utils/helpers";
-import { Account } from "@aptos-labs/ts-sdk";
-import Big from "big.js";
+import type { Account } from "@aptos-labs/ts-sdk";
 
 describe("ensures arena candlesticks work", () => {
   const emojicoin = new EmojicoinClient();
@@ -115,10 +113,9 @@ describe("ensures arena candlesticks work", () => {
     let candlesticks: ArenaCandlestickModel[] | null = null;
     let fifteenSecondCandles: ArenaCandlestickModel[] = [];
     let expectedPrice = 1;
-    let expectedFees = 0n;
     let expectedVolume = 0n;
-    let swap0: SwapEventModel | null = null;
-    let swap1: SwapEventModel | null = null;
+    let state0: MarketLatestStateEventModel = {} as MarketLatestStateEventModel;
+    let state1: MarketLatestStateEventModel = {} as MarketLatestStateEventModel;
 
     const queryCandlesticks = async () => {
       candlesticks = await postgrest
@@ -128,25 +125,21 @@ describe("ensures arena candlesticks work", () => {
         .then((r) => r.data)
         .then((r) => (r === null ? null : r.map(toArenaCandlestickModel)));
     };
-    const querySwaps = async () => {
-      swap0 = await postgrest
-        .from(TableName.SwapEvents)
+    const queryStates = async () => {
+      state0 = await postgrest
+        .from(TableName.MarketLatestStateEvent)
         .select("*")
         .eq("market_id", melee.market1.marketID)
-        .order("market_nonce", ORDER_BY.DESC)
-        .limit(1)
+        .single()
         .then((r) => r.data)
-        .then((r) => (r === null ? null : r.map(toSwapEventModel)))
-        .then((r) => (r?.length === 1 ? r[0] : null));
-      swap1 = await postgrest
-        .from(TableName.SwapEvents)
+        .then((r) => toMarketLatestStateEventModel(r));
+      state1 = await postgrest
+        .from(TableName.MarketLatestStateEvent)
         .select("*")
         .eq("market_id", melee.market2.marketID)
-        .order("market_nonce", ORDER_BY.DESC)
-        .limit(1)
+        .single()
         .then((r) => r.data)
-        .then((r) => (r === null ? null : r.map(toSwapEventModel)))
-        .then((r) => (r?.length === 1 ? r[0] : null));
+        .then((r) => toMarketLatestStateEventModel(r));
     };
     const waitTo15sBoundryStart = async () => {
       const now = new Date().getTime();
@@ -155,16 +148,23 @@ describe("ensures arena candlesticks work", () => {
       const timeToWait = Math.max(fifteenSecondEnd - now, 0) + 200;
       await sleep(timeToWait);
     };
-    const calculatePrice = (swap0: SwapEventModel, swap1: SwapEventModel) => {
-      const price0 = Big(swap0!.swap.avgExecutionPriceQ64.toString()).div(2 ** 64);
-      const price1 = Big(swap1!.swap.avgExecutionPriceQ64.toString()).div(2 ** 64);
+    const calculatePrice = (
+      state0: MarketLatestStateEventModel,
+      state1: MarketLatestStateEventModel
+    ) => {
+      const price0 = calculateCurvePrice(state0.state);
+      const price1 = calculateCurvePrice(state1.state);
       return price0.div(price1).toNumber();
     };
 
     await queryCandlesticks();
+    await queryStates();
 
     expect(candlesticks).not.toBeNull();
     expect(candlesticks).toHaveLength(0);
+
+    expect(state0.lastSwap.avgExecutionPriceQ64).toEqual(0n);
+    expect(state1.lastSwap.avgExecutionPriceQ64).toEqual(0n);
 
     await waitTo15sBoundryStart();
 
@@ -182,24 +182,23 @@ describe("ensures arena candlesticks work", () => {
     );
 
     await queryCandlesticks();
-    await querySwaps();
-
-    // Since we only have one swap on one side, there is no price, and all price
-    // columns are null. However, volume, integratorFees, and nSwaps are set.
+    await queryStates();
 
     expect(candlesticks).not.toBeNull();
     expect(candlesticks!.length).toBeGreaterThan(0);
 
     fifteenSecondCandles = candlesticks!.filter((c) => c.period === ArenaPeriod.Period15S);
 
+    expectedPrice = calculatePrice(state0, state1);
+    const expectedOpenPrice = expectedPrice;
+
     expect(fifteenSecondCandles).toHaveLength(1);
     expect(fifteenSecondCandles[0].nSwaps).toEqual(1n);
-    expect(fifteenSecondCandles[0].lowPrice).toBeNull();
-    expect(fifteenSecondCandles[0].highPrice).toBeNull();
-    expect(fifteenSecondCandles[0].openPrice).toBeNull();
-    expect(fifteenSecondCandles[0].closePrice).toBeNull();
-    expect(fifteenSecondCandles[0].integratorFees).toEqual(swap0!.swap.integratorFee);
-    expect(fifteenSecondCandles[0].volume).toEqual(swap0!.swap.quoteVolume);
+    expect(fifteenSecondCandles[0].lowPrice).toEqual(expectedPrice);
+    expect(fifteenSecondCandles[0].highPrice).toEqual(expectedPrice);
+    expect(fifteenSecondCandles[0].openPrice).toEqual(expectedOpenPrice);
+    expect(fifteenSecondCandles[0].closePrice).toEqual(expectedPrice);
+    expect(fifteenSecondCandles[0].volume).toEqual(state0!.lastSwap.quoteVolume);
 
     // No swap is generated from the exit.
 
@@ -219,14 +218,12 @@ describe("ensures arena candlesticks work", () => {
     );
 
     await queryCandlesticks();
-    await querySwaps();
+    await queryStates();
 
-    expectedPrice = calculatePrice(swap0!, swap1!);
+    let oldExpectedPrice = expectedPrice;
+    expectedPrice = calculatePrice(state0, state1);
 
-    expectedFees = swap0!.swap.integratorFee + swap1!.swap.integratorFee;
-    expectedVolume = swap0!.swap.quoteVolume + swap1!.swap.quoteVolume;
-
-    // Now that we have a price on each side, price columns are set as well.
+    expectedVolume = state0!.lastSwap.quoteVolume + state1!.lastSwap.quoteVolume;
 
     expect(candlesticks).not.toBeNull();
 
@@ -235,10 +232,9 @@ describe("ensures arena candlesticks work", () => {
     expect(fifteenSecondCandles).toHaveLength(1);
     expect(fifteenSecondCandles[0].nSwaps).toEqual(2n);
     expect(fifteenSecondCandles[0].lowPrice).toBeCloseTo(expectedPrice, 5);
-    expect(fifteenSecondCandles[0].highPrice).toBeCloseTo(expectedPrice, 5);
-    expect(fifteenSecondCandles[0].openPrice).toBeCloseTo(expectedPrice, 5);
+    expect(fifteenSecondCandles[0].highPrice).toBeCloseTo(oldExpectedPrice, 5);
+    expect(fifteenSecondCandles[0].openPrice).toBeCloseTo(expectedOpenPrice, 5);
     expect(fifteenSecondCandles[0].closePrice).toBeCloseTo(expectedPrice, 5);
-    expect(fifteenSecondCandles[0].integratorFees).toEqual(expectedFees);
     expect(fifteenSecondCandles[0].volume).toEqual(expectedVolume);
 
     // We swap for emojicoin 1 to emojicoin 0.
@@ -248,24 +244,22 @@ describe("ensures arena candlesticks work", () => {
     );
 
     await queryCandlesticks();
-    await querySwaps();
+    await queryStates();
 
     expect(candlesticks).not.toBeNull();
 
-    let oldExpectedPrice = expectedPrice;
+    oldExpectedPrice = expectedPrice;
 
-    expectedPrice = calculatePrice(swap0!, swap1!);
-    expectedFees += swap0!.swap.integratorFee + swap1!.swap.integratorFee;
-    expectedVolume += swap0!.swap.quoteVolume + swap1!.swap.quoteVolume;
+    expectedPrice = calculatePrice(state0!, state1!);
+    expectedVolume += state0!.lastSwap.quoteVolume + state1!.lastSwap.quoteVolume;
     fifteenSecondCandles = candlesticks!.filter((c) => c.period === ArenaPeriod.Period15S);
 
     expect(fifteenSecondCandles).toHaveLength(1);
     expect(fifteenSecondCandles[0].nSwaps).toEqual(4n);
     expect(fifteenSecondCandles[0].lowPrice).toBeCloseTo(oldExpectedPrice, 5);
     expect(fifteenSecondCandles[0].highPrice).toBeCloseTo(expectedPrice, 5);
-    expect(fifteenSecondCandles[0].openPrice).toBeCloseTo(oldExpectedPrice, 5);
+    expect(fifteenSecondCandles[0].openPrice).toBeCloseTo(expectedOpenPrice, 5);
     expect(fifteenSecondCandles[0].closePrice).toBeCloseTo(expectedPrice, 5);
-    expect(fifteenSecondCandles[0].integratorFees).toEqual(expectedFees);
     expect(fifteenSecondCandles[0].volume).toEqual(expectedVolume);
 
     await waitTo15sBoundryStart();
@@ -276,10 +270,10 @@ describe("ensures arena candlesticks work", () => {
       await emojicoin.arena.swap(account2, melee.market1.symbolEmojis, melee.market2.symbolEmojis)
     );
 
-    const oldSwap1 = swap1!;
+    const oldSwap1 = state1!;
 
     await queryCandlesticks();
-    await querySwaps();
+    await queryStates();
 
     expect(candlesticks).not.toBeNull();
 
@@ -290,13 +284,11 @@ describe("ensures arena candlesticks work", () => {
     expect(fifteenSecondCandles[0].nSwaps).toEqual(4n);
     expect(fifteenSecondCandles[0].lowPrice).toBeCloseTo(oldExpectedPrice, 5);
     expect(fifteenSecondCandles[0].highPrice).toBeCloseTo(expectedPrice, 5);
-    expect(fifteenSecondCandles[0].openPrice).toBeCloseTo(oldExpectedPrice, 5);
+    expect(fifteenSecondCandles[0].openPrice).toBeCloseTo(expectedOpenPrice, 5);
     expect(fifteenSecondCandles[0].closePrice).toBeCloseTo(expectedPrice, 5);
-    expect(fifteenSecondCandles[0].integratorFees).toEqual(expectedFees);
     expect(fifteenSecondCandles[0].volume).toEqual(expectedVolume);
 
-    expectedVolume = swap0!.swap.quoteVolume + swap1!.swap.quoteVolume;
-    expectedFees = swap0!.swap.integratorFee + swap1!.swap.integratorFee;
+    expectedVolume = state0!.lastSwap.quoteVolume + state1!.lastSwap.quoteVolume;
 
     // When an arena swap happens, they are actually slightly staggered, meaning
     // that two swaps happen (one on each market), one after the other. This
@@ -331,15 +323,14 @@ describe("ensures arena candlesticks work", () => {
     // candlestick time boundry, there are two different prices for low/high
     // and for open/close.
 
-    const intermediaryExpectedPrice = calculatePrice(swap0!, oldSwap1);
-    expectedPrice = calculatePrice(swap0!, swap1!);
+    const intermediaryExpectedPrice = calculatePrice(state0!, oldSwap1);
+    expectedPrice = calculatePrice(state0!, state1!);
 
     expect(fifteenSecondCandles[1].lowPrice).toBeCloseTo(expectedPrice, 5);
     expect(fifteenSecondCandles[1].highPrice).toBeCloseTo(intermediaryExpectedPrice, 5);
     expect(fifteenSecondCandles[1].openPrice).toBeCloseTo(intermediaryExpectedPrice, 5);
     expect(fifteenSecondCandles[1].closePrice).toBeCloseTo(expectedPrice, 5);
     expect(fifteenSecondCandles[1].nSwaps).toEqual(2n);
-    expect(fifteenSecondCandles[1].integratorFees).toEqual(expectedFees);
     expect(fifteenSecondCandles[1].volume).toEqual(expectedVolume);
   }, 70000);
 });

--- a/src/typescript/sdk/tests/e2e/arena/general.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/general.test.ts
@@ -367,6 +367,10 @@ describe("ensures leaderboard history is working", () => {
 
   const publisher = getPublisher();
 
+  let accountIndex = 100;
+
+  const getNextAccount = () => getFundedAccount((accountIndex++).toString() as unknown as Parameters<typeof getFundedAccount>[0]);
+
   // Utility function to avoid repetitive code. Only the `account` and `escrowCoin` differs.
   const enterHelper = (account: Account, escrowCoin: "symbol1" | "symbol2") =>
     emojicoin.arena.enter(
@@ -404,9 +408,9 @@ describe("ensures leaderboard history is working", () => {
   }, 10000);
 
   it("verifies that the leaderboard data is correct", async () => {
-    const account1 = getFundedAccount("420");
-    const account2 = getFundedAccount("421");
-    const account3 = getFundedAccount("422");
+    const account1 = getNextAccount();
+    const account2 = getNextAccount();
+    const account3 = getNextAccount();
     await enterHelper(account1, "symbol1");
     await enterHelper(account2, "symbol1");
     await enterHelper(account3, "symbol1");
@@ -428,9 +432,9 @@ describe("ensures leaderboard history is working", () => {
     expect(leaderboard).not.toBeNull();
     expect(leaderboard).toHaveLength(3);
 
-    const leaderboard1 = leaderboard!.find((l) => l.user.startsWith("0x420"))!;
-    const leaderboard2 = leaderboard!.find((l) => l.user.startsWith("0x421"))!;
-    const leaderboard3 = leaderboard!.find((l) => l.user.startsWith("0x422"))!;
+    const leaderboard1 = leaderboard!.find((l) => l.user === account1.accountAddress.toStringLong())!;
+    const leaderboard2 = leaderboard!.find((l) => l.user === account2.accountAddress.toStringLong())!;
+    const leaderboard3 = leaderboard!.find((l) => l.user === account3.accountAddress.toStringLong())!;
 
     expect(leaderboard1.exited).toEqual(true);
     expect(leaderboard1.lastExit0).toEqual(true);
@@ -447,7 +451,7 @@ describe("ensures leaderboard history is working", () => {
   it("verifies the data during a melee with no activity", async () => {
     await waitUntilCurrentMeleeEnds();
     const res = await emojicoin.arena.enter(
-      getFundedAccount("667"),
+      getNextAccount(),
       1n * 10n ** 8n,
       false,
       melee.market1.symbolEmojis,
@@ -467,9 +471,9 @@ describe("ensures leaderboard history is working", () => {
   }, 15000);
 
   it("verifies the data during a melee with no swaps", async () => {
-    const account1 = getFundedAccount("420");
-    const account2 = getFundedAccount("421");
-    const account3 = getFundedAccount("422");
+    const account1 = getNextAccount();
+    const account2 = getNextAccount();
+    const account3 = getNextAccount();
     await enterHelper(account1, "symbol1");
     await enterHelper(account2, "symbol2");
     await enterHelper(account3, "symbol1");
@@ -490,9 +494,9 @@ describe("ensures leaderboard history is working", () => {
     expect(leaderboard).not.toBeNull();
     expect(leaderboard).toHaveLength(3);
 
-    const leaderboard1 = leaderboard!.find((l) => l.user.startsWith("0x420"))!;
-    const leaderboard2 = leaderboard!.find((l) => l.user.startsWith("0x421"))!;
-    const leaderboard3 = leaderboard!.find((l) => l.user.startsWith("0x422"))!;
+    const leaderboard1 = leaderboard!.find((l) => l.user === account1.accountAddress.toStringLong())!;
+    const leaderboard2 = leaderboard!.find((l) => l.user === account2.accountAddress.toStringLong())!;
+    const leaderboard3 = leaderboard!.find((l) => l.user === account3.accountAddress.toStringLong())!;
 
     expect(leaderboard1.exited).toEqual(true);
     expect(leaderboard1.lastExit0).toEqual(true);
@@ -505,9 +509,9 @@ describe("ensures leaderboard history is working", () => {
   }, 15000);
 
   it("verifies the data during a melee with no exits", async () => {
-    const account1 = getFundedAccount("420");
-    const account2 = getFundedAccount("421");
-    const account3 = getFundedAccount("422");
+    const account1 = getNextAccount();
+    const account2 = getNextAccount();
+    const account3 = getNextAccount();
     await enterHelper(account1, "symbol1");
     await enterHelper(account2, "symbol2");
     await enterHelper(account3, "symbol1");
@@ -528,9 +532,9 @@ describe("ensures leaderboard history is working", () => {
     expect(leaderboard).not.toBeNull();
     expect(leaderboard).toHaveLength(3);
 
-    const leaderboard1 = leaderboard!.find((l) => l.user.startsWith("0x420"))!;
-    const leaderboard2 = leaderboard!.find((l) => l.user.startsWith("0x421"))!;
-    const leaderboard3 = leaderboard!.find((l) => l.user.startsWith("0x422"))!;
+    const leaderboard1 = leaderboard!.find((l) => l.user === account1.accountAddress.toStringLong())!;
+    const leaderboard2 = leaderboard!.find((l) => l.user === account2.accountAddress.toStringLong())!;
+    const leaderboard3 = leaderboard!.find((l) => l.user === account3.accountAddress.toStringLong())!;
 
     expect(leaderboard1.exited).toEqual(false);
     expect(leaderboard1.lastExit0).toBeNull();
@@ -551,6 +555,10 @@ describe("ensures arena info is working", () => {
   const MELEE_DURATION = ONE_SECOND_MICROSECONDS * 15n;
 
   const publisher = getPublisher();
+
+  let accountIndex = 200;
+
+  const getNextAccount = () => getFundedAccount((accountIndex++).toString() as unknown as Parameters<typeof getFundedAccount>[0]);
 
   // Utility function to avoid repetitive code. Only the `account` and `escrowCoin` differs.
   const enterHelper = (account: Account, escrowCoin: "symbol1" | "symbol2") =>
@@ -638,14 +646,14 @@ describe("ensures arena info is working", () => {
     let emojicoin1Locked = 0n;
 
     const accounts = [
-      getFundedAccount("420"),
-      getFundedAccount("421"),
-      getFundedAccount("422"),
-      getFundedAccount("423"),
-      getFundedAccount("424"),
-      getFundedAccount("425"),
-      getFundedAccount("426"),
-      getFundedAccount("427"),
+      getNextAccount(),
+      getNextAccount(),
+      getNextAccount(),
+      getNextAccount(),
+      getNextAccount(),
+      getNextAccount(),
+      getNextAccount(),
+      getNextAccount(),
     ];
 
     // Enter with all accounts alternating between symbol 1 and 2.

--- a/src/typescript/sdk/tests/e2e/arena/general.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/general.test.ts
@@ -4,6 +4,7 @@ import {
   EmojicoinArena,
   getAptosClient,
   ONE_APT_BIGINT,
+  sleep,
   type SymbolEmoji,
 } from "../../../src";
 import { EmojicoinClient } from "../../../src/client/emojicoin-client";
@@ -27,6 +28,7 @@ import {
 } from "../../../src/indexer-v2";
 import {
   fetchArenaMeleeView,
+  fetchArenaRegistryView,
   fetchMeleeEmojiData,
   type MeleeEmojiData,
 } from "../../../src/markets/arena-utils";
@@ -80,6 +82,9 @@ const expectObjectEqualityExceptEventIndexAndVersion = (a: object, b: object) =>
   const newB = objectKeysWithoutEventIndexAndVersion(b);
   expect(stringifyJSONWithBigInts(newA)).toEqual(stringifyJSONWithBigInts(newB));
 };
+
+const getNextAccountHelper = (i: number) =>
+  getFundedAccount(i.toString().padStart(3, "0") as FundedAccountIndex);
 
 /**
  * Because this test checks the details of the very first arena it must run separately from other
@@ -413,10 +418,7 @@ describe("ensures leaderboard history is working", () => {
 
   let accountIndex = 100;
 
-  const getNextAccount = () =>
-    getFundedAccount(
-      (accountIndex++).toString() as unknown as Parameters<typeof getFundedAccount>[0]
-    );
+  const getNextAccount = () => getNextAccountHelper(accountIndex++);
 
   // Utility function to avoid repetitive code. Only the `account` and `escrowCoin` differs.
   const enterHelper = (account: Account, escrowCoin: "symbol1" | "symbol2") =>
@@ -623,10 +625,7 @@ describe("ensures arena info is working", () => {
 
   let accountIndex = 200;
 
-  const getNextAccount = () =>
-    getFundedAccount(
-      (accountIndex++).toString() as unknown as Parameters<typeof getFundedAccount>[0]
-    );
+  const getNextAccount = () => getNextAccountHelper(accountIndex++);
 
   // Utility function to avoid repetitive code. Only the `account` and `escrowCoin` differs.
   const enterHelper = (account: Account, escrowCoin: "symbol1" | "symbol2") =>
@@ -796,5 +795,159 @@ describe("ensures arena info is working", () => {
     expect(arenaInfo!.volume).toEqual(volume);
     expect(arenaInfo!.emojicoin0Locked).toEqual(emojicoin0Locked);
     expect(arenaInfo!.emojicoin1Locked).toEqual(emojicoin1Locked);
+  }, 30000);
+});
+
+describe("ensures arena works in edge cases", () => {
+  const emojicoin = new EmojicoinClient();
+
+  let melee: MeleeEmojiData;
+
+  const MELEE_DURATION = ONE_SECOND_MICROSECONDS * 15n;
+
+  const publisher = getPublisher();
+
+  let accountIndex = 200;
+
+  const getNextAccount = () => getNextAccountHelper(accountIndex++);
+
+  // Utility function to avoid repetitive code. Only the `account` and `escrowCoin` differs.
+  const enterHelper = (account: Account, escrowCoin: "symbol1" | "symbol2") =>
+    emojicoin.arena.enter(
+      account,
+      ONE_APT_BIGINT,
+      false,
+      melee.market1.symbolEmojis,
+      melee.market2.symbolEmojis,
+      escrowCoin
+    );
+
+  beforeAll(async () => {
+    await waitUntilCurrentMeleeEnds();
+    await setNextMeleeDurationAndEnsureCrank(MELEE_DURATION).then((res) => {
+      melee = res.melee;
+      return waitForEmojicoinIndexer(res.version, PROCESSING_WAIT_TIME);
+    });
+  }, 30000);
+
+  beforeEach(async () => {
+    await waitUntilCurrentMeleeEnds();
+    // Crank the melee to end it and start a new one.
+    const res = await emojicoin.arena.enter(
+      publisher,
+      1n,
+      false,
+      melee.market1.symbolEmojis,
+      melee.market2.symbolEmojis,
+      "symbol1"
+    );
+    melee = await fetchArenaMeleeView(res.arena.event.meleeID).then(fetchMeleeEmojiData);
+    await waitForProcessor(res);
+
+    return true;
+  }, 30000);
+
+  it("verifies that a swap after a melee has endend and has been cranked is indexed properly", async () => {
+    const account1 = getNextAccount();
+    const account2 = getNextAccount();
+
+    await enterHelper(account1, "symbol1");
+    await enterHelper(account2, "symbol1");
+
+    await emojicoin.arena.exit(account1, melee.market1.symbolEmojis, melee.market2.symbolEmojis);
+
+    await waitUntilCurrentMeleeEnds();
+
+    // In order to crank
+    await enterHelper(account1, "symbol1");
+
+    const registry = await fetchArenaRegistryView();
+
+    expect(registry.currentMeleeID).toEqual(melee.view.meleeID + 1n);
+
+    await sleep(2000);
+
+    await waitForProcessor(
+      await emojicoin.arena.swap(account2, melee.market1.symbolEmojis, melee.market2.symbolEmojis)
+    );
+
+    const swaps = await postgrest
+      .from(TableName.ArenaSwapEvents)
+      .select("*")
+      .eq("melee_id", melee.view.meleeID)
+      .order("transaction_version")
+      .then((r) => r.data)
+      .then((r) => (r === null ? null : r.map(toArenaSwapModel)));
+
+    const exits = await postgrest
+      .from(TableName.ArenaExitEvents)
+      .select("*")
+      .eq("melee_id", melee.view.meleeID)
+      .order("transaction_version")
+      .then((r) => r.data)
+      .then((r) => (r === null ? null : r.map(toArenaExitModel)));
+
+    const positions = await postgrest
+      .from(TableName.ArenaPosition)
+      .select("*")
+      .eq("melee_id", melee.view.meleeID)
+      .then((r) => r.data)
+      .then((r) => (r === null ? null : r.map(toArenaPositionModel)));
+
+    const leaderboard = await postgrest
+      .from(TableName.ArenaLeaderboardHistory)
+      .select("*")
+      .eq("melee_id", melee.view.meleeID)
+      .then((r) => r.data)
+      .then((r) => (r === null ? null : r.map(toArenaLeaderboardHistoryModel)));
+
+    expect(swaps).not.toBeNull();
+    expect(swaps).toHaveLength(1);
+
+    expect(swaps![0].swap.duringMelee).toEqual(false);
+
+    expect(exits).not.toBeNull();
+    expect(exits).toHaveLength(2);
+
+    expect(exits![0].exit.duringMelee).toEqual(true);
+    expect(exits![1].exit.duringMelee).toEqual(false);
+
+    expect(positions).not.toBeNull();
+    expect(positions).toHaveLength(2);
+    expect(positions).toHaveLength(2);
+
+    const position1 = positions!.find((p) => p.user === account1.accountAddress.toStringLong())!;
+    const position2 = positions!.find((p) => p.user === account2.accountAddress.toStringLong())!;
+
+    expect(position1.open).toEqual(false);
+    expect(position2.open).toEqual(false);
+
+    expect(position1.lastExit0).toEqual(true);
+    expect(position2.lastExit0).toEqual(false);
+
+    expect(leaderboard).not.toBeNull();
+    expect(leaderboard).toHaveLength(2);
+
+    const leaderboard1 = leaderboard!.find(
+      (l) => l.user === account1.accountAddress.toStringLong()
+    )!;
+    const leaderboard2 = leaderboard!.find(
+      (l) => l.user === account2.accountAddress.toStringLong()
+    )!;
+
+    expect(leaderboard1.exited).toEqual(true);
+    expect(leaderboard2.exited).toEqual(true);
+
+    expect(leaderboard1.emojicoin0Balance).toEqual(0n);
+    expect(leaderboard2.emojicoin0Balance).toBeGreaterThan(0n);
+
+    expect(leaderboard1.emojicoin1Balance).toEqual(0n);
+    expect(leaderboard2.emojicoin1Balance).toEqual(0n);
+
+    expect(leaderboard1.withdrawals).toBeGreaterThan(0n);
+    expect(leaderboard2.withdrawals).toEqual(0n);
+
+    expect(leaderboard1.lastExit0).toEqual(true);
+    expect(leaderboard2.lastExit0).toEqual(false);
   }, 30000);
 });

--- a/src/typescript/sdk/tests/e2e/arena/general.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/general.test.ts
@@ -434,14 +434,14 @@ describe("ensures leaderboard history is working", () => {
 
     expect(leaderboard1.exited).toEqual(true);
     expect(leaderboard1.lastExit0).toEqual(true);
-    expect(Number(leaderboard![0].profits) / Number(leaderboard![0].losses)).toBeGreaterThan(1);
+    expect(Number(leaderboard1.profits) / Number(leaderboard1.losses)).toBeGreaterThan(1);
 
     expect(leaderboard2.exited).toEqual(true);
     expect(leaderboard2.lastExit0).toEqual(false);
 
     expect(leaderboard3.exited).toEqual(false);
     expect(leaderboard3.lastExit0).toBeNull();
-    expect(Number(leaderboard![2].profits) / Number(leaderboard![2].losses)).toBeLessThan(1);
+    expect(Number(leaderboard3.profits) / Number(leaderboard3.losses)).toBeLessThan(1);
   }, 15000);
 
   it("verifies the data during a melee with no activity", async () => {

--- a/src/typescript/sdk/tests/e2e/arena/general.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/general.test.ts
@@ -414,7 +414,9 @@ describe("ensures leaderboard history is working", () => {
   let accountIndex = 100;
 
   const getNextAccount = () =>
-    getFundedAccount((accountIndex++).toString().padStart(3, "0") as FundedAccountIndex);
+    getFundedAccount(
+      (accountIndex++).toString() as unknown as Parameters<typeof getFundedAccount>[0]
+    );
 
   // Utility function to avoid repetitive code. Only the `account` and `escrowCoin` differs.
   const enterHelper = (account: Account, escrowCoin: "symbol1" | "symbol2") =>

--- a/src/typescript/sdk/tests/e2e/arena/general.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/general.test.ts
@@ -30,7 +30,7 @@ import {
   fetchMeleeEmojiData,
   type MeleeEmojiData,
 } from "../../../src/markets/arena-utils";
-import { getFundedAccount } from "../../utils/test-accounts";
+import { type FundedAccountIndex, getFundedAccount } from "../../utils/test-accounts";
 import {
   ONE_SECOND_MICROSECONDS,
   setNextMeleeDurationAndEnsureCrank,
@@ -414,9 +414,7 @@ describe("ensures leaderboard history is working", () => {
   let accountIndex = 100;
 
   const getNextAccount = () =>
-    getFundedAccount(
-      (accountIndex++).toString() as unknown as Parameters<typeof getFundedAccount>[0]
-    );
+    getFundedAccount((accountIndex++).toString().padStart(3, "0") as FundedAccountIndex);
 
   // Utility function to avoid repetitive code. Only the `account` and `escrowCoin` differs.
   const enterHelper = (account: Account, escrowCoin: "symbol1" | "symbol2") =>

--- a/src/typescript/sdk/tests/e2e/arena/utils.ts
+++ b/src/typescript/sdk/tests/e2e/arena/utils.ts
@@ -1,13 +1,13 @@
 // cspell:word funder
 
 import { EmojicoinArena } from "@/contract-apis";
-import { UserTransactionResponse, type Account } from "@aptos-labs/ts-sdk";
+import type { UserTransactionResponse, Account } from "@aptos-labs/ts-sdk";
 import {
   type SymbolEmoji,
   fetchArenaRegistryView,
   fetchArenaMeleeView,
   fetchMeleeEmojiData,
-  AnyNumberString,
+  type AnyNumberString,
 } from "../../../src";
 import { EmojicoinClient } from "../../../src/client/emojicoin-client";
 import { getPublisher, getAptosClient } from "../../utils";


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR uses different account for different tests to avoid test data collision.
