### PR TITLE
chore(ECO-3011): Bump indexer binary versions in `compose.yaml`, deploy files, submodule

### DIFF
--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '4.0.2'
+  BrokerImageVersion: '6.0.1'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -23,7 +23,7 @@ parameters:
   Environment: 'fallback'
   IndexArena: 'false'
   Network: 'mainnet'
-  ProcessorImageVersion: '4.0.2'
+  ProcessorImageVersion: '6.0.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '6.0.1'
+  BrokerImageVersion: '6.0.0'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '6.0.1'
+  BrokerImageVersion: '6.0.0'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '4.0.2'
+  BrokerImageVersion: '6.0.1'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -23,7 +23,7 @@ parameters:
   Environment: 'production'
   IndexArena: 'false'
   Network: 'mainnet'
-  ProcessorImageVersion: '4.0.2'
+  ProcessorImageVersion: '6.0.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -15,7 +15,7 @@ services:
       PROCESSOR_WS_URL: 'ws://processor:${PROCESSOR_WS_PORT}/ws'
       PORT: '${BROKER_PORT}'
       RUST_LOG: 'info,broker=trace'
-    image: 'econialabs/emojicoin-dot-fun-indexer-broker:6.0.1'
+    image: 'econialabs/emojicoin-dot-fun-indexer-broker:6.0.0'
     container_name: 'broker'
     healthcheck:
       test: 'curl -f http://localhost:${BROKER_PORT}/live || exit 1'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -15,7 +15,7 @@ services:
       PROCESSOR_WS_URL: 'ws://processor:${PROCESSOR_WS_PORT}/ws'
       PORT: '${BROKER_PORT}'
       RUST_LOG: 'info,broker=trace'
-    image: 'econialabs/emojicoin-dot-fun-indexer-broker:6.0.0'
+    image: 'econialabs/emojicoin-dot-fun-indexer-broker:6.0.1'
     container_name: 'broker'
     healthcheck:
       test: 'curl -f http://localhost:${BROKER_PORT}/live || exit 1'
@@ -83,7 +83,7 @@ services:
     depends_on:
       postgres:
         condition: 'service_healthy'
-    image: 'econialabs/emojicoin-dot-fun-indexer-processor:6.0.0'
+    image: 'econialabs/emojicoin-dot-fun-indexer-processor:6.0.1'
     container_name: 'processor'
     healthcheck:
       test: 'curl -sf http://localhost:${PROCESSOR_WS_PORT} || exit 1'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Bump broker binaries to `v6.0.0`, processor to `v6.0.1` in `compose.yaml`, deploy files, and submodule

# Testing

SDK tests in CI
