### PR TITLE
fix(ECO-2920): Display market cap in USD on My Emojicoins page unless APT price isn't available

### DIFF
--- a/src/typescript/frontend/src/components/pages/wallet/PortfolioRow.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/PortfolioRow.tsx
@@ -53,7 +53,16 @@ export const PortfolioRow = ({ coinData, index, totalValue }: Props) => {
       </TableCell>
       <TableCell className="text-right">
         <span className="flex items-center justify-end gap-1">
-          <AptCell value={coinData.marketCap} />
+          {aptPrice ? (
+            <FormattedNumber
+              value={coinData.marketCap * aptPrice}
+              prefix={"$"}
+              style={"fixed"}
+              decimals={2}
+            />
+          ) : (
+            <AptCell value={coinData.marketCap} />
+          )}
         </span>
       </TableCell>
       <TableCell className="text-right">


### PR DESCRIPTION
# Description

Fairly self-explanatory.

- [x] Display market cap in USD on My Emojicoins page unless APT price isn't available

![image](https://github.com/user-attachments/assets/fa080104-6c8d-4193-b5b4-bef2ef818cca)

# Testing

Tested on a local build

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
