### PR TITLE
fix(ECO-2918): Fix trade history and my emojicoins on mobile

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -173,7 +173,10 @@ const MainInfo = ({ data }: MainInfoProps) => {
                 gap: "1em",
                 flexDirection: "column",
                 width: "100%",
-                padding: "40px",
+                paddingRight: "0px",
+                paddingLeft: "0px",
+                paddingTop: "40px",
+                paddingBottom: "40px",
               }
             : {
                 display: "grid",

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -173,10 +173,7 @@ const MainInfo = ({ data }: MainInfoProps) => {
                 gap: "1em",
                 flexDirection: "column",
                 width: "100%",
-                paddingRight: "0px",
-                paddingLeft: "0px",
-                paddingTop: "40px",
-                paddingBottom: "40px",
+                padding: "40px 0px",
               }
             : {
                 display: "grid",

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
@@ -22,7 +22,7 @@ import { TradeHistory } from "../trade-history/trade-history";
 const DISPLAY_HEADER_ABOVE_CHART = false;
 const HEIGHT = DISPLAY_HEADER_ABOVE_CHART ? "min-h-[320px]" : "min-h-[365px]";
 
-const TABS = ["Trade History", "Swap", "Chat", "Top Holders"] as const;
+const TABS = ["Trades", "Swap", "Chat", "Holders"] as const;
 
 const MobileGrid = (props: GridProps) => {
   const [tab, setTab] = useState<(typeof TABS)[number]>("Swap");
@@ -68,8 +68,8 @@ const MobileGrid = (props: GridProps) => {
         )}
 
         <StyledMobileContentInner>
-          {tab === "Trade History" && <TradeHistory data={props.data} />}
-          {tab === "Top Holders" && (
+          {tab === "Trades" && <TradeHistory data={props.data} />}
+          {tab === "Holders" && (
             <CoinHolders
               emojicoin={props.data.symbol}
               holders={props.data.holders}

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/styled.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/styled.tsx
@@ -4,8 +4,8 @@ export const StyledMobileContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   border: 1px solid ${({ theme }) => theme.colors.darkGray};
-  margin-left: 30px;
-  margin-right: 30px;
+  margin-left: 10px;
+  margin-right: 10px;
   position: relative;
 
   &:before {

--- a/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
@@ -54,13 +54,13 @@ export const WalletClientPage = ({ address }: { address: string }) => {
 
   return (
     <>
-      <span className="pixel-heading-2">
+      <span className="pixel-heading-2 mobile-sm:px-4 sm:px-0 flex flex-wrap gap-x-2 mb-4">
         Portfolio of{" "}
         <ExplorerLink className="text-ec-blue hover:underline" type="account" value={address}>
           {formatDisplayName(resolvedName, { noTruncateANSName: true })}
         </ExplorerLink>
       </span>
-      <div className="flex justify-between w-full mb-4">
+      <div className="flex justify-between w-full mb-4 flex-wrap gap-x-2 mobile-sm:px-4 sm:px-0">
         <span className="pixel-heading-3b">
           {"Total value: "}
           {isLoading ? (

--- a/src/typescript/frontend/src/components/ui/table/ecTableBody.tsx
+++ b/src/typescript/frontend/src/components/ui/table/ecTableBody.tsx
@@ -2,7 +2,6 @@ import { Fragment, useMemo } from "react";
 import { type TableProps } from "./ecTable";
 import { TableBody, TableCell, TableRow } from "./table";
 import { EcTableRow } from "./ecTableRow";
-import { cn } from "lib/utils/class-name";
 
 export const EcTableBody = <T,>({
   containerHeight,

--- a/src/typescript/frontend/src/components/ui/table/ecTableBody.tsx
+++ b/src/typescript/frontend/src/components/ui/table/ecTableBody.tsx
@@ -45,7 +45,7 @@ export const EcTableBody = <T,>({
           ))}
       {Array.from({ length: minRows - items.length }).map((_, i) => (
         <TableRow key={i} index={items.length + i} height={rowHeight} className="w-full">
-          {/* This is required for some browsers, otherwise the row doesn't take the full width */}
+          {/* Fill the row with empty cells, otherwise on some browsers the row won't be the full width */}
           {columns.map((c) => (
             <TableCell key={c.id} />
           ))}

--- a/src/typescript/frontend/src/components/ui/table/ecTableBody.tsx
+++ b/src/typescript/frontend/src/components/ui/table/ecTableBody.tsx
@@ -2,6 +2,7 @@ import { Fragment, useMemo } from "react";
 import { type TableProps } from "./ecTable";
 import { TableBody, TableCell, TableRow } from "./table";
 import { EcTableRow } from "./ecTableRow";
+import { cn } from "lib/utils/class-name";
 
 export const EcTableBody = <T,>({
   containerHeight,
@@ -43,8 +44,11 @@ export const EcTableBody = <T,>({
             />
           ))}
       {Array.from({ length: minRows - items.length }).map((_, i) => (
-        <TableRow key={i} index={items.length + i} height={rowHeight}>
-          <TableCell className="absolute !w-full !h-full" />
+        <TableRow key={i} index={items.length + i} height={rowHeight} className="w-full">
+          {/* This is required for some browsers, otherwise the row doesn't take the full width */}
+          {columns.map((c) => (
+            <TableCell key={c.id} />
+          ))}
         </TableRow>
       ))}
     </TableBody>

--- a/src/typescript/frontend/src/components/ui/table/table.tsx
+++ b/src/typescript/frontend/src/components/ui/table/table.tsx
@@ -102,8 +102,6 @@ const TableRow = React.forwardRef<
       layout
       initial={{
         opacity: 0,
-        filter: "brightness(1) saturate(1)",
-        boxShadow: "0 0 0px 0px rgba(0, 0, 0, 0)",
       }}
       animate={{
         opacity: 1,
@@ -112,21 +110,12 @@ const TableRow = React.forwardRef<
           delay,
         },
       }}
-      whileHover={
-        !isHeader
-          ? {
-              filter: "brightness(1.05) saturate(1.1)",
-              boxShadow: "0 0 9px 7px rgba(8, 108, 217, 0.2)",
-              transition: { duration: 0.05 },
-            }
-          : {}
-      }
       ref={ref}
       style={{ height, ...props.style }}
       className={cn(
         "relative w-full",
         !isHeader && !noHover
-          ? "border-solid border-y border-dark-gray transition-colors hover:border-ec-blue hover:border-2 hover:z-10"
+          ? "border-solid border-y border-dark-gray transition-colors hover:shadow-[inset_0px_0px_0px_2px_#086CD9] border-2 hover:z-10"
           : "",
         className
       )}

--- a/src/typescript/frontend/src/components/ui/table/table.tsx
+++ b/src/typescript/frontend/src/components/ui/table/table.tsx
@@ -18,9 +18,10 @@ const TableHeader = React.forwardRef<
   <thead
     ref={ref}
     className={cn(
-      "text-ec-blue body-lg bg-black uppercase text-center sticky -top-[1px] z-10",
+      "text-ec-blue body-lg bg-black uppercase text-center sticky top-0 z-50 border-y border-dark-gray bg-clip-padding",
       "[&_td]:!border [&_td]:!border-dark-gray [&_td]:before:absolute [&_td]:before:top-0",
       "[&_td]:before:h-[1px] [&_td]:before:w-full [&_td]:before:bg-dark-gray",
+      "before:absolute before:top-0 before:left-0 before:w-full before:h-[1px] before:bg-dark-gray before:z-50 after:absolute after:bottom-0 after:left-0 after:w-full after:h-[1px] after:bg-dark-gray",
       className
     )}
     {...props}
@@ -123,24 +124,15 @@ const TableRow = React.forwardRef<
       ref={ref}
       style={{ height, ...props.style }}
       className={cn(
-        "relative w-full group",
-        !isHeader ? "border-solid border-b border-dark-gray" : "",
+        "relative w-full",
+        !isHeader && !noHover
+          ? "border-solid border-y border-dark-gray transition-colors hover:border-ec-blue hover:border-2 hover:z-10"
+          : "",
         className
       )}
       {...props}
     >
       {props.children as React.ReactNode}
-      {
-        <td
-          className={cn(
-            "absolute bg-transparent z-[1] inline-flex left-0 w-full h-full pointer-events-none",
-            !isHeader &&
-              !noHover &&
-              "group-hover:border-solid group-hover:border-ec-blue border-[2px]",
-            isHeader && "border-solid border-[1px] border-dark-gray border-t"
-          )}
-        />
-      }
     </motion.tr>
   );
 });

--- a/src/typescript/frontend/src/components/ui/table/table.tsx
+++ b/src/typescript/frontend/src/components/ui/table/table.tsx
@@ -101,19 +101,8 @@ const TableRow = React.forwardRef<
     <motion.tr
       layout
       initial={{
-        filter: "brightness(1) saturate(1)",
-        boxShadow: "0 0 0px 0px rgba(0, 0, 0, 0)",
         opacity: 0,
       }}
-      whileHover={
-        !isHeader
-          ? {
-              filter: "brightness(1.05) saturate(1.1)",
-              boxShadow: "0 0 9px 7px rgba(8, 108, 217, 0.2)",
-              transition: { duration: 0.05 },
-            }
-          : {}
-      }
       animate={{
         opacity: 1,
         transition: {
@@ -126,7 +115,7 @@ const TableRow = React.forwardRef<
       className={cn(
         "relative w-full",
         !isHeader && !noHover
-          ? "border-solid border-y border-dark-gray transition-colors border-2 hover:z-10 before:absolute before:top-0 before:left-0 before:h-full before:w-full before:hover:shadow-[0px_0px_0px_2px_#086CD9]"
+          ? "border-solid border-y border-dark-gray transition-colors hover:shadow-[inset_0px_0px_0px_2px_#086CD9] border-2 hover:z-10"
           : "",
         className
       )}

--- a/src/typescript/frontend/src/components/ui/table/table.tsx
+++ b/src/typescript/frontend/src/components/ui/table/table.tsx
@@ -101,6 +101,8 @@ const TableRow = React.forwardRef<
     <motion.tr
       layout
       initial={{
+        filter: "brightness(1) saturate(1)",
+        boxShadow: "0 0 0px 0px rgba(0, 0, 0, 0)",
         opacity: 0,
       }}
       animate={{
@@ -110,12 +112,21 @@ const TableRow = React.forwardRef<
           delay,
         },
       }}
+      whileHover={
+        !isHeader
+          ? {
+              filter: "brightness(1.05) saturate(1.1)",
+              boxShadow: "0px 0px 4px 2px #086CD9",
+              transition: { duration: 0.01 },
+            }
+          : {}
+      }
       ref={ref}
       style={{ height, ...props.style }}
       className={cn(
         "relative w-full",
         !isHeader && !noHover
-          ? "border-solid border-y border-dark-gray transition-colors hover:shadow-[inset_0px_0px_0px_2px_#086CD9] border-2 hover:z-10"
+          ? "border-solid border-y border-dark-gray transition-colors border-2 hover:z-10"
           : "",
         className
       )}

--- a/src/typescript/frontend/src/components/ui/table/table.tsx
+++ b/src/typescript/frontend/src/components/ui/table/table.tsx
@@ -101,8 +101,19 @@ const TableRow = React.forwardRef<
     <motion.tr
       layout
       initial={{
+        filter: "brightness(1) saturate(1)",
+        boxShadow: "0 0 0px 0px rgba(0, 0, 0, 0)",
         opacity: 0,
       }}
+      whileHover={
+        !isHeader
+          ? {
+              filter: "brightness(1.05) saturate(1.1)",
+              boxShadow: "0 0 9px 7px rgba(8, 108, 217, 0.2)",
+              transition: { duration: 0.05 },
+            }
+          : {}
+      }
       animate={{
         opacity: 1,
         transition: {
@@ -115,7 +126,7 @@ const TableRow = React.forwardRef<
       className={cn(
         "relative w-full",
         !isHeader && !noHover
-          ? "border-solid border-y border-dark-gray transition-colors hover:shadow-[inset_0px_0px_0px_2px_#086CD9] border-2 hover:z-10"
+          ? "border-solid border-y border-dark-gray transition-colors border-2 hover:z-10 before:absolute before:top-0 before:left-0 before:h-full before:w-full before:hover:shadow-[0px_0px_0px_2px_#086CD9]"
           : "",
         className
       )}


### PR DESCRIPTION
Fixes and minor improvements on mobile.

## Table issue
Having an absolute positionned td inside of the tr to handle the hover effect was causing issues on some devices/browsers.
I managed to have the hover-effect working without needing the absolutely-positioned td.

Additionnaly, I took the liberty to reduce the horizontal padding on mobile for the market page.

## Before
<img width="179" alt="image" src="https://github.com/user-attachments/assets/0ed068b7-bc85-4136-a4c6-f9d15111dde7" />

## After
<img width="177" alt="image" src="https://github.com/user-attachments/assets/73985ab1-93e0-497d-add3-135ea606046f" />
