### PR TITLE
feat(ECO-2928): Add `/api/trending` route

### DIFF
--- a/src/typescript/frontend/src/app/api/trending/route.ts
+++ b/src/typescript/frontend/src/app/api/trending/route.ts
@@ -24,42 +24,45 @@ import { fetchCachedPriceFeed, NUM_MARKETS_ON_PRICE_FEED } from "lib/queries/pri
  * ```json
  * [
  *   {
- *     "market_nonce": 26245,
  *     "market_id": 413,
  *     "symbol_bytes": "0xf09fa7a7",
  *     "symbol_emojis": ["🧧"],
  *     "market_address": "0x6b0debd0d80e34b073b1de5f8bfe27983dd604497ac457fb082844894a3e548d",
+ *     "theoretical_curve_price": 0.03549040905972445,
+ *     "market_nonce": 26386,
+ *     "in_bonding_curve": false,
  *     "clamm_virtual_reserves": {
  *       "base": 0,
  *       "quote": 0
  *     },
  *     "cpamm_real_reserves": {
- *       "base": 559288.95671031,
- *       "quote": 19814.01809551
+ *       "base": 558793.14425783,
+ *       "quote": 19831.79726948
  *     },
  *     "cumulative_stats": {
- *       "base_volume": 102726771.2477148,
- *       "quote_volume": 515902.75892755,
- *       "integrator_fees": 5097.5643033,
- *       "pool_fees_base": 76889.80051043,
- *       "pool_fees_quote": 626.22126947,
- *       "n_swaps": 25370,
+ *       "base_volume": 102729004.71052358,
+ *       "quote_volume": 515981.96931268,
+ *       "integrator_fees": 5097.70502162,
+ *       "pool_fees_base": 76893.22065444,
+ *       "pool_fees_quote": 626.29825998,
+ *       "n_swaps": 25511,
  *       "n_chat_messages": 840
  *     },
  *     "instantaneous_stats": {
- *       "total_quote_locked": 19814.01809551,
- *       "total_value_locked": 39628.03619102,
- *       "market_cap": 1574408.08051778,
- *       "fully_diluted_value": 1594222.09861329,
- *       "market_cap_usd": 9608140.192975856
+ *       "circulating_supply": 44441206.85574217,
+ *       "total_quote_locked": 19831.79726948,
+ *       "total_value_locked": 39663.59453896,
+ *       "fully_diluted_value": 1597068.4076876,
+ *       "market_cap_apt": 1577236.61041812,
+ *       "market_cap_usd": 9086302.388957748
  *     },
- *     "daily_tvl_lp_growth": 0.99959452,
- *     "in_bonding_curve": false,
- *     "daily_volume_apt": 4192.15884355,
- *     "daily_volume_emojicoin": 109780.70181239,
- *     "price_current": 0.03533928558048081,
- *     "price_24h_ago": 0.04395169029413305,
- *     "price_delta_24h": -19.595161542175966
+ *     "daily_tvl_lp_growth": 1.0004915,
+ *     "daily_volume_quote": 3825.62539183,
+ *     "daily_volume_base": 101609.09655166,
+ *     "quote_price": 0.03557685205345566,
+ *     "quote_price_24h_ago": 0.04263140726110441,
+ *     "quote_price_delta_24h": -16.547788733413714,
+ *     "usd_price": 0.20495468699475275
  *   }
  * ]
  * ```

--- a/src/typescript/frontend/src/app/api/trending/route.ts
+++ b/src/typescript/frontend/src/app/api/trending/route.ts
@@ -9,6 +9,7 @@ import { getAptPrice } from "lib/queries/get-apt-price";
 import { DECIMALS } from "@sdk/const";
 import { q64ToBig } from "@sdk/utils";
 import { fetchCachedPriceFeed, NUM_MARKETS_ON_PRICE_FEED } from "lib/queries/price-feed";
+import { type AccountAddress } from "@aptos-labs/ts-sdk";
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 /**
@@ -25,6 +26,8 @@ import { fetchCachedPriceFeed, NUM_MARKETS_ON_PRICE_FEED } from "lib/queries/pri
  *
  * All APT and emojicoin values are converted to their decimalized formats; that is, they are
  * divided by 10 ^ {@link DECIMALS}.
+ * 
+ * All addresses are AIP-40 compliant. See `.toString()` in {@link AccountAddress}.
  *
  * `base` always refers to the emojicoin.
  *

--- a/src/typescript/frontend/src/app/api/trending/route.ts
+++ b/src/typescript/frontend/src/app/api/trending/route.ts
@@ -69,14 +69,12 @@ import { fetchCachedPriceFeed, NUM_MARKETS_ON_PRICE_FEED } from "lib/queries/pri
  */
 export async function GET(_request: Request) {
   try {
-    const res = await getAptPrice().then((aptPrice) =>
-      fetchCachedPriceFeed().then((res) =>
-        res.map((v) => {
-          (v as TrendingMarketArgs)["apt_price"] = aptPrice;
-          return toTrendingMarket(v);
-        })
-      )
-    );
+    const aptPrice = await getAptPrice();
+    const priceFeed = await fetchCachedPriceFeed();
+    const res = priceFeed.map((mkt) => {
+      (mkt as TrendingMarketArgs)["apt_price"] = aptPrice;
+      return toTrendingMarket(mkt);
+    });
 
     return NextResponse.json<TrendingMarketsResponse>(res);
   } catch (error) {

--- a/src/typescript/frontend/src/app/api/trending/route.ts
+++ b/src/typescript/frontend/src/app/api/trending/route.ts
@@ -26,7 +26,7 @@ import { type AccountAddress } from "@aptos-labs/ts-sdk";
  *
  * All APT and emojicoin values are converted to their decimalized formats; that is, they are
  * divided by 10 ^ {@link DECIMALS}.
- * 
+ *
  * All addresses are AIP-40 compliant. See `.toString()` in {@link AccountAddress}.
  *
  * `base` always refers to the emojicoin.

--- a/src/typescript/frontend/src/app/api/trending/route.ts
+++ b/src/typescript/frontend/src/app/api/trending/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import {
+  toTrendingMarket,
+  type TrendingMarketArgs,
+  type TrendingMarketsResponse,
+} from "@sdk/indexer-v2/queries";
+import { getAptPrice } from "lib/queries/get-apt-price";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { DECIMALS } from "@sdk/const";
+import { q64ToBig } from "@sdk/utils";
+import { fetchCachedPriceFeed, NUM_MARKETS_ON_PRICE_FEED } from "lib/queries/price-feed";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+/**
+ * Returns the top {@link NUM_MARKETS_ON_PRICE_FEED} markets in the form of a JSON response.
+ *
+ * NOTES:
+ *   - All q64 values are normalized to decimalized values with {@link q64ToBig}
+ *   - All APT and emojicoin values are converted to their decimalized formats; that is, they are
+ *     divided by 10 ^ {@link DECIMALS}.
+ *
+ * @returns the top trending markets {@link TrendingMarketsResponse}
+ * @example
+ * ```json
+ * [
+ *   {
+ *     "market_nonce": 26245,
+ *     "market_id": 413,
+ *     "symbol_bytes": "0xf09fa7a7",
+ *     "symbol_emojis": ["🧧"],
+ *     "market_address": "0x6b0debd0d80e34b073b1de5f8bfe27983dd604497ac457fb082844894a3e548d",
+ *     "clamm_virtual_reserves": {
+ *       "base": 0,
+ *       "quote": 0
+ *     },
+ *     "cpamm_real_reserves": {
+ *       "base": 559288.95671031,
+ *       "quote": 19814.01809551
+ *     },
+ *     "cumulative_stats": {
+ *       "base_volume": 102726771.2477148,
+ *       "quote_volume": 515902.75892755,
+ *       "integrator_fees": 5097.5643033,
+ *       "pool_fees_base": 76889.80051043,
+ *       "pool_fees_quote": 626.22126947,
+ *       "n_swaps": 25370,
+ *       "n_chat_messages": 840
+ *     },
+ *     "instantaneous_stats": {
+ *       "total_quote_locked": 19814.01809551,
+ *       "total_value_locked": 39628.03619102,
+ *       "market_cap": 1574408.08051778,
+ *       "fully_diluted_value": 1594222.09861329,
+ *       "market_cap_usd": 9608140.192975856
+ *     },
+ *     "daily_tvl_lp_growth": 0.99959452,
+ *     "in_bonding_curve": false,
+ *     "daily_volume_apt": 4192.15884355,
+ *     "daily_volume_emojicoin": 109780.70181239,
+ *     "price_current": 0.03533928558048081,
+ *     "price_24h_ago": 0.04395169029413305,
+ *     "price_delta_24h": -19.595161542175966
+ *   }
+ * ]
+ * ```
+ */
+export async function GET(_request: Request) {
+  try {
+    const res = await getAptPrice().then((aptPrice) =>
+      fetchCachedPriceFeed().then((res) =>
+        res.map((v) => {
+          (v as TrendingMarketArgs)["apt_price"] = aptPrice;
+          return toTrendingMarket(v);
+        })
+      )
+    );
+
+    return NextResponse.json<TrendingMarketsResponse>(res);
+  } catch (error) {
+    console.error("Failed to fetch trending markets:", error);
+
+    return new NextResponse("Failed to fetch trending markets.", { status: 500 });
+  }
+}

--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -166,7 +166,7 @@ export const Chart = (props: ChartContainerProps) => {
             countBack: countBack.toString(),
             to: to.toString(),
           });
-          const data: PeriodicStateEventModel[] = await fetch(`/candlesticks?${params.toString()}`)
+          const data: PeriodicStateEventModel[] = await fetch(`${ROUTES.candlesticks}?${params.toString()}`)
             .then((res) => res.text())
             .then((res) => parseJSON(res));
 

--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -166,7 +166,9 @@ export const Chart = (props: ChartContainerProps) => {
             countBack: countBack.toString(),
             to: to.toString(),
           });
-          const data: PeriodicStateEventModel[] = await fetch(`${ROUTES.candlesticks}?${params.toString()}`)
+          const data: PeriodicStateEventModel[] = await fetch(
+            `${ROUTES.candlesticks}?${params.toString()}`
+          )
             .then((res) => res.text())
             .then((res) => parseJSON(res));
 

--- a/src/typescript/frontend/src/lib/queries/price-feed.ts
+++ b/src/typescript/frontend/src/lib/queries/price-feed.ts
@@ -1,0 +1,19 @@
+import { fetchPriceFeedWithMarketState } from "@/queries/home";
+import { SortMarketsBy } from "@econia-labs/emojicoin-sdk";
+import { ORDER_BY } from "@sdk/indexer-v2/const";
+import { unstable_cache } from "next/cache";
+
+export const NUM_MARKETS_ON_PRICE_FEED = 25;
+
+const fetchPriceFeed = () =>
+  fetchPriceFeedWithMarketState({
+    sortBy: SortMarketsBy.DailyVolume,
+    orderBy: ORDER_BY.DESC,
+    pageSize: NUM_MARKETS_ON_PRICE_FEED,
+  });
+
+export const fetchCachedPriceFeed = unstable_cache(
+  fetchPriceFeed,
+  ["price-feed-with-market-data"],
+  { revalidate: 10 }
+);

--- a/src/typescript/frontend/src/lib/utils/decimals.ts
+++ b/src/typescript/frontend/src/lib/utils/decimals.ts
@@ -1,6 +1,7 @@
 import Big from "big.js";
 import { DECIMALS } from "@sdk/const";
 import { type AnyNumberString } from "@sdk-types";
+import { toNominal } from "@sdk/utils";
 
 // Converts a number to its representation in coin decimals.
 // Both APT and emojicoins use a fixed number of decimals: 8.
@@ -61,7 +62,5 @@ const toDisplayCoinDecimals = ({
   }
   return res.toString();
 };
-
-const toNominal = (num: bigint) => new Big(num.toString()).div(10 ** DECIMALS).toNumber();
 
 export { toDisplayCoinDecimals, toActualCoinDecimals, toNominal };

--- a/src/typescript/frontend/src/router/routes.ts
+++ b/src/typescript/frontend/src/router/routes.ts
@@ -2,7 +2,10 @@
 export const ROUTES = {
   root: "/",
   // Alphabetized after this.
-  api: "/api",
+  api: {
+    trending: "/api/trending",
+  },
+  candlesticks: "/candlesticks",
   cult: "/cult",
   dexscreener: "/dexscreener",
   docs: "https://docs.emojicoin.fun/category/--start-here",

--- a/src/typescript/sdk/src/indexer-v2/queries/api/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./trending";

--- a/src/typescript/sdk/src/indexer-v2/queries/api/trending.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/api/trending.ts
@@ -1,0 +1,64 @@
+import { deserializeToHexString, toNominal } from "../../../utils";
+import { type DatabaseJsonType, toPriceFeedData } from "../../types";
+import { DECIMALS } from "../../../const"; /* eslint-disable-line */
+
+export type TrendingMarketsResponse = TrendingMarket[];
+export type TrendingMarket = ReturnType<typeof toTrendingMarket>;
+export type TrendingMarketArgs = DatabaseJsonType["price_feed"] & { apt_price?: number };
+
+const coin = (v: string) => toNominal(BigInt(v));
+
+/**
+ * Converts data from the `price_feed` view into a `TrendingMarket` for the trending markets
+ * API route.
+ *
+ * NOTE: All fields in this response that represent coin values are converted to their nominal
+ * value form. That is, they are divided by 10 ^ {@link DECIMALS}.
+ *
+ * @param data
+ * @returns a JSON response of price feed and market data, intended to be consumed as a
+ * public API.
+ *
+ */
+export const toTrendingMarket = (data: TrendingMarketArgs) => {
+  const priceFeedData = toPriceFeedData(data);
+  const market_cap = coin(data.instantaneous_stats_market_cap);
+  return {
+    market_nonce: Number(data.market_nonce),
+    market_id: Number(data.market_id),
+    symbol_bytes: deserializeToHexString(data.symbol_bytes),
+    symbol_emojis: data.symbol_emojis,
+    market_address: data.market_address,
+    clamm_virtual_reserves: {
+      base: coin(data.clamm_virtual_reserves_base),
+      quote: coin(data.clamm_virtual_reserves_quote),
+    },
+    cpamm_real_reserves: {
+      base: coin(data.cpamm_real_reserves_base),
+      quote: coin(data.cpamm_real_reserves_quote),
+    },
+    cumulative_stats: {
+      base_volume: coin(data.cumulative_stats_base_volume),
+      quote_volume: coin(data.cumulative_stats_quote_volume),
+      integrator_fees: coin(data.cumulative_stats_integrator_fees),
+      pool_fees_base: coin(data.cumulative_stats_pool_fees_base),
+      pool_fees_quote: coin(data.cumulative_stats_pool_fees_quote),
+      n_swaps: Number(data.cumulative_stats_n_swaps),
+      n_chat_messages: Number(data.cumulative_stats_n_chat_messages),
+    },
+    instantaneous_stats: {
+      total_quote_locked: coin(data.instantaneous_stats_total_quote_locked),
+      total_value_locked: coin(data.instantaneous_stats_total_value_locked),
+      market_cap,
+      fully_diluted_value: coin(data.instantaneous_stats_fully_diluted_value),
+      market_cap_usd: data.apt_price ? market_cap * data.apt_price : undefined,
+    },
+    daily_tvl_lp_growth: Number(Number(data.daily_tvl_per_lp_coin_growth).toPrecision(8)),
+    in_bonding_curve: data.in_bonding_curve,
+    daily_volume_apt: coin(data.daily_volume),
+    daily_volume_emojicoin: coin(data.daily_base_volume),
+    price_current: priceFeedData.closePrice,
+    price_24h_ago: priceFeedData.openPrice,
+    price_delta_24h: priceFeedData.deltaPercentage,
+  };
+};

--- a/src/typescript/sdk/src/indexer-v2/queries/api/trending.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/api/trending.ts
@@ -4,7 +4,6 @@ import { DECIMALS } from "../../../const"; /* eslint-disable-line */
 import { calculateCirculatingSupply, calculateCurvePrice } from "../../../markets";
 import { toReserves } from "../../../types";
 
-export type TrendingMarketsResponse = TrendingMarket[];
 export type TrendingMarket = ReturnType<typeof toTrendingMarket>;
 export type TrendingMarketArgs = DatabaseJsonType["price_feed"] & { apt_price?: number };
 
@@ -13,20 +12,15 @@ const coin = (v: string) => toNominal(BigInt(v));
 /**
  * Converts data from the `price_feed` view into a `TrendingMarket` for the trending markets
  * API route.
+ * 
+ * If you pass `apt_price` to this function, it will calculate USD values for relevant fields.
  *
- * NOTE: All fields in this response that represent coin values are converted to their nominal
- * value form. That is, they are divided by 10 ^ {@link DECIMALS}.
- *
- * `base` always refers to the emojicoin.
- * `quote` always refers to APT.
- *
- * `theoretical_curve_price` is the exact current quote price on the curve- it doesn't mean the
- * price ever actually traded there. In other words, if a user traded an infinitesimally small
- * amount, that's the price they would get quoted at.
- *
- * @param data
+ * @param data a price feed query JSON response, possibly with `apt_price` included.
  * @returns a JSON response of price feed and market data, intended to be consumed as a
  * public API.
+ *
+ * See {@link [/api/trending](../../../../../frontend/src/app/api/trending/route.ts)} for more
+ * details.
  */
 export const toTrendingMarket = (data: TrendingMarketArgs) => {
   const priceFeedData = toPriceFeedData(data);

--- a/src/typescript/sdk/src/indexer-v2/queries/api/trending.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/api/trending.ts
@@ -3,6 +3,7 @@ import { type DatabaseJsonType, toPriceFeedData } from "../../types";
 import { DECIMALS } from "../../../const"; /* eslint-disable-line */
 import { calculateCirculatingSupply, calculateCurvePrice } from "../../../markets";
 import { toReserves } from "../../../types";
+import { AccountAddress } from "@aptos-labs/ts-sdk";
 
 export type TrendingMarket = ReturnType<typeof toTrendingMarket>;
 export type TrendingMarketArgs = DatabaseJsonType["price_feed"] & { apt_price?: number };
@@ -12,7 +13,7 @@ const coin = (v: string) => toNominal(BigInt(v));
 /**
  * Converts data from the `price_feed` view into a `TrendingMarket` for the trending markets
  * API route.
- * 
+ *
  * If you pass `apt_price` to this function, it will calculate USD values for relevant fields.
  *
  * @param data a price feed query JSON response, possibly with `apt_price` included.
@@ -38,11 +39,15 @@ export const toTrendingMarket = (data: TrendingMarketArgs) => {
   };
   const circulatingSupply = calculateCirculatingSupply(calculationArgs).toString();
   const curvePrice = calculateCurvePrice(calculationArgs);
+  const timestampAsUTC = `${data.transaction_timestamp}Z`;
   return {
+    transaction_version: Number(data.transaction_version),
+    sender: AccountAddress.from(data.sender).toString(),
+    transaction_timestamp: timestampAsUTC,
     market_id: Number(data.market_id),
     symbol_bytes: deserializeToHexString(data.symbol_bytes),
     symbol_emojis: data.symbol_emojis,
-    market_address: data.market_address,
+    market_address: AccountAddress.from(data.market_address).toString(),
     theoretical_curve_price: curvePrice.toNumber(),
     market_nonce: Number(data.market_nonce),
     in_bonding_curve: data.in_bonding_curve,

--- a/src/typescript/sdk/src/indexer-v2/queries/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/index.ts
@@ -1,3 +1,4 @@
+export * from "./api";
 export * from "./app";
 export * from "./client";
 export * from "./misc";

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -1,9 +1,4 @@
-import { hexToBytes } from "@noble/hashes/utils";
-import {
-  type Uint64String,
-  type AccountAddressString,
-  type HexString,
-} from "../../emojicoin_dot_fun";
+import { type Uint64String, type AccountAddressString } from "../../emojicoin_dot_fun";
 import {
   type AnyNumberString,
   type EventName,
@@ -26,7 +21,7 @@ import {
 } from "./json-types";
 import { type MarketEmojiData, type SymbolEmoji, toMarketEmojiData } from "../../emoji_data";
 import { toPeriod, toTrigger, type Period, type Trigger } from "../../const";
-import { toAccountAddressString } from "../../utils";
+import { deserializeToHexString, toAccountAddressString } from "../../utils";
 import Big from "big.js";
 import { q64ToBig } from "../../utils/nominal-price";
 
@@ -61,14 +56,6 @@ const toBlockAndEventIndex = (data: BlockAndEventIndexMetadata) =>
       }
     : undefined;
 
-/// If received from postgres, symbol bytes come in as a hex string in the format "\\xabcd" where
-/// "abcd" is the hex string.
-/// If received from the broker, the symbolBytes will be deserialized as an array of values.
-const deserializeSymbolBytes = (symbolBytes: HexString | Array<AnyNumberString>) =>
-  Array.isArray(symbolBytes)
-    ? new Uint8Array(symbolBytes.map(Number))
-    : hexToBytes(symbolBytes.replace(/\\x/g, ""));
-
 export type MarketMetadataModel = {
   marketID: bigint;
   time: bigint;
@@ -85,7 +72,7 @@ const toMarketMetadataModel = (
     | DatabaseStructType["MarketAndStateMetadata"]
     | WithEmitTime<DatabaseStructType["MarketAndStateMetadata"]>
 ): MarketMetadataModel => {
-  const symbolBytes = deserializeSymbolBytes(data.symbol_bytes);
+  const symbolBytes = deserializeToHexString(data.symbol_bytes);
 
   return {
     marketID: BigInt(data.market_id),

--- a/src/typescript/sdk/src/indexer-v2/types/json-types.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/json-types.ts
@@ -57,7 +57,7 @@ type PostgresTimestamp = string;
  *
  * NOTE: This function assumes that the input timestamp is in UTC, but without the "Z" suffix.
  * If that changes, this function will break. This is intentional.
-
+ *
  * This function takes a PostgreSQL timestamp string and converts it to the number of
  * microseconds elapsed since the Unix epoch (January 1, 1970, 00:00:00 UTC). It handles
  * timestamps with varying precision in the fractional seconds part, from 1 to 6 digits.

--- a/src/typescript/sdk/src/indexer-v2/types/json-types.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/json-types.ts
@@ -4,7 +4,6 @@ import { type SymbolEmoji } from "../../emoji_data";
 import type {
   UnsizedDecimalString,
   AccountAddressString,
-  HexString,
   Uint128String,
   Uint64String,
 } from "../../emojicoin_dot_fun/types";
@@ -58,7 +57,7 @@ type PostgresTimestamp = string;
  *
  * NOTE: This function assumes that the input timestamp is in UTC, but without the "Z" suffix.
  * If that changes, this function will break. This is intentional.
- *
+
  * This function takes a PostgreSQL timestamp string and converts it to the number of
  * microseconds elapsed since the Unix epoch (January 1, 1970, 00:00:00 UTC). It handles
  * timestamps with varying precision in the fractional seconds part, from 1 to 6 digits.
@@ -118,7 +117,7 @@ export const postgresTimestampToDate = (timestamp: PostgresTimestamp): Date => {
 
 // `inserted_at` is omitted if the data comes from the broker.
 type TransactionMetadata = {
-  transaction_version: Uint64String;
+  transaction_version: Uint64String | number;
   sender: AccountAddressString;
   entry_function?: string | null;
   transaction_timestamp: PostgresTimestamp;
@@ -130,9 +129,12 @@ export type BlockAndEventIndexMetadata = {
   event_index: number;
 };
 
+type PostgresBytes = `\\x${string}`;
+type BrokerBytes = number[];
+
 type MarketAndStateMetadata = {
   market_id: Uint64String;
-  symbol_bytes: HexString;
+  symbol_bytes: PostgresBytes | BrokerBytes;
   symbol_emojis: SymbolEmoji[];
   bump_time: PostgresTimestamp;
   market_nonce: Uint64String;

--- a/src/typescript/sdk/src/utils/hex.ts
+++ b/src/typescript/sdk/src/utils/hex.ts
@@ -37,7 +37,6 @@ export const normalizeHex = (hex: HexInput) => {
   return `0x${bytesToHex(bytes)}` as const;
 };
 
-//
 /**
  * Converts an input hex string or byte array to a hex string.
  *   - If received from postgrest, `BYTEA` bytes come in as a string in the format "\\xabcd" where

--- a/src/typescript/sdk/src/utils/hex.ts
+++ b/src/typescript/sdk/src/utils/hex.ts
@@ -36,3 +36,25 @@ export const normalizeHex = (hex: HexInput) => {
   }
   return `0x${bytesToHex(bytes)}` as const;
 };
+
+//
+/**
+ * Converts an input hex string or byte array to a hex string.
+ *   - If received from postgrest, `BYTEA` bytes come in as a string in the format "\\xabcd" where
+ *     "abcd" is the hex string.
+ *   - If received from the rust broker, the bytes will be a number[] array.
+ *
+ * Also accepts valid hex `string`, `0x${string}` and `Uint8Array` inputs.
+ *
+ * @param bytes the input hex string, number array, or byte array
+ * @returns a valid hex string: `0x${string}`
+ */
+export const deserializeToHexString = (
+  bytes: `0x${string}` | `\\x${string}` | number[] | Uint8Array
+): `0x${string}` => {
+  if (typeof bytes === "string") {
+    return `0x${bytes.replace(/^(0x|\\x)/, "")}`;
+  }
+  const uint8Arr = new Uint8Array([...bytes]);
+  return `0x${bytesToHex(uint8Arr)}`;
+};

--- a/src/typescript/sdk/src/utils/nominal-price.ts
+++ b/src/typescript/sdk/src/utils/nominal-price.ts
@@ -1,20 +1,30 @@
 /* eslint-disable import/no-unused-modules */
 import { Big } from "big.js";
+import { DECIMALS } from "../const";
 
 /* eslint-disable-next-line no-bitwise */
 const Q64_BASE = Big(Big(2).pow(64).toString());
-const DECIMALS = 16;
+const DEFAULT_PRICE_DECIMALS = 16;
 
 export const q64ToBig = (q64: string | number | bigint) => Big(q64.toString()).div(Q64_BASE);
 
 export const toNominalPrice = (
   avgExecutionPriceQ64: string | number | bigint,
-  decimals: number = DECIMALS
+  decimals: number = DEFAULT_PRICE_DECIMALS
 ) => Number(q64ToBig(avgExecutionPriceQ64).toFixed(decimals));
 
-export const toQuotePrice = (
-  avgExecutionPriceQ64: string | number | bigint,
-  decimals: number = DECIMALS
-) => Number(Big(Q64_BASE).div(avgExecutionPriceQ64.toString()).toFixed(decimals));
-
 export const toQ64Big = (input: string | number | bigint) => Big(input.toString()).mul(Q64_BASE);
+
+/**
+ * Returns the decimalized amount of APT or emojicoin.
+ *
+ * Works with any coin that uses {@link DECIMALS} decimals.
+ *
+ * @param num a bigint representing a coin balance
+ * @returns the nominal number value
+ * @example
+ * const res = toNominalCoinValue(100_000_000n);
+ * // res === 1.1
+ * expect(res).toBe(1.1);
+ */
+export const toNominal = (num: bigint) => new Big(num.toString()).div(10 ** DECIMALS).toNumber();

--- a/src/typescript/sdk/src/utils/utility-types.ts
+++ b/src/typescript/sdk/src/utils/utility-types.ts
@@ -27,7 +27,7 @@ export type AtLeastOne<T, K extends keyof T = keyof T> = K extends keyof T
  * type OrderByValues = ValueOf<typeof ORDER_BY>; // 'ASC' | 'DESC' | 100
  * ```
  */
-export type ValueOf<T> = T[keyof T];
+export type ValueOf<T> = Required<T>[keyof T];
 
 export type Writable<T> = {
   -readonly [P in keyof T]: T[P];

--- a/src/typescript/sdk/tests/unit/hex.test.ts
+++ b/src/typescript/sdk/tests/unit/hex.test.ts
@@ -10,6 +10,9 @@ import {
   generateRandomSymbol,
   toCoinTypes,
   getMarketAddress,
+  deserializeToHexString,
+  chunk,
+  zip,
 } from "../../src";
 
 describe("hex utility functions", () => {
@@ -174,4 +177,33 @@ describe("hex utility functions", () => {
     expect(lpTypeString.endsWith("::coin_factory::EmojicoinLP")).toBe(true);
     expect(lpNoLeadingZeros.endsWith("::coin_factory::EmojicoinLP")).toBe(true);
   }, 2000);
+
+  const hexInputs = ["0011223344", "4433221100", "0123456789", "0f", "f0", "00", "ff", ""];
+  const hexOutputs = hexInputs.map((v) => `0x${v}`);
+  it("deserializes symbol hex bytes from the broker properly, with number[] and Uint8Array", () => {
+    const hexInputsAsNumbers = hexInputs.map((v) =>
+      chunk(Array.from(v), 2)
+        .map((pair) => pair.join(""))
+        .map((hexValue) => parseInt(hexValue, 16))
+    );
+    zip(hexInputsAsNumbers, hexOutputs).forEach(([input, output]) => {
+      expect(deserializeToHexString(input)).toEqual(output);
+      const asBytes = new Uint8Array(input);
+      expect(deserializeToHexString(asBytes)).toEqual(output);
+    });
+  });
+
+  it("deserializes symbol hex bytes from a postgres JSON response properly, with & w/o leading 0x", () => {
+    const postgresHexInputs = hexInputs.map((v) => `\\x${v}` as const);
+    zip(postgresHexInputs, hexOutputs).forEach(([input, output]) => {
+      expect(deserializeToHexString(input)).toEqual(output);
+    })
+  });
+
+  it("deserializes symbol bytes from a 0x${string} hex string properly, with & w/o leading 0x", () => {
+    const withPrefixes = hexInputs.map((v) => `0x${v}` as const);
+    zip(withPrefixes, hexOutputs).forEach(([input, output]) => {
+      expect(deserializeToHexString(input)).toEqual(output);
+    })
+  });
 });

--- a/src/typescript/sdk/tests/unit/hex.test.ts
+++ b/src/typescript/sdk/tests/unit/hex.test.ts
@@ -197,13 +197,13 @@ describe("hex utility functions", () => {
     const postgresHexInputs = hexInputs.map((v) => `\\x${v}` as const);
     zip(postgresHexInputs, hexOutputs).forEach(([input, output]) => {
       expect(deserializeToHexString(input)).toEqual(output);
-    })
+    });
   });
 
   it("deserializes symbol bytes from a 0x${string} hex string properly, with & w/o leading 0x", () => {
     const withPrefixes = hexInputs.map((v) => `0x${v}` as const);
     zip(withPrefixes, hexOutputs).forEach(([input, output]) => {
       expect(deserializeToHexString(input)).toEqual(output);
-    })
+    });
   });
 });


### PR DESCRIPTION
# Description

- [x] Convert existing `price_feed` query to an `/api/trending` route
- [x] Clean up the response JSON and make it easy to use and understand

Misc small fixes
- [x] Update `ValueOf<T>` utility type to include possibly undefined values
- [x] Change `/candlesticks` to `${ROUTES.candlesticks}`

# Testing

Testing manually and in preview.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

