### PR TITLE
chore(ECO-3005): Disable production/fallback arena indexing

### DIFF
--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -21,6 +21,7 @@ parameters:
   EnableWafRulesRestApi: 'false'
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
+  IndexArena: 'false'
   Network: 'mainnet'
   ProcessorImageVersion: '4.0.2'
   VpcStackName: 'emoji-vpc'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -21,6 +21,7 @@ parameters:
   EnableWafRulesRestApi: 'false'
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
+  IndexArena: 'false'
   Network: 'mainnet'
   ProcessorImageVersion: '4.0.2'
   VpcStackName: 'emoji-vpc'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Overload the `IndexArena` stack parameter to `false` for production and fallback

# Testing

Tested during development in #608
