### PR TITLE
feat(ECO-2993): Add estimated volume in USD based on current APT price

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -21,7 +21,8 @@ import { useAptos } from "context/wallet-context/AptosContextProvider";
 import type { Colors } from "theme/types";
 import Popup from "components/popup";
 import { DISCORD_METADATA_REQUEST_CHANNEL, LINKS } from "lib/env";
-import { useUsdMarketCap } from "@hooks/use-usd-market-cap";
+import { useUsdMarketCap, useUSDValue } from "@hooks/use-usd-market-cap";
+import { Switcher } from "../../../../switcher";
 
 const statsTextClasses = "uppercase ellipses font-forma text-[24px]";
 
@@ -82,6 +83,7 @@ const MainInfo = ({ data }: MainInfoProps) => {
   const [allTimeVolume, setAllTimeVolume] = useState(
     BigInt(data.state.state.cumulativeStats.quoteVolume)
   );
+  const [showUSD, setShowUSD] = useState<boolean>(false);
 
   useEffect(() => {
     if (stateEvents.length === 0) return;
@@ -96,6 +98,8 @@ const MainInfo = ({ data }: MainInfoProps) => {
   }, [stateEvents]);
 
   const usdMarketCap = useUsdMarketCap(marketCap);
+  const usdDailyVolume = useUSDValue(dailyVolume);
+  const usdAllTimeVolume = useUSDValue(allTimeVolume);
 
   const { isMobile, isTablet } = useMatchBreakpoints();
 
@@ -157,6 +161,32 @@ const MainInfo = ({ data }: MainInfoProps) => {
     />
   );
 
+  const switcher = <Switcher checked={showUSD} onChange={() => setShowUSD(!showUSD)} />;
+
+  function aptOrUsd(value: bigint, valueUsd: number | undefined) {
+    if (showUSD) {
+      if (valueUsd) {
+        return (
+          <>
+            <FormattedNumber value={valueUsd} scramble />
+            &nbsp;
+            {"$"}
+          </>
+        );
+      } else {
+        return <>{"N/A $"}</>;
+      }
+    } else {
+      return (
+        <>
+          <FormattedNumber value={value} nominalize scramble />
+          &nbsp;
+          <AptosIconBlack className={"icon-inline mb-[0.3ch]"} />
+        </>
+      );
+    }
+  }
+
   return (
     <div
       className="flex justify-center mt-[10px]"
@@ -193,20 +223,18 @@ const MainInfo = ({ data }: MainInfoProps) => {
 
         <div className={`flex flex-col justify-between ${borderStyle}`}>
           <div className="flex justify-between">
+            <div className={statsTextClasses + " text-light-gray"}>
+              APT&nbsp;
+              <AptosIconBlack className={"icon-inline mb-[0.0ch]"} />
+              &nbsp;/&nbsp;USD&nbsp;$:
+            </div>
+            <div className={statsTextClasses + " text-white"}>{switcher}</div>
+          </div>
+          <div className="flex justify-between">
             <div className={statsTextClasses + " text-light-gray"}>{t("Market Cap:")}</div>
             <div className={statsTextClasses + " text-white"}>
               <div className="flex flex-row justify-center items-center">
-                {usdMarketCap === undefined ? (
-                  <FormattedNumber value={marketCap} nominalize scramble />
-                ) : (
-                  <FormattedNumber value={usdMarketCap} scramble />
-                )}
-                &nbsp;
-                {usdMarketCap === undefined ? (
-                  <AptosIconBlack className={"icon-inline mb-[0.3ch]"} />
-                ) : (
-                  "$"
-                )}
+                {aptOrUsd(marketCap, usdMarketCap)}
               </div>
             </div>
           </div>
@@ -215,9 +243,7 @@ const MainInfo = ({ data }: MainInfoProps) => {
             <div className={statsTextClasses + " text-light-gray"}>{t("24 hour vol:")}</div>
             <div className={statsTextClasses + " text-white"}>
               <div className="flex flex-row justify-center items-center">
-                <FormattedNumber value={dailyVolume} nominalize scramble />
-                &nbsp;
-                <AptosIconBlack className="icon-inline mb-[0.3ch]" />
+                {aptOrUsd(dailyVolume, usdDailyVolume)}
               </div>
             </div>
           </div>
@@ -226,9 +252,7 @@ const MainInfo = ({ data }: MainInfoProps) => {
             <div className={statsTextClasses + " text-light-gray"}>{t("All-time vol:")}</div>
             <div className={statsTextClasses + " text-white"}>
               <div className="flex flex-row justify-center items-center">
-                <FormattedNumber value={allTimeVolume} nominalize scramble />
-                &nbsp;
-                <AptosIconBlack className="icon-inline mb-[0.3ch]" />
+                {aptOrUsd(allTimeVolume, usdAllTimeVolume)}
               </div>
             </div>
           </div>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -161,21 +161,16 @@ const MainInfo = ({ data }: MainInfoProps) => {
     />
   );
 
-  const switcher = <Switcher checked={showUSD} onChange={() => setShowUSD(!showUSD)} />;
+  const switcher = <Switcher disabled={valueUsd === undefined} checked={showUSD} onChange={() => setShowUSD((v) => !v)} />;
 
   function aptOrUsd(value: bigint, valueUsd: number | undefined) {
-    if (showUSD) {
-      if (valueUsd) {
-        return (
-          <>
-            <FormattedNumber value={valueUsd} scramble />
-            &nbsp;
-            {"$"}
-          </>
-        );
-      } else {
-        return <>{"N/A $"}</>;
-      }
+    if (valueUsd !== undefined && showUSD) {
+      return (
+        <>
+          <FormattedNumber value={valueUsd} scramble />
+          {" $"}
+        </>
+      );
     } else {
       return (
         <>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -219,9 +219,9 @@ const MainInfo = ({ data }: MainInfoProps) => {
         <div className={`flex flex-col justify-between ${borderStyle}`}>
           <div className="flex justify-between">
             <div className={statsTextClasses + " text-light-gray"}>
-              APT&nbsp;
+              {"APT "}
               <AptosIconBlack className={"icon-inline mb-[0.0ch]"} />
-              &nbsp;/&nbsp;USD&nbsp;$:
+              {" / USD $:"}
             </div>
             <div className={statsTextClasses + " text-white"}>{switcher}</div>
           </div>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -161,7 +161,13 @@ const MainInfo = ({ data }: MainInfoProps) => {
     />
   );
 
-  const switcher = <Switcher disabled={valueUsd === undefined} checked={showUSD} onChange={() => setShowUSD((v) => !v)} />;
+  const switcher = (
+    <Switcher
+      disabled={usdMarketCap === undefined}
+      checked={showUSD}
+      onChange={() => setShowUSD((v) => !v)}
+    />
+  );
 
   function aptOrUsd(value: bigint, valueUsd: number | undefined) {
     if (valueUsd !== undefined && showUSD) {

--- a/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
+++ b/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
@@ -17,3 +17,20 @@ export function useUsdMarketCap(marketCapInOctas: bigint): number | undefined {
 
   return aptInUsd;
 }
+
+/**
+ * Multiplies the value times the APT price to get the value in USD.
+ *
+ * If the APT price isn't available, it will return `undefined`.
+ */
+export function useUSDValue(marketCapInOctas: bigint): number | undefined {
+  const aptPrice = useAptPrice();
+  const aptInUsd = aptPrice ? toNominal(marketCapInOctas) * aptPrice : undefined;
+
+  // Remove decimals if market cap is over 1 million
+  if (aptInUsd && aptInUsd >= 1_000_000) {
+    return Math.floor(aptInUsd);
+  }
+
+  return aptInUsd;
+}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This is just estimated, but it gives users a way to determine what their value trading is with less confusion.

# Testing
Tested locally
![Screenshot 2025-03-07 at 6 36 01 PM](https://github.com/user-attachments/assets/56f6a591-9c13-4d39-b1c6-392adc6bfae1)
![Screenshot 2025-03-07 at 6 36 16 PM](https://github.com/user-attachments/assets/eca31f8d-6a85-4970-80b7-cafe73d2a00f)



# Checklist
