### PR TITLE
fix(ECO-3018): Catch fetch errors on `[market]/page.tsx`

### DIFF
--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -30,7 +30,7 @@ interface EmojicoinPageProps {
 const EVENTS_ON_PAGE_LOAD = 25;
 
 const logAndReturnValue = <T extends [] | undefined | null>(dataType: string, onFailure: T) => {
-  console.warn(`Failed to fetch ${dataType}`);
+  console.warn(`[WARNING]: Failed to fetch ${dataType}.`);
   return onFailure;
 };
 

--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -29,6 +29,11 @@ interface EmojicoinPageProps {
 
 const EVENTS_ON_PAGE_LOAD = 25;
 
+const logAndReturnValue = <T extends [] | undefined | null>(dataType: string, onFailure: T) => {
+  console.warn(`Failed to fetch ${dataType}`);
+  return onFailure;
+};
+
 export async function generateMetadata({ params }: EmojicoinPageProps): Promise<Metadata> {
   const { market: marketSlug } = params;
   const names = pathToEmojiNames(marketSlug);
@@ -80,14 +85,18 @@ const EmojicoinPage = async (params: EmojicoinPageProps) => {
     const marketAddress = getMarketAddress(emojis).toString();
 
     const [chats, swaps, marketView, aptPrice, holders, melee] = await Promise.all([
-      fetchChatEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }).catch(() => []),
-      fetchSwapEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }).catch(() => []),
+      fetchChatEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }).catch(() =>
+        logAndReturnValue("chat events", [])
+      ),
+      fetchSwapEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }).catch(() =>
+        logAndReturnValue("swap events", [])
+      ),
       wrappedCachedContractMarketView(marketAddress),
-      getAptPrice().catch(() => undefined),
-      fetchCachedTopHolders(marketAddress).catch(() => []),
+      getAptPrice().catch(() => logAndReturnValue("APT price", undefined)),
+      fetchCachedTopHolders(marketAddress).catch(() => logAndReturnValue("top holders", [])),
       fetchMelee({})
         .then((res) => (res ? res.melee : null))
-        .catch(() => null),
+        .catch(() => logAndReturnValue("arena melee data", null)),
     ]);
 
     const isInMelee =

--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -80,11 +80,11 @@ const EmojicoinPage = async (params: EmojicoinPageProps) => {
     const marketAddress = getMarketAddress(emojis).toString();
 
     const [chats, swaps, marketView, aptPrice, holders, melee] = await Promise.all([
-      fetchChatEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }),
-      fetchSwapEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }),
+      fetchChatEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }).catch(() => []),
+      fetchSwapEvents({ marketID, pageSize: EVENTS_ON_PAGE_LOAD }).catch(() => []),
       wrappedCachedContractMarketView(marketAddress),
-      getAptPrice(),
-      fetchCachedTopHolders(marketAddress),
+      getAptPrice().catch(() => undefined),
+      fetchCachedTopHolders(marketAddress).catch(() => []),
       fetchMelee({})
         .then((res) => (res ? res.melee : null))
         .catch(() => null),


### PR DESCRIPTION
# Description

In general we should be catching errors and providing default values where possible in the higher level server components to avoid a single fetch taking the rest of the page down with it.

I noticed this while using `testnet` queries with the `fetchTopHolders`, where the fetch often fails. If this does happen- we merely want to log it and return an empty value.

Here I add default values to the following:

- [x] fetching chat events now returns `[]` on failure
- [x] fetching swap events now returns `[]` on failure
- [x] fetching APT price now returns `undefined` on failure
- [x] fetching top holders now returns `[]` on failure
- [x] They all log a warning on failure now

NOTE: The only one this isn't possible for (currently) is the `marketView`, since it utilizes state from on-chain (current `PeriodicStateTrackers`, not in the database), so that one is left alone.

# Testing

I'll test it locally with a failed fetch.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
