### PR TITLE
chore(ECO-2882): Bump frontend version

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -120,5 +120,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.4.1"
+  "version": "1.5.0"
 }


### PR DESCRIPTION
# Description

The SDK was already recently bumped and just merged, with the new version being `0.5.2`.

- [x] Bump the frontend minor version to reflect the new `/wallet/[address]` page and `Top Holders` features.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
