### PR TITLE
feat(ECO-2949): Add `ArenaCandlestick`s to the broker

### DIFF
--- a/src/rust/broker/README.md
+++ b/src/rust/broker/README.md
@@ -44,14 +44,18 @@ Arena events don't follow the same rules as the other subscriptions.
 To subscribe to arena events, simply pass `{ "arena": true }`. The default value
 is `false`; i.e., no subscription to arena events.
 
+To subscribe to arena candlesticks, pass `{ "arena_candlesticks": true }`. The
+default value is `false`.
+
 ```json5
 // Subscribe to every single event type.
-{ "arena": true, "markets": [], "event_types": [] }
+{ "arena": true, "arena_candlesticks": true, "markets": [], "event_types": [] }
 
 // Subscribe to all non-arena event types.
-// Both of the JSON objects below are equivalent.
+// All of the JSON objects below are equivalent.
 { "markets": [], "event_types": [] }
 { "arena": false, "markets": [], "event_types": [] }
+{ "arena_candlesticks": false, "markets": [], "event_types": [] }
 ```
 
 ### All markets, all non-arena event types

--- a/src/rust/broker/src/types.rs
+++ b/src/rust/broker/src/types.rs
@@ -21,4 +21,6 @@ pub struct Subscription {
     pub event_types: Vec<EmojicoinDbEventType>,
     #[serde(default)]
     pub arena: bool,
+    #[serde(default)]
+    pub arena_candlesticks: bool,
 }

--- a/src/rust/broker/src/util.rs
+++ b/src/rust/broker/src/util.rs
@@ -37,6 +37,7 @@ pub fn is_match(subscription: &Subscription, event: &EmojicoinDbEvent) -> bool {
         EmojicoinDbEventType::ArenaMelee => subscription.arena,
         EmojicoinDbEventType::ArenaSwap => subscription.arena,
         EmojicoinDbEventType::ArenaVaultBalanceUpdate => subscription.arena,
+        EmojicoinDbEventType::ArenaCandlestick => subscription.arena_candlesticks,
         EmojicoinDbEventType::GlobalState => {
             subscription.event_types.is_empty() || subscription.event_types.contains(&event_type)
         }

--- a/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
@@ -15,6 +15,7 @@ import {
   type ArenaPositionModel,
 } from "@sdk/indexer-v2/types";
 import { ROUTES } from "router/routes";
+import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
 
 const RewardsRemainingBox = ({ rewardsRemaining }: { rewardsRemaining: bigint }) => {
   const { isMobile } = useMatchBreakpoints();
@@ -96,6 +97,8 @@ export const ArenaClient = (props: ArenaProps) => {
   // Undefined while loading. Null means no position
   const [position, setPosition] = useState<ArenaPositionModel | undefined | null>(null);
   const [history, setHistory] = useState<ArenaLeaderboardHistoryWithArenaInfoModel[]>([]);
+
+  useReliableSubscribe({ eventTypes: ["Swap"], arena: true, arenaCandlesticks: true });
 
   const r = useMemo(
     () =>

--- a/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
+++ b/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 export type ReliableSubscribeArgs = {
   eventTypes: Array<SubscribableBrokerEvents>;
   arena?: boolean;
+  arenaCandlesticks?: boolean;
 };
 
 /**
@@ -12,7 +13,7 @@ export type ReliableSubscribeArgs = {
  * mounted. It automatically cleans up subscriptions when the component is unmounted.
  */
 export const useReliableSubscribe = (args: ReliableSubscribeArgs) => {
-  const { eventTypes, arena } = args;
+  const { eventTypes, arena, arenaCandlesticks } = args;
   const subscribeEvents = useEventStore((s) => s.subscribeEvents);
   const unsubscribeEvents = useEventStore((s) => s.unsubscribeEvents);
 
@@ -20,13 +21,19 @@ export const useReliableSubscribe = (args: ReliableSubscribeArgs) => {
     // Don't subscribe right away, to let other components unmounting time to unsubscribe, that way
     // components unmounting don't undo/overwrite another component subscribing.
     const timeout = window.setTimeout(() => {
-      subscribeEvents(eventTypes, arena);
+      subscribeEvents(eventTypes, {
+        baseEvents: arena,
+        candlesticks: arenaCandlesticks,
+      });
     }, 250);
 
     // Unsubscribe from all topics passed into the hook when the component unmounts.
     return () => {
       clearTimeout(timeout);
-      unsubscribeEvents(eventTypes, arena);
+      unsubscribeEvents(eventTypes, {
+        baseEvents: arena,
+        candlesticks: arenaCandlesticks,
+      });
     };
-  }, [eventTypes, arena, subscribeEvents, unsubscribeEvents]);
+  }, [eventTypes, arena, arenaCandlesticks, subscribeEvents, unsubscribeEvents]);
 };

--- a/src/typescript/frontend/src/lib/store/websocket/store.ts
+++ b/src/typescript/frontend/src/lib/store/websocket/store.ts
@@ -19,8 +19,14 @@ export type ClientState = {
 
 export type ClientActions = {
   close: () => void;
-  subscribeEvents: (events: SubscribableBrokerEvents[], arena?: boolean) => void;
-  unsubscribeEvents: (events: SubscribableBrokerEvents[], arena?: boolean) => void;
+  subscribeEvents: (
+    events: SubscribableBrokerEvents[],
+    arena?: { baseEvents?: boolean; candlesticks?: boolean }
+  ) => void;
+  unsubscribeEvents: (
+    events: SubscribableBrokerEvents[],
+    arena?: { baseEvents?: boolean; candlesticks?: boolean }
+  ) => void;
 };
 
 export type WebSocketClientStore = ClientState & ClientActions;
@@ -52,6 +58,7 @@ export const createWebSocketClientStore = (
     marketIDs: new Set(),
     eventTypes: new Set(),
     arena: false,
+    arenaCandlesticks: false,
   },
   received: 0,
   client: getSingletonClient({
@@ -84,14 +91,16 @@ export const createWebSocketClientStore = (
   subscribeEvents: (e, arena) => {
     set((state) => {
       state.client.subscribeEvents(e, arena);
-      state.subscriptions.arena = !!arena;
+      state.subscriptions.arena = !!arena?.baseEvents;
+      state.subscriptions.arenaCandlesticks = !!arena?.candlesticks;
       state.subscriptions = state.client.subscriptions;
     });
   },
   unsubscribeEvents: (e, arena) => {
     set((state) => {
       state.client.unsubscribeEvents(e, arena);
-      state.subscriptions.arena = !!arena;
+      state.subscriptions.arena = !!arena?.baseEvents;
+      state.subscriptions.arenaCandlesticks = !!arena?.candlesticks;
       state.subscriptions = state.client.subscriptions;
     });
   },

--- a/src/typescript/sdk/src/broker-v2/types.ts
+++ b/src/typescript/sdk/src/broker-v2/types.ts
@@ -1,13 +1,10 @@
-import {
-  type BrokerEventModels,
-  DatabaseTypeConverter,
-  type ARENA_CANDLESTICK_NAME,
-} from "../indexer-v2/types";
+import { type BrokerEventModels, DatabaseTypeConverter } from "../indexer-v2/types";
 import {
   type BrokerJsonTypes,
   type DatabaseJsonType,
   TableName,
 } from "../indexer-v2/types/json-types";
+import { ARENA_CANDLESTICK_NAME } from "../types/arena-types";
 import { type AnyNumberString } from "../types/types";
 
 export type BrokerEvent = SubscribableBrokerEvents | BrokerArenaEvent;

--- a/src/typescript/sdk/src/broker-v2/types.ts
+++ b/src/typescript/sdk/src/broker-v2/types.ts
@@ -1,4 +1,8 @@
-import { type BrokerEventModels, DatabaseTypeConverter } from "../indexer-v2/types";
+import {
+  type BrokerEventModels,
+  DatabaseTypeConverter,
+  type ARENA_CANDLESTICK_NAME,
+} from "../indexer-v2/types";
 import {
   type BrokerJsonTypes,
   type DatabaseJsonType,
@@ -22,7 +26,8 @@ type BrokerArenaEvent =
   | "ArenaExit"
   | "ArenaMelee"
   | "ArenaSwap"
-  | "ArenaVaultBalanceUpdate";
+  | "ArenaVaultBalanceUpdate"
+  | typeof ARENA_CANDLESTICK_NAME;
 
 const Chat = TableName.ChatEvents;
 const Swap = TableName.SwapEvents;
@@ -36,6 +41,7 @@ const ArenaExit = TableName.ArenaExitEvents;
 const ArenaMelee = TableName.ArenaMeleeEvents;
 const ArenaSwap = TableName.ArenaSwapEvents;
 const ArenaVaultBalanceUpdate = TableName.ArenaVaultBalanceUpdateEvents;
+const ArenaCandlestick = TableName.ArenaCandlestick;
 type ChatType = DatabaseJsonType[typeof Chat];
 type SwapType = DatabaseJsonType[typeof Swap];
 type LiquidityType = DatabaseJsonType[typeof Liquidity];
@@ -48,6 +54,7 @@ type ArenaExitType = DatabaseJsonType[typeof ArenaExit];
 type ArenaMeleeType = DatabaseJsonType[typeof ArenaMelee];
 type ArenaSwapType = DatabaseJsonType[typeof ArenaSwap];
 type ArenaVaultBalanceUpdateType = DatabaseJsonType[typeof ArenaVaultBalanceUpdate];
+type ArenaCandlestickType = DatabaseJsonType[typeof ArenaCandlestick];
 
 export const brokerMessageConverter: Record<BrokerEvent, (data: unknown) => BrokerEventModels> = {
   Chat: (d) => DatabaseTypeConverter[Chat](d as ChatType),
@@ -63,6 +70,7 @@ export const brokerMessageConverter: Record<BrokerEvent, (data: unknown) => Brok
   ArenaSwap: (d) => DatabaseTypeConverter[ArenaSwap](d as ArenaSwapType),
   ArenaVaultBalanceUpdate: (d) =>
     DatabaseTypeConverter[ArenaVaultBalanceUpdate](d as ArenaVaultBalanceUpdateType),
+  ArenaCandlestick: (d) => DatabaseTypeConverter[ArenaCandlestick](d as ArenaCandlestickType),
 };
 
 /**
@@ -79,6 +87,7 @@ export type SubscriptionMessage = {
   markets: number[];
   event_types: BrokerEvent[];
   arena: boolean;
+  arena_candlesticks: boolean;
 };
 
 /* eslint-disable-next-line import/no-unused-modules */
@@ -86,4 +95,5 @@ export type WebSocketSubscriptions = {
   marketIDs: Set<AnyNumberString>;
   eventTypes: Set<BrokerEvent>;
   arena: boolean;
+  arenaCandlesticks: boolean;
 };

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -584,7 +584,7 @@ export const withArenaVaultBalanceUpdateData = curryToNamedType(
   "arenaVaultBalanceUpdate"
 );
 
-const EVENT_NAMES = {
+export const EVENT_NAMES = {
   GlobalState: "GlobalState",
   PeriodicState: "PeriodicState",
   MarketRegistration: "MarketRegistration",
@@ -1046,7 +1046,8 @@ export type BrokerEventModels =
   | DatabaseModels[TableName.ArenaMeleeEvents]
   | DatabaseModels[TableName.ArenaExitEvents]
   | DatabaseModels[TableName.ArenaSwapEvents]
-  | DatabaseModels[TableName.ArenaVaultBalanceUpdateEvents];
+  | DatabaseModels[TableName.ArenaVaultBalanceUpdateEvents]
+  | DatabaseModels[TableName.ArenaCandlestick];
 
 export type EventModelWithMarket =
   | DatabaseModels[TableName.SwapEvents]

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -10,6 +10,9 @@ import {
   type ArenaVaultBalanceUpdateModel,
   type ArenaEventModels,
   type ArenaEventModelWithMeleeID,
+  type ArenaCandlestickModel,
+  EVENT_NAMES,
+  ARENA_CANDLESTICK_NAME,
 } from "../indexer-v2";
 import { postgresTimestampToDate } from "../indexer-v2/types/json-types";
 import { dateFromMicroseconds, toAccountAddressString } from "../utils";
@@ -333,32 +336,36 @@ export type AnyArenaEvent =
 /* eslint-disable import/no-unused-modules */
 
 export const isArenaEnterEvent = (e: AnyArenaEvent): e is Types["ArenaEnterEvent"] =>
-  e.eventName === "ArenaEnter";
+  e.eventName === EVENT_NAMES.ArenaEnter;
 
 export const isArenaExitEvent = (e: AnyArenaEvent): e is Types["ArenaExitEvent"] =>
-  e.eventName === "ArenaExit";
+  e.eventName === EVENT_NAMES.ArenaExit;
 
 export const isArenaMeleeEvent = (e: AnyArenaEvent): e is Types["ArenaMeleeEvent"] =>
-  e.eventName === "ArenaMelee";
+  e.eventName === EVENT_NAMES.ArenaMelee;
 
 export const isArenaSwapEvent = (e: AnyArenaEvent): e is Types["ArenaSwapEvent"] =>
-  e.eventName === "ArenaSwap";
+  e.eventName === EVENT_NAMES.ArenaSwap;
 
 export const isArenaVaultBalanceUpdateEvent = (
   e: AnyArenaEvent
-): e is Types["ArenaVaultBalanceUpdateEvent"] => e.eventName === "ArenaVaultBalanceUpdate";
+): e is Types["ArenaVaultBalanceUpdateEvent"] =>
+  e.eventName === EVENT_NAMES.ArenaVaultBalanceUpdate;
 
 export const isArenaEnterModel = (e: BrokerEventModels): e is ArenaEnterModel =>
-  e.eventName === "ArenaEnter";
+  e.eventName === EVENT_NAMES.ArenaEnter;
 
 export const isArenaExitModel = (e: BrokerEventModels): e is ArenaExitModel =>
-  e.eventName === "ArenaExit";
+  e.eventName === EVENT_NAMES.ArenaExit;
 
 export const isArenaMeleeModel = (e: BrokerEventModels): e is ArenaMeleeModel =>
-  e.eventName === "ArenaMelee";
+  e.eventName === EVENT_NAMES.ArenaMelee;
 
 export const isArenaSwapModel = (e: BrokerEventModels): e is ArenaSwapModel =>
-  e.eventName === "ArenaSwap";
+  e.eventName === EVENT_NAMES.ArenaSwap;
+
+export const isArenaCandlestickModel = (e: BrokerEventModels): e is ArenaCandlestickModel =>
+  e.eventName === ARENA_CANDLESTICK_NAME;
 
 export const isArenaVaultBalanceUpdateModel = (
   e: BrokerEventModels

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -11,7 +11,7 @@ import {
   type ArenaEventModels,
   type ArenaEventModelWithMeleeID,
   type ArenaCandlestickModel,
-  ARENA_CANDLESTICK_NAME,
+  // Note that if you import anything more than a type here, you'll get lots of import issues.
 } from "../indexer-v2/types";
 import { postgresTimestampToDate } from "../indexer-v2/types/json-types";
 import { dateFromMicroseconds, toAccountAddressString } from "../utils";

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -11,9 +11,8 @@ import {
   type ArenaEventModels,
   type ArenaEventModelWithMeleeID,
   type ArenaCandlestickModel,
-  EVENT_NAMES,
   ARENA_CANDLESTICK_NAME,
-} from "../indexer-v2";
+} from "../indexer-v2/types";
 import { postgresTimestampToDate } from "../indexer-v2/types/json-types";
 import { dateFromMicroseconds, toAccountAddressString } from "../utils";
 import type JsonTypes from "./json-types";
@@ -336,33 +335,32 @@ export type AnyArenaEvent =
 /* eslint-disable import/no-unused-modules */
 
 export const isArenaEnterEvent = (e: AnyArenaEvent): e is Types["ArenaEnterEvent"] =>
-  e.eventName === EVENT_NAMES.ArenaEnter;
+  e.eventName === "ArenaEnter";
 
 export const isArenaExitEvent = (e: AnyArenaEvent): e is Types["ArenaExitEvent"] =>
-  e.eventName === EVENT_NAMES.ArenaExit;
+  e.eventName === "ArenaExit";
 
 export const isArenaMeleeEvent = (e: AnyArenaEvent): e is Types["ArenaMeleeEvent"] =>
-  e.eventName === EVENT_NAMES.ArenaMelee;
+  e.eventName === "ArenaMelee";
 
 export const isArenaSwapEvent = (e: AnyArenaEvent): e is Types["ArenaSwapEvent"] =>
-  e.eventName === EVENT_NAMES.ArenaSwap;
+  e.eventName === "ArenaSwap";
 
 export const isArenaVaultBalanceUpdateEvent = (
   e: AnyArenaEvent
-): e is Types["ArenaVaultBalanceUpdateEvent"] =>
-  e.eventName === EVENT_NAMES.ArenaVaultBalanceUpdate;
+): e is Types["ArenaVaultBalanceUpdateEvent"] => e.eventName === "ArenaVaultBalanceUpdate";
 
 export const isArenaEnterModel = (e: BrokerEventModels): e is ArenaEnterModel =>
-  e.eventName === EVENT_NAMES.ArenaEnter;
+  e.eventName === "ArenaEnter";
 
 export const isArenaExitModel = (e: BrokerEventModels): e is ArenaExitModel =>
-  e.eventName === EVENT_NAMES.ArenaExit;
+  e.eventName === "ArenaExit";
 
 export const isArenaMeleeModel = (e: BrokerEventModels): e is ArenaMeleeModel =>
-  e.eventName === EVENT_NAMES.ArenaMelee;
+  e.eventName === "ArenaMelee";
 
 export const isArenaSwapModel = (e: BrokerEventModels): e is ArenaSwapModel =>
-  e.eventName === EVENT_NAMES.ArenaSwap;
+  e.eventName === "ArenaSwap";
 
 export const isArenaCandlestickModel = (e: BrokerEventModels): e is ArenaCandlestickModel =>
   e.eventName === ARENA_CANDLESTICK_NAME;
@@ -373,10 +371,10 @@ export const isArenaVaultBalanceUpdateModel = (
 
 /* eslint-enable import/no-unused-modules */
 
-export const isArenaEventModel = (e: BrokerEventModels): e is ArenaEventModels =>
-  isArenaEventModelWithMeleeID(e) || isArenaVaultBalanceUpdateModel(e);
-
 export const isArenaEventModelWithMeleeID = (
   e: BrokerEventModels
 ): e is ArenaEventModelWithMeleeID =>
   isArenaEnterModel(e) || isArenaExitModel(e) || isArenaMeleeModel(e) || isArenaSwapModel(e);
+
+export const isArenaEventModel = (e: BrokerEventModels): e is ArenaEventModels =>
+  isArenaEventModelWithMeleeID(e) || isArenaVaultBalanceUpdateModel(e);

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -369,8 +369,6 @@ export const isArenaVaultBalanceUpdateModel = (
   e: BrokerEventModels
 ): e is ArenaVaultBalanceUpdateModel => e.eventName === "ArenaVaultBalanceUpdate";
 
-/* eslint-enable import/no-unused-modules */
-
 export const isArenaEventModelWithMeleeID = (
   e: BrokerEventModels
 ): e is ArenaEventModelWithMeleeID =>
@@ -378,3 +376,5 @@ export const isArenaEventModelWithMeleeID = (
 
 export const isArenaEventModel = (e: BrokerEventModels): e is ArenaEventModels =>
   isArenaEventModelWithMeleeID(e) || isArenaVaultBalanceUpdateModel(e);
+
+/* eslint-enable import/no-unused-modules */

--- a/src/typescript/sdk/tests/e2e/broker/utils.ts
+++ b/src/typescript/sdk/tests/e2e/broker/utils.ts
@@ -97,12 +97,14 @@ export const subscribe = (
   client: WebSocket,
   markets: AnyNumberString[],
   eventTypes: SubscribableBrokerEvents[],
-  arena: boolean = false
+  arena: boolean = false,
+  arenaCandlesticks: boolean = false
 ) => {
   const outgoingMessage: SubscriptionMessage = {
     markets: markets.map((n) => Number(n)),
     event_types: eventTypes,
     arena,
+    arena_candlesticks: arenaCandlesticks,
   };
   const json = JSON.stringify(outgoingMessage);
   client.send(json);


### PR DESCRIPTION
# Description

- [x] Add the ability to subscribe to arena candlesticks to the broker.

# Testing

- [ ] Will add some straightforward SDK tests for this.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
