### PR TITLE
feat(ECO-3028): Add support for granular arena period subscriptions in the broker [3.3/4]

### DIFF
--- a/src/rust/broker/src/server/sse.rs
+++ b/src/rust/broker/src/server/sse.rs
@@ -12,7 +12,10 @@ use futures_util::{Stream, StreamExt};
 use log::{error, info, trace, warn};
 use tokio::sync::broadcast::error::RecvError;
 
-use crate::{types::Subscription, util::is_match};
+use crate::{
+    types::{ClientSubscription, SubscriptionMessage},
+    util::is_match,
+};
 
 use super::AppState;
 
@@ -30,9 +33,10 @@ use super::AppState;
 /// - `/sse`: subscribe to all events
 /// - `/sse?markets=1&markets=2&event_types=Chat&event_types=Swap`: subscribe to Chat and Swap events on markets 1 and 2
 pub async fn handler(
-    Query(subscription): Query<Subscription>,
+    Query(msg): Query<SubscriptionMessage>,
     State(state): State<Arc<AppState>>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let subscription = ClientSubscription::from(msg);
     info!("New SSE connection ({subscription:?}).");
 
     let mut rx = state.tx.subscribe();

--- a/src/rust/broker/src/types.rs
+++ b/src/rust/broker/src/types.rs
@@ -1,4 +1,6 @@
-use processor::emojicoin_dot_fun::EmojicoinDbEventType;
+use std::collections::HashSet;
+
+use processor::emojicoin_dot_fun::{EmojicoinDbEventType, Period};
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString};
 
@@ -13,8 +15,15 @@ pub enum EventType {
     MarketRegistration,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub struct Subscription {
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ArenaPeriodRequest {
+    Subscribe { period: Period },
+    Unsubscribe { period: Period },
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
+pub struct SubscriptionMessage {
     #[serde(default)]
     pub markets: Vec<u64>,
     #[serde(default)]
@@ -22,5 +31,116 @@ pub struct Subscription {
     #[serde(default)]
     pub arena: bool,
     #[serde(default)]
-    pub arena_candlesticks: bool,
+    pub arena_period: Option<ArenaPeriodRequest>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ClientSubscription {
+    pub markets: HashSet<u64>,
+    pub event_types: HashSet<EmojicoinDbEventType>,
+    pub arena: bool,
+    pub arena_candlestick_periods: HashSet<Period>,
+}
+
+#[test]
+fn deserialize_subscription_message() {
+    assert_eq!(
+        serde_json::from_str::<SubscriptionMessage>(
+            r#"{ "markets": [1, 2, 3], "event_types": ["Chat"], "arena": true }"#,
+        )
+        .unwrap(),
+        SubscriptionMessage {
+            markets: vec![1, 2, 3],
+            event_types: vec![EmojicoinDbEventType::Chat],
+            arena: true,
+            arena_period: None,
+        },
+    );
+
+    assert_eq!(
+        serde_json::from_str::<SubscriptionMessage>(
+            r#"{
+              "markets": [4, 2],
+              "event_types": ["MarketRegistration"],
+              "arena": false,
+              "arena_period": { "action": "subscribe", "period": "FifteenSeconds" }
+            }"#,
+        )
+        .unwrap(),
+        SubscriptionMessage {
+            markets: vec![4, 2],
+            event_types: vec![EmojicoinDbEventType::MarketRegistration],
+            arena: false,
+            arena_period: Some(ArenaPeriodRequest::Subscribe {
+                period: Period::FifteenSeconds
+            }),
+        },
+    );
+
+    assert_eq!(
+        serde_json::from_str::<SubscriptionMessage>(
+            r#"{ "markets": [7, 11], "event_types": ["Swap"], "arena": true }"#,
+        )
+        .unwrap(),
+        SubscriptionMessage {
+            markets: vec![7, 11],
+            event_types: vec![EmojicoinDbEventType::Swap],
+            arena: true,
+            arena_period: None,
+        },
+    );
+}
+
+#[test]
+fn deserialize_subscription_happy_path() {
+    let json = r#"{
+        "markets": [1, 2, 3],
+        "event_types": [],
+        "arena": true
+    }"#;
+    let sub: SubscriptionMessage = serde_json::from_str(json).unwrap();
+    assert_eq!(sub.arena_period, None);
+
+    let json2 = r#"{
+        "markets": [1, 2, 3],
+        "event_types": [],
+        "arena_period": { "action": "subscribe", "period": "FifteenSeconds" }
+    }"#;
+    let sub2: SubscriptionMessage = serde_json::from_str(json2).unwrap();
+    assert_eq!(
+        sub2.arena_period,
+        Some(ArenaPeriodRequest::Subscribe {
+            period: Period::FifteenSeconds
+        }),
+    );
+
+    let json3 = r#"{
+        "markets": [1, 2, 3],
+        "event_types": [],
+        "arena_period": { "action": "unsubscribe", "period": "OneHour" },
+        "arena": false
+    }"#;
+    let sub3: SubscriptionMessage = serde_json::from_str(json3).unwrap();
+    assert_eq!(
+        sub3.arena_period,
+        Some(ArenaPeriodRequest::Unsubscribe {
+            period: (Period::OneHour)
+        })
+    );
+}
+
+#[test]
+fn subscription_idempotent_serialization_happy_path() {
+    let sub = SubscriptionMessage {
+        markets: vec![1, 2, 3],
+        event_types: vec![EmojicoinDbEventType::Chat],
+        arena: true,
+        arena_period: Some(ArenaPeriodRequest::Unsubscribe {
+            period: Period::FifteenMinutes,
+        }),
+    };
+
+    let json = serde_json::to_string(&sub).unwrap();
+    let sub_parsed: SubscriptionMessage = serde_json::from_str(json.as_str()).unwrap();
+    assert_eq!(sub, sub_parsed);
 }

--- a/src/rust/broker/src/util.rs
+++ b/src/rust/broker/src/util.rs
@@ -1,9 +1,12 @@
+use std::collections::HashSet;
+
 use log::error;
 use num_traits::ToPrimitive;
 use processor::emojicoin_dot_fun::{EmojicoinDbEvent, EmojicoinDbEventType};
+use serde_json::Error;
 use tokio::signal;
 
-use crate::types::Subscription;
+use crate::types::{ArenaPeriodRequest, ClientSubscription, SubscriptionMessage};
 
 /// Get the market ID of a EmojicoinDbEvent of a given EventType
 #[allow(dead_code)]
@@ -29,15 +32,23 @@ pub fn get_market_id(event: &EmojicoinDbEvent) -> Result<u64, String> {
 
 /// Returns true if the given subscription should receive the given event.
 #[allow(dead_code)]
-pub fn is_match(subscription: &Subscription, event: &EmojicoinDbEvent) -> bool {
+pub fn is_match(subscription: &ClientSubscription, event: &EmojicoinDbEvent) -> bool {
     let event_type: EmojicoinDbEventType = event.into();
     match event_type {
-        EmojicoinDbEventType::ArenaEnter => subscription.arena,
-        EmojicoinDbEventType::ArenaExit => subscription.arena,
-        EmojicoinDbEventType::ArenaMelee => subscription.arena,
-        EmojicoinDbEventType::ArenaSwap => subscription.arena,
-        EmojicoinDbEventType::ArenaVaultBalanceUpdate => subscription.arena,
-        EmojicoinDbEventType::ArenaCandlestick => subscription.arena_candlesticks,
+        EmojicoinDbEventType::ArenaEnter
+        | EmojicoinDbEventType::ArenaExit
+        | EmojicoinDbEventType::ArenaMelee
+        | EmojicoinDbEventType::ArenaSwap
+        | EmojicoinDbEventType::ArenaVaultBalanceUpdate => subscription.arena,
+        EmojicoinDbEventType::ArenaCandlestick => {
+            if let EmojicoinDbEvent::ArenaCandlestick(event) = event {
+                subscription
+                    .arena_candlestick_periods
+                    .contains(&event.period)
+            } else {
+                unreachable!("This would only ever be reachable if enums were mapped incorrectly.");
+            }
+        }
         EmojicoinDbEventType::GlobalState => {
             subscription.event_types.is_empty() || subscription.event_types.contains(&event_type)
         }
@@ -84,5 +95,138 @@ pub async fn shutdown_signal() -> Result<(), String> {
             Ok(())
         },
         result = terminate_signal => { result }
+    }
+}
+
+impl From<SubscriptionMessage> for ClientSubscription {
+    fn from(val: SubscriptionMessage) -> Self {
+        ClientSubscription {
+            arena: val.arena,
+            markets: HashSet::from_iter(val.markets),
+            event_types: HashSet::from_iter(val.event_types),
+            arena_candlestick_periods: match val.arena_period {
+                Some(period) => match period {
+                    ArenaPeriodRequest::Subscribe { period } => HashSet::from([period]),
+                    // Ignore whatever period they sent in; there's nothing to unsubscribe from.
+                    ArenaPeriodRequest::Unsubscribe { period: _ } => HashSet::new(),
+                },
+                None => HashSet::new(),
+            },
+        }
+    }
+}
+
+// Update the incoming subscription based on the text in the message received.
+#[allow(dead_code)]
+pub fn update_subscription(
+    current_sub_opt: &mut Option<ClientSubscription>,
+    msg: &str,
+) -> Result<(), Error> {
+    let msg = serde_json::from_str::<SubscriptionMessage>(msg)?;
+    match current_sub_opt {
+        // Existing subscription; insert/remove from the existing arena candlestick periods.
+        Some(current_sub) => {
+            if let Some(period) = msg.arena_period {
+                match period {
+                    ArenaPeriodRequest::Subscribe { period } => {
+                        current_sub.arena_candlestick_periods.insert(period)
+                    }
+                    ArenaPeriodRequest::Unsubscribe { period } => {
+                        current_sub.arena_candlestick_periods.remove(&period)
+                    }
+                };
+            }
+            current_sub.arena = msg.arena;
+            current_sub.markets = HashSet::from_iter(msg.markets);
+            current_sub.event_types = HashSet::from_iter(msg.event_types);
+        }
+        _ => {
+            // No current subscription; just convert the message into a new subscription.
+            *current_sub_opt = Some(msg.into());
+        }
+    };
+
+    Ok(())
+}
+
+#[cfg(test)]
+use processor::emojicoin_dot_fun::Period;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ignore_unsubscribe_on_non_existent_sub() {
+        let msg = SubscriptionMessage {
+            markets: vec![1, 2, 3],
+            event_types: vec![EmojicoinDbEventType::Chat],
+            arena: true,
+            arena_period: Some(ArenaPeriodRequest::Unsubscribe {
+                period: Period::FifteenMinutes,
+            }),
+        };
+        assert_eq!(
+            ClientSubscription::from(msg),
+            ClientSubscription {
+                markets: HashSet::from([1, 2, 3]),
+                event_types: HashSet::from([EmojicoinDbEventType::Chat]),
+                arena: true,
+                arena_candlestick_periods: HashSet::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_new_and_update_happy_path() {
+        let subscription = &mut Some(ClientSubscription {
+            markets: HashSet::from([1, 2, 3]),
+            event_types: HashSet::from([EmojicoinDbEventType::Chat]),
+            arena: true,
+            arena_candlestick_periods: HashSet::from([Period::FiveMinutes]),
+        });
+
+        assert!(update_subscription(
+            subscription,
+            r#"{ "arena_period": { "action": "unsubscribe", "period": "FiveMinutes" } }"#,
+        )
+        .is_ok());
+
+        assert_eq!(
+            subscription.take().unwrap(),
+            ClientSubscription {
+                markets: HashSet::new(),
+                event_types: HashSet::new(),
+                arena: false,
+                arena_candlestick_periods: HashSet::new(),
+            }
+        );
+
+        assert!(update_subscription(
+            subscription,
+            r#"{ "arena_period": { "action": "subscribe", "period": "FifteenMinutes" } }"#,
+        )
+        .is_ok());
+
+        assert!(update_subscription(
+            subscription,
+            r#"{
+               "markets": [4, 2, 13, 14, 14, 14, 14, 14],
+               "event_types": ["MarketRegistration"],
+               "arena": false,
+               "arena_period": { "action": "subscribe", "period": "OneHour" }
+            }"#,
+        )
+        .is_ok());
+
+        assert_eq!(
+            subscription.take().unwrap(),
+            ClientSubscription {
+                markets: HashSet::from([4, 2, 13, 14]),
+                event_types: HashSet::from([EmojicoinDbEventType::MarketRegistration]),
+                arena: false,
+                arena_candlestick_periods: HashSet::from([Period::FifteenMinutes, Period::OneHour]),
+            }
+        );
     }
 }

--- a/src/typescript/frontend/src/components/charts/const.ts
+++ b/src/typescript/frontend/src/components/charts/const.ts
@@ -6,12 +6,14 @@ import {
   type ResolutionString,
   type ThemeName,
 } from "@static/charting_library";
-import { Period } from "@econia-labs/emojicoin-sdk";
+import { ArenaPeriod, Period } from "@sdk/const";
 import { GREEN as GREEN_HEX, PINK as PINK_HEX } from "theme/colors";
 import { hexToRgba } from "utils/hex-to-rgba";
 import { CDN_URL } from "lib/env";
+import { type PeriodTypeFromBroker } from "@econia-labs/emojicoin-sdk";
 
 export const TV_CHARTING_LIBRARY_RESOLUTIONS = [
+  "15S",
   "1",
   "5",
   "15",
@@ -26,7 +28,8 @@ export const GREEN = hexToRgba(GREEN_HEX);
 export const PINK_OPACITY_HALF = hexToRgba(`${PINK_HEX}80`);
 export const GREEN_OPACITY_HALF = hexToRgba(`${GREEN_HEX}80`);
 
-export const ResolutionStringToPeriod: { [key: string]: Period } = {
+export const ResolutionStringToPeriod: { [key: string]: Period | ArenaPeriod } = {
+  "15S": ArenaPeriod.Period15S,
   "1": Period.Period1M,
   "5": Period.Period5M,
   "15": Period.Period15M,
@@ -36,17 +39,31 @@ export const ResolutionStringToPeriod: { [key: string]: Period } = {
   "1D": Period.Period1D,
 };
 
+export const ResolutionStringToBrokerPeriod: { [key: string]: PeriodTypeFromBroker } = {
+  "15S": "FifteenSeconds",
+  "1": "OneMinute",
+  "5": "FiveMinutes",
+  "15": "FifteenMinutes",
+  "30": "ThirtyMinutes",
+  "60": "OneHour",
+  "240": "FourHours",
+  "1D": "OneDay",
+};
+
 export const MS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
 
 export const EXCHANGE_NAME = "emojicoin.fun";
 
+export const DEFAULT_RESOLUTION_STRING = "60" as ResolutionString;
+export const DEFAULT_BROKER_PERIOD = ResolutionStringToBrokerPeriod[DEFAULT_RESOLUTION_STRING];
+
 export const WIDGET_OPTIONS: Omit<ChartingLibraryWidgetOptions, "datafeed" | "container"> = {
   library_path: `${CDN_URL}/charting_library/`,
-  interval: "60" as ResolutionString,
+  interval: DEFAULT_RESOLUTION_STRING,
   theme: "Dark" as ThemeName,
   locale: "en" as LanguageCode,
   custom_css_url: `${CDN_URL}/charting_library_stylesheets/emojicoin-dot-fun.css`,
-  enabled_features: ["iframe_loading_compatibility_mode"],
+  enabled_features: ["iframe_loading_compatibility_mode", "seconds_resolution"],
   disabled_features: [
     "use_localstorage_for_settings",
     "left_toolbar",

--- a/src/typescript/frontend/src/components/charts/get-bars.ts
+++ b/src/typescript/frontend/src/components/charts/get-bars.ts
@@ -11,6 +11,7 @@ import {
   type PeriodDuration,
   type ArenaPeriod,
   isNonArenaPeriod,
+  type AnyPeriod,
 } from "@sdk/const";
 import { toMarketEmojiData } from "@sdk/emoji_data/utils";
 import {
@@ -133,9 +134,9 @@ export const fetchLatestBarsFromMarketResource = async ({
   period,
 }: {
   marketAddress: `0x${string}`;
-  period: Period;
+  period: AnyPeriod;
 }) => {
-  if (isNonArenaPeriod(period)) {
+  if (!isNonArenaPeriod(period)) {
     throw new Error("Invalid period passed");
   }
   const marketResource = await getMarketResource({ aptos: getAptosClient(), marketAddress });

--- a/src/typescript/frontend/src/components/charts/get-bars.ts
+++ b/src/typescript/frontend/src/components/charts/get-bars.ts
@@ -10,6 +10,7 @@ import {
   periodEnumToRawDuration,
   type PeriodDuration,
   type ArenaPeriod,
+  isNonArenaPeriod,
 } from "@sdk/const";
 import { toMarketEmojiData } from "@sdk/emoji_data/utils";
 import {
@@ -134,6 +135,9 @@ export const fetchLatestBarsFromMarketResource = async ({
   marketAddress: `0x${string}`;
   period: Period;
 }) => {
+  if (isNonArenaPeriod(period)) {
+    throw new Error("Invalid period passed");
+  }
   const marketResource = await getMarketResource({ aptos: getAptosClient(), marketAddress });
   return {
     marketMetadata: marketResourceToMarketMetadataModel(marketResource),

--- a/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
+++ b/src/typescript/frontend/src/hooks/use-reliable-subscribe.ts
@@ -1,11 +1,12 @@
 import { type SubscribableBrokerEvents } from "@/broker/types";
+import { type PeriodTypeFromBroker } from "@econia-labs/emojicoin-sdk";
 import { useEventStore } from "context/event-store-context/hooks";
 import { useEffect } from "react";
 
 export type ReliableSubscribeArgs = {
   eventTypes: Array<SubscribableBrokerEvents>;
   arena?: boolean;
-  arenaCandlesticks?: boolean;
+  arenaPeriod?: PeriodTypeFromBroker;
 };
 
 /**
@@ -13,7 +14,7 @@ export type ReliableSubscribeArgs = {
  * mounted. It automatically cleans up subscriptions when the component is unmounted.
  */
 export const useReliableSubscribe = (args: ReliableSubscribeArgs) => {
-  const { eventTypes, arena, arenaCandlesticks } = args;
+  const { eventTypes, arena, arenaPeriod } = args;
   const subscribeEvents = useEventStore((s) => s.subscribeEvents);
   const unsubscribeEvents = useEventStore((s) => s.unsubscribeEvents);
 
@@ -23,7 +24,7 @@ export const useReliableSubscribe = (args: ReliableSubscribeArgs) => {
     const timeout = window.setTimeout(() => {
       subscribeEvents(eventTypes, {
         baseEvents: arena,
-        candlesticks: arenaCandlesticks,
+        arenaPeriod,
       });
     }, 250);
 
@@ -32,8 +33,8 @@ export const useReliableSubscribe = (args: ReliableSubscribeArgs) => {
       clearTimeout(timeout);
       unsubscribeEvents(eventTypes, {
         baseEvents: arena,
-        candlesticks: arenaCandlesticks,
+        arenaPeriod,
       });
     };
-  }, [eventTypes, arena, arenaCandlesticks, subscribeEvents, unsubscribeEvents]);
+  }, [eventTypes, arena, arenaPeriod, subscribeEvents, unsubscribeEvents]);
 };

--- a/src/typescript/frontend/src/lib/store/event/types.ts
+++ b/src/typescript/frontend/src/lib/store/event/types.ts
@@ -1,4 +1,4 @@
-import { type Period } from "@sdk/const";
+import { type AnyPeriod, type Period } from "@sdk/const";
 import { type SymbolEmoji } from "@sdk/emoji_data";
 import {
   type MarketMetadataModel,
@@ -58,7 +58,7 @@ export type EventState = {
 
 export type PeriodSubscription = {
   marketEmojis: SymbolEmoji[];
-  period: Period;
+  period: AnyPeriod;
   cb: SubscribeBarsCallback;
 };
 

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -244,7 +244,19 @@ export const connect = () => {
         }
       },
       onConnect(_e) {
-        client.subscribeEvents(["Swap", "Chat", "MarketLatestState"]);
+        client.subscribeEvents(
+          // Subscribe to the following basic emojicoin_dot_fun events.
+          ["Swap", "Chat", "MarketLatestState"],
+          {
+            // Subscribe to all base arena events (Melee, Swap, Enter, Exit).
+            baseEvents: true,
+            // Subscribe to 1H candlestick updates for the current arena melee.
+            arenaPeriodRequest: {
+              action: "subscribe",
+              period: "OneHour",
+            }
+          }
+        );
       },
       onError(e) {
         console.error(e);

--- a/src/typescript/sdk/src/broker-v2/types.ts
+++ b/src/typescript/sdk/src/broker-v2/types.ts
@@ -1,4 +1,9 @@
-import { type BrokerEventModels, DatabaseTypeConverter } from "../indexer-v2/types";
+import { type AnyPeriod, ArenaPeriod } from "../const";
+import {
+  type BrokerEventModels,
+  DatabaseTypeConverter,
+  type PeriodTypeFromBroker,
+} from "../indexer-v2/types";
 import {
   type BrokerJsonTypes,
   type DatabaseJsonType,
@@ -18,7 +23,7 @@ export type SubscribableBrokerEvents =
   | "PeriodicState"
   | "MarketRegistration";
 
-type BrokerArenaEvent =
+export type BrokerArenaEvent =
   | "ArenaEnter"
   | "ArenaExit"
   | "ArenaMelee"
@@ -78,13 +83,21 @@ export type BrokerMessage = {
 };
 
 /**
+ * Arena periods are subscribed in a granular way- like an actual sub/pub model with topics.
+ */
+export type ArenaPeriodRequest = {
+  action: "subscribe" | "unsubscribe";
+  period: PeriodTypeFromBroker;
+};
+
+/**
  * The message the client sends to the broker to subscribe or unsubscribe.
  */
 export type SubscriptionMessage = {
   markets: number[];
   event_types: BrokerEvent[];
   arena: boolean;
-  arena_candlesticks: boolean;
+  arena_period?: ArenaPeriodRequest;
 };
 
 /* eslint-disable-next-line import/no-unused-modules */
@@ -92,5 +105,18 @@ export type WebSocketSubscriptions = {
   marketIDs: Set<AnyNumberString>;
   eventTypes: Set<BrokerEvent>;
   arena: boolean;
-  arenaCandlesticks: boolean;
+  arenaPeriods: Set<PeriodTypeFromBroker>;
 };
+
+const PeriodToBrokerPeriodType: Record<AnyPeriod, PeriodTypeFromBroker> = {
+  [ArenaPeriod.Period15S]: "FifteenSeconds",
+  [ArenaPeriod.Period1M]: "OneMinute",
+  [ArenaPeriod.Period5M]: "FiveMinutes",
+  [ArenaPeriod.Period15M]: "FifteenMinutes",
+  [ArenaPeriod.Period30M]: "ThirtyMinutes",
+  [ArenaPeriod.Period1H]: "OneHour",
+  [ArenaPeriod.Period4H]: "FourHours",
+  [ArenaPeriod.Period1D]: "OneDay",
+};
+
+export const periodToPeriodTypeFromBroker = (period: AnyPeriod) => PeriodToBrokerPeriodType[period];

--- a/src/typescript/sdk/tests/e2e/broker/utils.ts
+++ b/src/typescript/sdk/tests/e2e/broker/utils.ts
@@ -1,5 +1,6 @@
 import { type AnyNumberString, waitFor } from "../../../src";
 import {
+  type ArenaPeriodRequest,
   type BrokerEvent,
   type BrokerMessage,
   brokerMessageConverter,
@@ -98,13 +99,13 @@ export const subscribe = (
   markets: AnyNumberString[],
   eventTypes: SubscribableBrokerEvents[],
   arena: boolean = false,
-  arenaCandlesticks: boolean = false
+  arenaPeriod?: ArenaPeriodRequest
 ) => {
   const outgoingMessage: SubscriptionMessage = {
     markets: markets.map((n) => Number(n)),
     event_types: eventTypes,
     arena,
-    arena_candlesticks: arenaCandlesticks,
+    arena_period: arenaPeriod,
   };
   const json = JSON.stringify(outgoingMessage);
   client.send(json);


### PR DESCRIPTION
# Description

Instead of just a boolean flag, enforce that the broker only accepts a single period type for a subscription to arena candlestick events. Otherwise, the broker sends out 6+ messages to every client on each arena swap.

This way, it only sends out one candlestick per client subscription, based on the period they subscribe to.

- [x] Make the broker accept a single period type for a subscription
- [x] Only send an addition/removal a single time, because they are now "consumed" by the broker each time (added/removed from the hash set of arena candlestick periods) 
- [x] Update the SDK types to use the new type
- [x] Have the home page by default subscribe to "60" aka 1h candlesticks for arena when on the arena page (updated subscriptions from the charting library to come in the charting PR)
- [x] Consolidate the default "resolution" to an exported constant variable and use it
- [x] Update misc TradingView config types to decrease the diff size on the next PR
- [x] Update README.md for the broker and update examples in the typescript SDK README since it explains how to use it (and it's now outdated)

# Testing

- [x] Added simple json serialization unit tests to ensure it works as expected

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
