### PR TITLE
chore(ECO-2936): Fix default path revalidation time for `/api/trending`; indicate that `market_cap_usd` and `usd_price` might be undefined

### DIFF
--- a/src/typescript/frontend/src/app/api/trending/route.ts
+++ b/src/typescript/frontend/src/app/api/trending/route.ts
@@ -12,6 +12,8 @@ import { fetchCachedPriceFeed, NUM_MARKETS_ON_PRICE_FEED } from "lib/queries/pri
 import { type AccountAddress } from "@aptos-labs/ts-sdk";
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
+export const revalidate = 10;
+
 /**
  * ### /api/trending
  *
@@ -21,6 +23,8 @@ import { type AccountAddress } from "@aptos-labs/ts-sdk";
  * Prices are expressed in terms of the base asset being the emojicoin.
  *   - `"quote_price": 0.0123` indicates `1` emojicoin is worth  `0.0123` APT.
  *   - `"usd_price": 0.20` indicates `1` emojicoin is worth `0.20 USD`.
+ *
+ * #### NOTE: `market_cap_usd` and `usd_price` may be absent if APT/USD isn't fetched successfully.
  *
  * All q64 values in the contract are normalized to decimalized values with {@link q64ToBig}
  *
@@ -71,7 +75,7 @@ import { type AccountAddress } from "@aptos-labs/ts-sdk";
  *       "total_value_locked": 39663.59453896,
  *       "fully_diluted_value": 1597068.4076876,
  *       "market_cap_apt": 1577236.61041812,
- *       "market_cap_usd": 9086302.388957748
+ *       "market_cap_usd": 9086302.388957748 // possibly undefined
  *     },
  *     "daily_tvl_lp_growth": 1.0004915,
  *     "daily_volume_quote": 3825.62539183,
@@ -79,7 +83,7 @@ import { type AccountAddress } from "@aptos-labs/ts-sdk";
  *     "quote_price": 0.03557685205345566,
  *     "quote_price_24h_ago": 0.04263140726110441,
  *     "quote_price_delta_24h": -16.547788733413714,
- *     "usd_price": 0.20495468699475275
+ *     "usd_price": 0.20495468699475275 // possibly undefined
  *   }
  * ]
  * ```


### PR DESCRIPTION
# Description

- [x] Fix the default path revalidation time for `GET` requests and set it to `10`.
- [x] Adding very explicit documentation- since unexpected undefined values could cause some issues as a consumer of this endpoint.

# Testing

```shell
March 01 00:42:17, 03-01T00:40:35.77985Z 13345
March 01 00:42:18, 03-01T00:40:35.77985Z 13345
March 01 00:42:19, 03-01T00:41:26.165342Z 13346
March 01 00:42:21, 03-01T00:41:26.165342Z 13346
```

I polled the endpoint every second and watched for cahnges. You can see above that when the market nonce for a market was incremented, it took slightly longer than 10 seconds to see it. Note that the times overall may be slightly out of sync, since the left is my computer time vs the on-chain time.

In general, the data won't stale for longer than ~30 seconds. Since the `revalidate` in the `GET` request path can be out of sync with the revalidation time in the `unstable_cache` `fetch` caches, it's not always exactly 10 seconds. In general, it seems to be roughly 15-25 seconds.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?

