### PR TITLE
chore(ECO-2930): Unalias `toNominal` in `frontend/lib/utils/decimals.ts` and replace with `@sdk/utils`

### DIFF
--- a/src/typescript/frontend/src/app/coingecko/tickers/route.ts
+++ b/src/typescript/frontend/src/app/coingecko/tickers/route.ts
@@ -2,7 +2,7 @@ import { APTOS_COIN_TYPE_TAG } from "@sdk/const";
 import { postgrest } from "@sdk/indexer-v2/queries/client";
 import { TableName } from "@sdk/indexer-v2/types";
 import { toNominalPrice } from "@sdk/utils";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 import type { NextRequest } from "next/server";
 import { stringifyJSON } from "utils";
 import { estimateLiquidityInUSD } from "./utils";

--- a/src/typescript/frontend/src/app/dexscreener/asset/route.ts
+++ b/src/typescript/frontend/src/app/dexscreener/asset/route.ts
@@ -26,7 +26,7 @@ import { EMOJICOIN_SUPPLY } from "@sdk/const";
 import { calculateCirculatingSupply } from "@sdk/markets";
 import { symbolEmojiStringToArray } from "../util";
 import { fetchMarketState } from "@/queries/market";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 
 /**
  * - In most cases, asset ids will correspond to contract addresses. Ids are case-sensitive.

--- a/src/typescript/frontend/src/app/stats/TableData.tsx
+++ b/src/typescript/frontend/src/app/stats/TableData.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 import { calculateCurvePrice, calculateCirculatingSupply } from "@sdk/markets";
 import { MiniBondingCurveProgress } from "./MiniBondingCurveProgress";
 import { toNominalPrice } from "@sdk/utils";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/holders/coin-holders.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/holders/coin-holders.tsx
@@ -7,7 +7,7 @@ import { WalletAddressCell } from "components/ui/table-cells/wallet-address-cell
 import { EcTable, type EcTableColumn } from "components/ui/table/ecTable";
 import { useAptPrice } from "context/AptPrice";
 import { type AssetBalance } from "lib/queries/aptos-indexer/fetch-emojicoin-balances";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 import { useRouter } from "next/navigation";
 import { useMemo, type FC } from "react";
 import { ROUTES } from "router/routes";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.tsx
@@ -12,7 +12,7 @@ import { FormattedNumber } from "components/FormattedNumber";
 import { WalletAddressCell } from "components/ui/table-cells/wallet-address-cell";
 import { toExplorerLink } from "lib/utils/explorer-link";
 import { AptCell } from "components/ui/table-cells/apt-cell";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 import { ColoredPriceDisplay } from "components/misc/ColoredPriceDisplay";
 import { type SwapEventModel } from "@sdk/indexer-v2/types";
 

--- a/src/typescript/frontend/src/components/pages/wallet/fetch-specific-markets-action.ts
+++ b/src/typescript/frontend/src/components/pages/wallet/fetch-specific-markets-action.ts
@@ -3,7 +3,7 @@
 import { type SymbolEmoji } from "@sdk/emoji_data";
 import { fetchSpecificMarkets } from "@sdk/indexer-v2/queries";
 import { calculateCurvePrice } from "@sdk/markets";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 
 /**
  * Wrapper to make `fetchSpecificMarkets` into a single server action. Only return the data required

--- a/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
+++ b/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
@@ -1,5 +1,5 @@
 import { useAptPrice } from "context/AptPrice";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 
 /**
  * Returns the market cap in USD.

--- a/src/typescript/frontend/src/lib/hooks/queries/use-fetch-owner-emojicoin-balances.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-fetch-owner-emojicoin-balances.ts
@@ -6,7 +6,7 @@ import { useMemo } from "react";
 import { withResponseError } from "./client";
 import { getSymbolEmojisInString, toMarketEmojiData } from "@sdk/emoji_data/utils";
 import { type AssetBalance } from "lib/queries/aptos-indexer/fetch-emojicoin-balances";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 import { emojiNamesToPath } from "utils/pathname-helpers";
 import { fetchSpecificMarketsAction } from "components/pages/wallet/fetch-specific-markets-action";
 

--- a/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
+++ b/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
@@ -4,7 +4,7 @@ import { type SwapEventModel, type PeriodicStateEventModel } from "@sdk/indexer-
 import { getPeriodStartTimeFromTime } from "@sdk/utils";
 import { q64ToBig } from "@sdk/utils/nominal-price";
 import Big from "big.js";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 
 export type Bar = {
   time: number;

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -12,7 +12,7 @@ import {
 import { getPeriodStartTimeFromTime } from "@sdk/utils";
 import { createBarFromPeriodicState, createBarFromSwap, type LatestBar } from "./candlestick-bars";
 import { q64ToBig } from "@sdk/utils/nominal-price";
-import { toNominal } from "lib/utils/decimals";
+import { toNominal } from "@sdk/utils";
 
 type PeriodicState = DatabaseModels["periodic_state_events"];
 

--- a/src/typescript/frontend/src/lib/utils/decimals.ts
+++ b/src/typescript/frontend/src/lib/utils/decimals.ts
@@ -1,7 +1,6 @@
 import Big from "big.js";
 import { DECIMALS } from "@sdk/const";
 import { type AnyNumberString } from "@sdk-types";
-import { toNominal } from "@sdk/utils";
 
 // Converts a number to its representation in coin decimals.
 // Both APT and emojicoins use a fixed number of decimals: 8.
@@ -63,4 +62,4 @@ const toDisplayCoinDecimals = ({
   return res.toString();
 };
 
-export { toDisplayCoinDecimals, toActualCoinDecimals, toNominal };
+export { toDisplayCoinDecimals, toActualCoinDecimals };

--- a/src/typescript/frontend/src/lib/utils/format-number-string.ts
+++ b/src/typescript/frontend/src/lib/utils/format-number-string.ts
@@ -1,5 +1,5 @@
 import { type AnyNumberString, type Flatten } from "@sdk-types";
-import { toNominal } from "./decimals";
+import { toNominal } from "@sdk/utils";
 
 /**
  * Sliding precision will show `decimals` decimals when Math.abs(number) is


### PR DESCRIPTION
# Description

`toNominal` was used in the frontend, but in some places in the `sdk` we needed it. I moved it to the SDK a week or so ago, but left it aliased in the frontend to allow other files to continue to import from the original `frontend/src/lib/utils` location to avoid conflicts.

- [x] This PR un-aliases it and replaces the imports with the proper `@sdk/utils` location.

# Testing

This change only affects imports. Static analysis will report any errors (build time failure)

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
