### PR TITLE
chore(ECO-3045): Add the new `/api/arena/candlesticks` route; properly implement `Period | ArenaPeriod` types [3.2/4]

### DIFF
--- a/src/typescript/frontend/src/app/api/arena/candlesticks/fetch.ts
+++ b/src/typescript/frontend/src/app/api/arena/candlesticks/fetch.ts
@@ -1,0 +1,140 @@
+// cspell:word timespan
+
+import { parseJSON, stringifyJSON } from "utils";
+import { type ArenaCandlesticksSearchParams } from "./search-params-schema";
+import {
+  getCachedLatestProcessedEmojicoinTimestamp,
+  getPeriodDurationSeconds,
+  HISTORICAL_CACHE_DURATION,
+  indexToParcelEndDate,
+  indexToParcelStartDate,
+  jsonStrAppend,
+  NORMAL_CACHE_DURATION,
+  PARCEL_SIZE,
+  toIndex,
+} from "app/api/candlesticks/utils";
+import {
+  type ArenaCandlestickModel,
+  fetchArenaCandlesticksSince,
+  fetchArenaInfoByMeleeID,
+} from "@sdk/indexer-v2";
+import { type AnyNumberString } from "@sdk-types";
+import { unstable_cache } from "next/cache";
+import { type ArenaPeriod } from "@sdk/const";
+import { getPeriodStartTimeFromTime } from "@sdk/utils/misc";
+
+const getCandlesticks = async (
+  params: Pick<ArenaCandlesticksSearchParams, "meleeID" | "period"> & { index: number }
+) => {
+  const { meleeID, period, index } = params;
+  const start = indexToParcelStartDate(index, period);
+  const periodDurationMilliseconds = getPeriodDurationSeconds(period) * 1000;
+  const timespan = periodDurationMilliseconds * PARCEL_SIZE;
+  const end = new Date(start.getTime() + timespan);
+
+  // PARCEL_SIZE determines the max number of rows, so we don't need to pass a `LIMIT` value.
+  // `start` and `end` determine the level of pagination, so no need to specify `offset` either.
+  const data = await fetchArenaCandlesticksSince({
+    meleeID,
+    period,
+    start,
+    end,
+  });
+
+  return {
+    data: stringifyJSON(data),
+    count: data.length,
+  };
+};
+
+const MELEE_START_TIMES_TAG = "melee-start-times" as const;
+/**
+ * In case the nextjs cache is poisoned (by fetching candlestick data for a melee that doesn't exist
+ * yet), return a unique time very far in the future to indicate that a response is invalid and thus
+ * should be ignored when returned from the cached fetch response.
+ *
+ * There is no clear way to circumvent this issue- it is a limitation of `unstable_cache`, and
+ * `revalidateTag` is not clear or worth the time to figure out properly.
+ */
+const START_TIME_IF_FAILURE = 777777777777777 as const; // new Date(777...777) === year ~22,600.
+
+const getMeleeStartMs = async (meleeID: AnyNumberString) =>
+  fetchArenaInfoByMeleeID({ meleeID }).then((res) => {
+    if (res) {
+      return res.startTime.getTime();
+    }
+    return START_TIME_IF_FAILURE;
+  });
+
+const getCachedMeleeStartMs = unstable_cache(getMeleeStartMs, [MELEE_START_TIMES_TAG], {
+  revalidate: HISTORICAL_CACHE_DURATION,
+});
+
+/**
+ * A function that handles getting the melee start period boundary.
+ *
+ * If the cache for the melee `start_time` was poisoned or the meleeID data was simply queried
+ * before it was started, we unfortunately have to always skip the cache and force fetch the data.
+ * @see {@link START_TIME_IF_FAILURE}
+ */
+const getMeleeStartPeriodBoundary = (meleeID: AnyNumberString, period: ArenaPeriod) =>
+  getCachedMeleeStartMs(meleeID)
+    .then(async (time) => {
+      if (time === START_TIME_IF_FAILURE) {
+        return await getMeleeStartMs(meleeID);
+      }
+      return time;
+    })
+    .then((validTime) => new Date(Number(getPeriodStartTimeFromTime(validTime, period))));
+
+const getHistoricCachedCandlesticks = unstable_cache(
+  getCandlesticks,
+  ["arena-candlesticks-historic"],
+  {
+    revalidate: HISTORICAL_CACHE_DURATION,
+  }
+);
+
+const getNormalCachedCandlesticks = unstable_cache(getCandlesticks, ["arena-candlesticks"], {
+  revalidate: NORMAL_CACHE_DURATION,
+});
+
+/**
+ * This implementation and all utility functions imported from "utils" are essentially copied over
+ * from {@link [/api/candlesticks](../../candlesticks/utils.ts)}.
+ */
+export const fetchArenaCandlesticksRoute = async (args: ArenaCandlesticksSearchParams) => {
+  const { meleeID, to, period, countBack } = args;
+  const index = toIndex(to, period);
+
+  let data: string = "[]";
+  const processorTimestamp = new Date(await getCachedLatestProcessedEmojicoinTimestamp());
+  let totalCount = 0;
+  let i = 0;
+
+  const meleeStartPeriodBoundary = await getMeleeStartPeriodBoundary(meleeID, period);
+
+  while (totalCount <= countBack) {
+    const localIndex = index - i;
+    const endDate = indexToParcelEndDate(localIndex, period);
+    const query =
+      endDate < processorTimestamp ? getHistoricCachedCandlesticks : getNormalCachedCandlesticks;
+    const res = await query({ meleeID, index: localIndex, period });
+
+    if (i === 0) {
+      const parsed = parseJSON<ArenaCandlestickModel[]>(res.data);
+      const filtered = parsed.filter((val) => val.startTime.getTime() < to * 1000);
+      totalCount += filtered.length;
+      data = jsonStrAppend(data, stringifyJSON(filtered));
+    } else {
+      totalCount += res.count;
+      data = jsonStrAppend(data, res.data);
+    }
+    if (endDate < meleeStartPeriodBoundary) {
+      break;
+    }
+    i += 1;
+  }
+
+  return data;
+};

--- a/src/typescript/frontend/src/app/api/arena/candlesticks/route.ts
+++ b/src/typescript/frontend/src/app/api/arena/candlesticks/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { ArenaCandlesticksSearchParamsSchema } from "./search-params-schema";
+import { fetchArenaCandlesticksRoute } from "./fetch";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const params = Object.fromEntries(searchParams.entries());
+  const {
+    data: validatedParams,
+    success,
+    error,
+  } = ArenaCandlesticksSearchParamsSchema.safeParse(params);
+
+  if (!success) {
+    return NextResponse.json(
+      {
+        error: "Invalid search params",
+        details: error.flatten().fieldErrors,
+      },
+      {
+        status: 400,
+      }
+    );
+  }
+
+  try {
+    const data = await fetchArenaCandlesticksRoute(validatedParams);
+    return new NextResponse(data);
+  } catch (e) {
+    return new NextResponse((e as Error).message, { status: 400 });
+  }
+}

--- a/src/typescript/frontend/src/app/api/arena/candlesticks/search-params-schema.ts
+++ b/src/typescript/frontend/src/app/api/arena/candlesticks/search-params-schema.ts
@@ -1,0 +1,20 @@
+import { ArenaPeriod } from "@sdk/const";
+import { Schemas } from "@sdk/utils";
+import { z } from "zod";
+
+export const ArenaCandlesticksSearchParamsSchema = z.object({
+  meleeID: Schemas["PositiveInteger"].describe("`meleeID` must be a positive integer."),
+  to: Schemas["PositiveInteger"].describe("`to` must be a positive integer."),
+  countBack: Schemas["PositiveInteger"].describe("`countBack` must be a positive integer."),
+  period: z.nativeEnum(ArenaPeriod).describe("Invalid `period` passed."),
+});
+
+/**
+ * The search params used in the `GET` request at `candlesticks/api`.
+ *
+ * @property {string} meleeID       - A number string, as the melee ID.
+ * @property {string} to            - A number string, as the end time boundary as a UNIX timestamp.
+ * @property {string} countBack     - A number string, as `countBack` requested by the datafeed API.
+ * @property {string} period        - A string representing the {@link ArenaPeriod}
+ */
+export type ArenaCandlesticksSearchParams = z.infer<typeof ArenaCandlesticksSearchParamsSchema>;

--- a/src/typescript/frontend/src/app/api/candlesticks/utils.ts
+++ b/src/typescript/frontend/src/app/api/candlesticks/utils.ts
@@ -2,6 +2,7 @@
 
 import {
   type AnyNumberString,
+  type AnyPeriod,
   getPeriodStartTimeFromTime,
   type Period,
   PeriodDuration,
@@ -25,15 +26,15 @@ import { type CandlesticksSearchParams } from "./search-params-schema";
  */
 export const PARCEL_SIZE = 500;
 
-export const indexToParcelStartDate = (index: number, period: Period): Date =>
+export const indexToParcelStartDate = (index: number, period: AnyPeriod): Date =>
   new Date((PARCEL_SIZE * (index * periodEnumToRawDuration(period))) / 1000);
-export const indexToParcelEndDate = (index: number, period: Period): Date =>
+export const indexToParcelEndDate = (index: number, period: AnyPeriod): Date =>
   new Date((PARCEL_SIZE * ((index + 1) * periodEnumToRawDuration(period))) / 1000);
 
-export const getPeriodDurationSeconds = (period: Period) =>
+export const getPeriodDurationSeconds = (period: AnyPeriod) =>
   (periodEnumToRawDuration(period) / PeriodDuration.PERIOD_1M) * 60;
 
-export const toIndex = (end: number, period: Period): number => {
+export const toIndex = (end: number, period: AnyPeriod): number => {
   const periodDuration = getPeriodDurationSeconds(period);
   const parcelDuration = periodDuration * PARCEL_SIZE;
 
@@ -134,7 +135,7 @@ const getNormalCachedCandlesticks = unstable_cache(getCandlesticks, ["candlestic
   revalidate: NORMAL_CACHE_DURATION,
 });
 
-const getCachedLatestProcessedEmojicoinTimestamp = unstable_cache(
+export const getCachedLatestProcessedEmojicoinTimestamp = unstable_cache(
   getLatestProcessedEmojicoinTimestamp,
   ["processor-timestamp"],
   { revalidate: 5 }

--- a/src/typescript/frontend/src/components/charts/get-bars.ts
+++ b/src/typescript/frontend/src/components/charts/get-bars.ts
@@ -33,10 +33,6 @@ type CandlesticksParams = Flatten<
   } & XOR<{ marketID: string }, { meleeID: string }>
 >;
 
-type ParsedResponse<T extends CandlesticksParams> = T extends { marketID: string }
-  ? PeriodicStateEventModel
-  : ArenaCandlestickModel;
-
 export const fetchCandlesticksForChart = async <T extends CandlesticksParams>({
   marketID,
   meleeID,
@@ -52,7 +48,7 @@ export const fetchCandlesticksForChart = async <T extends CandlesticksParams>({
 
   return await fetch(`${ROUTES.api.candlesticks}?${params.toString()}`)
     .then((res) => res.text())
-    .then((res) => parseJSON<ParsedResponse<T>[]>(res))
+    .then((res) => parseJSON<PeriodicStateEventModel[] | ArenaCandlestickModel[]>(res))
     .then((res) =>
       res
         .map(toBar)

--- a/src/typescript/frontend/src/components/charts/get-bars.ts
+++ b/src/typescript/frontend/src/components/charts/get-bars.ts
@@ -44,7 +44,10 @@ export const fetchCandlesticksForChart = async ({
     to: periodParams.to.toString(),
   });
 
-  return await fetch(`${ROUTES.api.candlesticks}?${params.toString()}`)
+  const route =
+    marketID !== undefined ? ROUTES.api["candlesticks"] : ROUTES.api["arena"]["candlesticks"];
+
+  return await fetch(`${route}?${params}`)
     .then((res) => res.text())
     .then((res) => parseJSON<PeriodicStateEventModel[] | ArenaCandlestickModel[]>(res))
     .then((res) =>

--- a/src/typescript/frontend/src/components/charts/get-bars.ts
+++ b/src/typescript/frontend/src/components/charts/get-bars.ts
@@ -26,19 +26,17 @@ import { hasTradingActivity } from "lib/chart-utils";
 import { ROUTES } from "router/routes";
 import { parseJSON } from "utils";
 
-type CandlesticksParams = Flatten<
-  {
-    periodParams: PeriodParams;
-    period: ArenaPeriod | Period;
-  } & XOR<{ marketID: string }, { meleeID: string }>
->;
-
-export const fetchCandlesticksForChart = async <T extends CandlesticksParams>({
+export const fetchCandlesticksForChart = async ({
   marketID,
   meleeID,
   periodParams,
   period,
-}: T): Promise<Bar[]> => {
+}: Flatten<
+  XOR<{ marketID: string }, { meleeID: string }> & {
+    periodParams: PeriodParams;
+    period: ArenaPeriod | Period;
+  }
+>): Promise<Bar[]> => {
   const params = new URLSearchParams({
     ...(marketID !== undefined ? { marketID } : { meleeID }),
     period: period.toString(),

--- a/src/typescript/frontend/src/components/charts/get-bars.ts
+++ b/src/typescript/frontend/src/components/charts/get-bars.ts
@@ -55,7 +55,11 @@ export const fetchCandlesticksForChart = async ({
         .map(toBar)
         .sort((a, b) => a.time - b.time)
         .reduce(curriedBarsReducer(periodParams.to), [])
-    );
+    )
+    .catch((error) => {
+      console.error(`Couldn't fetch candlesticks from ${route}: ${error}`);
+      return [];
+    });
 };
 
 /**

--- a/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
@@ -18,6 +18,7 @@ import { ROUTES } from "router/routes";
 import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
 import { useRouter } from "next/navigation";
 import { useLatestMeleeID } from "@hooks/use-latest-melee-id";
+import { useEventStore } from "context/event-store-context/hooks";
 
 const RewardsRemainingBox = ({ rewardsRemaining }: { rewardsRemaining: bigint }) => {
   const { isMobile } = useMatchBreakpoints();
@@ -96,12 +97,19 @@ export const ArenaClient = (props: ArenaProps) => {
   const { isMobile } = useMatchBreakpoints();
   const { account } = useAptos();
   const router = useRouter();
+  const loadArenaInfoFromServer = useEventStore((s) => s.loadArenaInfoFromServer);
 
   // Undefined while loading. Null means no position
   const [position, setPosition] = useState<ArenaPositionModel | undefined | null>(null);
   const [history, setHistory] = useState<ArenaLeaderboardHistoryWithArenaInfoModel[]>([]);
 
   useReliableSubscribe({ eventTypes: ["Chat"], arena: true });
+
+  useEffect(() => {
+    if (props.arenaInfo) {
+      loadArenaInfoFromServer(props.arenaInfo);
+    }
+  }, [loadArenaInfoFromServer, props.arenaInfo]);
 
   const latestMeleeID = useLatestMeleeID();
 

--- a/src/typescript/frontend/src/lib/store/arena/utils.ts
+++ b/src/typescript/frontend/src/lib/store/arena/utils.ts
@@ -1,12 +1,13 @@
 import { type MarketEmojiData, toMarketEmojiData } from "@sdk/emoji_data";
 import { type AccountAddressString } from "@sdk/emojicoin_dot_fun";
+import { type ArenaInfoModel, type ArenaModelWithMeleeID } from "@sdk/indexer-v2";
 import {
-  type ArenaEventModels,
-  type ArenaVaultBalanceUpdateModel,
-  type ArenaInfoModel,
-  type ArenaEventModelWithMeleeID,
-} from "@sdk/indexer-v2";
-import { isArenaEnterModel, isArenaExitModel, isArenaMeleeModel } from "@sdk/types/arena-types";
+  isArenaCandlestickModel,
+  isArenaEnterModel,
+  isArenaExitModel,
+  isArenaMeleeModel,
+  isArenaSwapModel,
+} from "@sdk/types/arena-types";
 
 export type ArenaMarketPair = {
   market0: {
@@ -40,7 +41,7 @@ export const toArenaMarketPair = (info: ArenaInfoModel): ArenaMarketPair => {
   };
 };
 
-export const toMappedMelees = <T extends ArenaEventModelWithMeleeID>(models: T[]) => {
+export const toMappedMelees = <T extends ArenaModelWithMeleeID>(models: T[]) => {
   const map = new Map<bigint, T[]>();
 
   models.forEach((model) => {
@@ -53,15 +54,17 @@ export const toMappedMelees = <T extends ArenaEventModelWithMeleeID>(models: T[]
   return map;
 };
 
-export const getMeleeIDFromArenaModel = (
-  model: Exclude<ArenaEventModels, ArenaVaultBalanceUpdateModel>
-): bigint => {
+export const getMeleeIDFromArenaModel = (model: ArenaModelWithMeleeID): bigint => {
   if (isArenaMeleeModel(model)) {
     return model.melee.meleeID;
   } else if (isArenaEnterModel(model)) {
     return model.enter.meleeID;
   } else if (isArenaExitModel(model)) {
     return model.exit.meleeID;
+  } else if (isArenaSwapModel(model)) {
+    return model.swap.meleeID;
+  } else if (isArenaCandlestickModel(model)) {
+    return model.meleeID;
   }
-  return model.swap.meleeID;
+  throw new Error("Invalid arena model for `getMeleeID`: ", model);
 };

--- a/src/typescript/frontend/src/lib/store/event/event-store.ts
+++ b/src/typescript/frontend/src/lib/store/event/event-store.ts
@@ -31,7 +31,7 @@ import {
 import { initializeArenaStore } from "../arena/store";
 import {
   isArenaEnterModel,
-  isArenaEventModelWithMeleeID,
+  isArenaModelWithMeleeID,
   isArenaExitModel,
   isArenaMeleeModel,
   isArenaSwapModel,
@@ -99,7 +99,7 @@ export const createEventStore = () => {
             DEBUG_ASSERT(() => marketEvents.length === 0);
           });
 
-          const arenaEvents = events.filter(isArenaEventModelWithMeleeID);
+          const arenaEvents = events.filter(isArenaModelWithMeleeID);
           const arenaMap = toMappedMelees(arenaEvents);
           Array.from(arenaMap.entries()).forEach(([meleeID, events]) => {
             ensureMeleeInStore(state, meleeID);
@@ -145,7 +145,7 @@ export const createEventStore = () => {
                   maybeUpdateLocalStorage(pushToLocalStorage, "periodic", event);
                 }
               } else {
-                if (isArenaEventModelWithMeleeID(event)) {
+                if (isArenaModelWithMeleeID(event)) {
                   const meleeID = getMeleeIDFromArenaModel(event);
                   ensureMeleeInStore(state, meleeID);
                   const melee = state.melees.get(meleeID)!;

--- a/src/typescript/frontend/src/lib/store/event/types.ts
+++ b/src/typescript/frontend/src/lib/store/event/types.ts
@@ -23,7 +23,7 @@ type MarketLatestState = DatabaseModels["market_state"];
 
 export type SymbolString = string;
 
-export type CandlestickData = {
+export type CandlestickPeriod = {
   callback: SubscribeBarsCallback | undefined;
   latestBar: LatestBar | undefined;
 };
@@ -39,13 +39,13 @@ export type MarketEventStore = {
   liquidityEvents: readonly Liquidity[];
   stateEvents: readonly (MarketLatestStateEvent | MarketLatestState)[];
   chatEvents: readonly Chat[];
-  [Period.Period1M]: CandlestickData;
-  [Period.Period5M]: CandlestickData;
-  [Period.Period15M]: CandlestickData;
-  [Period.Period30M]: CandlestickData;
-  [Period.Period1H]: CandlestickData;
-  [Period.Period4H]: CandlestickData;
-  [Period.Period1D]: CandlestickData;
+  [Period.Period1M]: CandlestickPeriod;
+  [Period.Period5M]: CandlestickPeriod;
+  [Period.Period15M]: CandlestickPeriod;
+  [Period.Period30M]: CandlestickPeriod;
+  [Period.Period1H]: CandlestickPeriod;
+  [Period.Period4H]: CandlestickPeriod;
+  [Period.Period1D]: CandlestickPeriod;
 };
 
 export type EventState = {

--- a/src/typescript/frontend/src/lib/store/event/types.ts
+++ b/src/typescript/frontend/src/lib/store/event/types.ts
@@ -23,7 +23,7 @@ type MarketLatestState = DatabaseModels["market_state"];
 
 export type SymbolString = string;
 
-export type CandlestickPeriod = {
+export type CandlestickData = {
   callback: SubscribeBarsCallback | undefined;
   latestBar: LatestBar | undefined;
 };
@@ -39,13 +39,13 @@ export type MarketEventStore = {
   liquidityEvents: readonly Liquidity[];
   stateEvents: readonly (MarketLatestStateEvent | MarketLatestState)[];
   chatEvents: readonly Chat[];
-  [Period.Period1M]: CandlestickPeriod;
-  [Period.Period5M]: CandlestickPeriod;
-  [Period.Period15M]: CandlestickPeriod;
-  [Period.Period30M]: CandlestickPeriod;
-  [Period.Period1H]: CandlestickPeriod;
-  [Period.Period4H]: CandlestickPeriod;
-  [Period.Period1D]: CandlestickPeriod;
+  [Period.Period1M]: CandlestickData;
+  [Period.Period5M]: CandlestickData;
+  [Period.Period15M]: CandlestickData;
+  [Period.Period30M]: CandlestickData;
+  [Period.Period1H]: CandlestickData;
+  [Period.Period4H]: CandlestickData;
+  [Period.Period1D]: CandlestickData;
 };
 
 export type EventState = {

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -1,9 +1,9 @@
-import { Period, PERIODS, periodEnumToRawDuration } from "@sdk/const";
+import { Period, NON_ARENA_PERIODS, periodEnumToRawDuration } from "@sdk/const";
 import { type SubscribeBarsCallback } from "@static/charting_library/datafeed-api";
 import { type WritableDraft } from "immer";
 import {
   type EventState,
-  type CandlestickData,
+  type CandlestickPeriod,
   type MarketEventStore,
   type MarketStoreMetadata,
 } from "./types";
@@ -17,7 +17,7 @@ import { createBarFromPeriodicState, createBarFromSwap, type LatestBar } from ".
 import { q64ToBig, toNominal } from "@sdk/utils/nominal-price";
 import { type ArenaState, createInitialMeleeState } from "../arena/store";
 
-export const createInitialCandlestickData = (): WritableDraft<CandlestickData> => ({
+export const createPeriodData = (): WritableDraft<CandlestickPeriod> => ({
   callback: undefined,
   latestBar: undefined,
 });
@@ -30,13 +30,13 @@ export const createInitialMarketState = (
   liquidityEvents: [],
   stateEvents: [],
   chatEvents: [],
-  [Period.Period1M]: createInitialCandlestickData(),
-  [Period.Period5M]: createInitialCandlestickData(),
-  [Period.Period15M]: createInitialCandlestickData(),
-  [Period.Period30M]: createInitialCandlestickData(),
-  [Period.Period1H]: createInitialCandlestickData(),
-  [Period.Period4H]: createInitialCandlestickData(),
-  [Period.Period1D]: createInitialCandlestickData(),
+  [Period.Period1M]: createPeriodData(),
+  [Period.Period5M]: createPeriodData(),
+  [Period.Period15M]: createPeriodData(),
+  [Period.Period30M]: createPeriodData(),
+  [Period.Period1H]: createPeriodData(),
+  [Period.Period4H]: createPeriodData(),
+  [Period.Period1D]: createPeriodData(),
 });
 
 export const ensureMarketInStore = (
@@ -59,7 +59,7 @@ export const handleLatestBarForSwapEvent = (
   market: WritableDraft<MarketEventStore>,
   event: SwapEventModel
 ) => {
-  for (const period of PERIODS) {
+  for (const period of NON_ARENA_PERIODS) {
     const data = market[period];
     const swapPeriodStart = getPeriodStartTimeFromTime(event.market.time, period);
     const latestBarPeriodStart = BigInt(data.latestBar?.time ?? -1n) * 1000n;
@@ -70,13 +70,13 @@ export const handleLatestBarForSwapEvent = (
       callbackClonedLatestBarIfSubscribed(data.callback, newBar);
     } else if (!data.latestBar) {
       throw new Error("This should never occur. It is a type guard/hint.");
-    } else if (event.market.marketNonce >= data.latestBar.marketNonce) {
+    } else if (event.market.marketNonce >= data.latestBar.nonce) {
       const price = q64ToBig(event.swap.avgExecutionPriceQ64).toNumber();
       data.latestBar.time = Number(getPeriodStartTimeFromTime(event.market.time, period) / 1000n);
       data.latestBar.close = price;
       data.latestBar.high = Math.max(data.latestBar.high, price);
       data.latestBar.low = Math.min(data.latestBar.low, price);
-      data.latestBar.marketNonce = event.market.marketNonce;
+      data.latestBar.nonce = event.market.marketNonce;
       data.latestBar.volume += toNominal(event.swap.quoteVolume);
       // Note this results in `time order violation` errors if we set `has_empty_bars`
       // to `true` in the `LibrarySymbolInfo` configuration.
@@ -95,7 +95,7 @@ export const handleLatestBarForPeriodicStateEvent = (
   // Check if the new bar would be newer than the current latest bar.
   if (
     !data.latestBar ||
-    (data.latestBar.marketNonce < newBar.marketNonce && data.latestBar.time <= newBar.time)
+    (data.latestBar.nonce < newBar.nonce && data.latestBar.time <= newBar.time)
   ) {
     data.latestBar = newBar;
     // We need to update the latest bar for all periods with any existing swap
@@ -111,14 +111,14 @@ export const handleLatestBarForPeriodicStateEvent = (
       // NOTE: When a new periodic state event is emitted, the market nonce
       // for the swap event is actually exactly the same as the periodic state event,
       // hence why we use `>=` instead of just `>`.
-      if (swapInTimeRange && swapEvent.market.marketNonce >= data.latestBar.marketNonce) {
+      if (swapInTimeRange && swapEvent.market.marketNonce >= data.latestBar.nonce) {
         if (!data.latestBar) throw new Error("This should never occur. It is a type guard/hint.");
         const price = q64ToBig(innerSwap.avgExecutionPriceQ64).toNumber();
         data.latestBar.time = Number(getPeriodStartTimeFromTime(innerMarket.time, period) / 1000n);
         data.latestBar.close = price;
         data.latestBar.high = Math.max(data.latestBar.high, price);
         data.latestBar.low = Math.min(data.latestBar.low, price);
-        data.latestBar.marketNonce = innerMarket.marketNonce;
+        data.latestBar.nonce = innerMarket.marketNonce;
         data.latestBar.volume += toNominal(innerSwap.quoteVolume);
       }
     }

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -3,7 +3,7 @@ import { type SubscribeBarsCallback } from "@static/charting_library/datafeed-ap
 import { type WritableDraft } from "immer";
 import {
   type EventState,
-  type CandlestickPeriod,
+  type CandlestickData,
   type MarketEventStore,
   type MarketStoreMetadata,
 } from "./types";
@@ -17,7 +17,7 @@ import { createBarFromPeriodicState, createBarFromSwap, type LatestBar } from ".
 import { q64ToBig, toNominal } from "@sdk/utils/nominal-price";
 import { type ArenaState, createInitialMeleeState } from "../arena/store";
 
-export const createPeriodData = (): WritableDraft<CandlestickPeriod> => ({
+export const createInitialCandlestickData = (): WritableDraft<CandlestickData> => ({
   callback: undefined,
   latestBar: undefined,
 });
@@ -30,13 +30,13 @@ export const createInitialMarketState = (
   liquidityEvents: [],
   stateEvents: [],
   chatEvents: [],
-  [Period.Period1M]: createPeriodData(),
-  [Period.Period5M]: createPeriodData(),
-  [Period.Period15M]: createPeriodData(),
-  [Period.Period30M]: createPeriodData(),
-  [Period.Period1H]: createPeriodData(),
-  [Period.Period4H]: createPeriodData(),
-  [Period.Period1D]: createPeriodData(),
+  [Period.Period1M]: createInitialCandlestickData(),
+  [Period.Period5M]: createInitialCandlestickData(),
+  [Period.Period15M]: createInitialCandlestickData(),
+  [Period.Period30M]: createInitialCandlestickData(),
+  [Period.Period1H]: createInitialCandlestickData(),
+  [Period.Period4H]: createInitialCandlestickData(),
+  [Period.Period1D]: createInitialCandlestickData(),
 });
 
 export const ensureMarketInStore = (

--- a/src/typescript/frontend/src/router/routes.ts
+++ b/src/typescript/frontend/src/router/routes.ts
@@ -8,6 +8,7 @@ export const ROUTES = expandRoutes({
     arena: {
       position: _,
       "historical-positions": _,
+      candlesticks: _,
     },
     candlesticks: _,
     dexscreener: {

--- a/src/typescript/sdk/src/const.ts
+++ b/src/typescript/sdk/src/const.ts
@@ -166,13 +166,13 @@ export enum Period {
 
 export enum ArenaPeriod {
   Period15S = "period_15s",
-  Period1M = "period_1m",
-  Period5M = "period_5m",
-  Period15M = "period_15m",
-  Period30M = "period_30m",
-  Period1H = "period_1h",
-  Period4H = "period_4h",
-  Period1D = "period_1d",
+  Period1M = Period.Period1M,
+  Period5M = Period.Period5M,
+  Period15M = Period.Period15M,
+  Period30M = Period.Period30M,
+  Period1H = Period.Period1H,
+  Period4H = Period.Period4H,
+  Period1D = Period.Period1D,
 }
 
 /// As defined in the database, aka the enum string.
@@ -229,7 +229,7 @@ export const toArenaPeriod = (s: DatabaseStructType["ArenaCandlestick"]["period"
     OneHour: ArenaPeriod.Period1H,
     FourHours: ArenaPeriod.Period4H,
     OneDay: ArenaPeriod.Period1D,
-  })[s as ValueOf<typeof Period>] ??
+  })[s as ValueOf<typeof ArenaPeriod>] ??
   (() => {
     throw new Error(`Unknown period: ${s}`);
   })();
@@ -273,6 +273,7 @@ export enum TriggerFromContract {
  * are all referred to interchangeably throughout this codebase.
  */
 export enum PeriodDuration {
+  PERIOD_15S = 15000000,
   PERIOD_1M = 60000000,
   PERIOD_5M = 300000000,
   PERIOD_15M = 900000000,
@@ -282,7 +283,8 @@ export enum PeriodDuration {
   PERIOD_1D = 86400000000,
 }
 
-export const periodEnumToRawDuration = (period: Period): PeriodDuration => {
+export const periodEnumToRawDuration = (period: Period | ArenaPeriod): PeriodDuration => {
+  if (period === ArenaPeriod.Period15S) return PeriodDuration.PERIOD_15S;
   if (period === Period.Period1M) return PeriodDuration.PERIOD_1M;
   if (period === Period.Period5M) return PeriodDuration.PERIOD_5M;
   if (period === Period.Period15M) return PeriodDuration.PERIOD_15M;
@@ -340,13 +342,13 @@ export const MAX_SYMBOL_LENGTH = 10;
 // The default grace period time for a new market registrant to trade on a new market before
 // non-registrants can trade. Note that this period is ended early once the registrant makes a
 // single trade.
-export const GRACE_PERIOD_TIME = BigInt(PeriodDuration.PERIOD_5M.valueOf());
+export const GRACE_PERIOD_TIME = BigInt(PeriodDuration.PERIOD_5M);
 
 /**
- * A helper object to convert from an untyped number to a PeriodDuration enum value.
- * If the number is invalid, the value returned will be undefined.
+ * A helper function to convert from an untyped number to a PeriodDuration enum value.
  */
 export const toPeriodDuration = (num: number | bigint): PeriodDuration => {
+  if (Number(num) === PeriodDuration.PERIOD_15S) return PeriodDuration.PERIOD_15S;
   if (Number(num) === PeriodDuration.PERIOD_1M) return PeriodDuration.PERIOD_1M;
   if (Number(num) === PeriodDuration.PERIOD_5M) return PeriodDuration.PERIOD_5M;
   if (Number(num) === PeriodDuration.PERIOD_15M) return PeriodDuration.PERIOD_15M;
@@ -357,7 +359,7 @@ export const toPeriodDuration = (num: number | bigint): PeriodDuration => {
   throw new Error(`Invalid candlestick period duration: ${num}`);
 };
 
-export const PERIODS = [
+export const NON_ARENA_PERIODS = new Set([
   Period.Period1M,
   Period.Period5M,
   Period.Period15M,
@@ -365,4 +367,7 @@ export const PERIODS = [
   Period.Period1H,
   Period.Period4H,
   Period.Period1D,
-];
+]);
+
+export const isPeriod = (period: Period | ArenaPeriod): period is Period =>
+  (NON_ARENA_PERIODS as Set<string>).has(period);

--- a/src/typescript/sdk/src/const.ts
+++ b/src/typescript/sdk/src/const.ts
@@ -154,6 +154,8 @@ export const INITIAL_REAL_RESERVES: Types["Reserves"] = {
   quote: 0n,
 };
 
+export type AnyPeriod = Period | ArenaPeriod;
+
 export enum Period {
   Period1M = "period_1m",
   Period5M = "period_5m",

--- a/src/typescript/sdk/src/const.ts
+++ b/src/typescript/sdk/src/const.ts
@@ -369,5 +369,5 @@ export const NON_ARENA_PERIODS = new Set([
   Period.Period1D,
 ]);
 
-export const isPeriod = (period: Period | ArenaPeriod): period is Period =>
+export const isNonArenaPeriod = (period: Period | ArenaPeriod): period is Period =>
   (NON_ARENA_PERIODS as Set<string>).has(period);

--- a/src/typescript/sdk/src/emojicoin_dot_fun/arena-events.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/arena-events.ts
@@ -1,4 +1,5 @@
-import { type Types, type JsonTypes, type AnyNumberString } from "../types";
+import { type Types, type AnyNumberString } from "../types";
+import { type ArenaJsonTypes } from "../types/arena-json-types";
 import {
   toArenaEnterEvent,
   toArenaExitEvent,
@@ -48,7 +49,7 @@ export const createEmptyArenaEvents = (): ArenaEvents => ({
 
 type ArenaConverter = {
   [K in ArenaStructName]: (
-    data: JsonTypes[K],
+    data: ArenaJsonTypes[K],
     version: AnyNumberString,
     eventIndex: AnyNumberString
   ) => Types[K];

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -685,10 +685,15 @@ export const GuidGetters = {
     eventName: EVENT_NAMES.ArenaVaultBalanceUpdate,
     guid: `${EVENT_NAMES.ArenaVaultBalanceUpdate}::${sender}::${version}::${event_index}` as const,
   }),
-  arenaCandlestick: ({ melee_id, start_time, period }: DatabaseJsonType["arena_candlesticks"]) => ({
+  arenaCandlestick: ({
+    melee_id,
+    start_time,
+    period,
+    last_transaction_version: version,
+  }: DatabaseJsonType["arena_candlesticks"]) => ({
     // Not a real contract event, but used to classify the type of data.
     eventName: ARENA_CANDLESTICK_NAME,
-    guid: `${ARENA_CANDLESTICK_NAME}::${melee_id}::${period}::${start_time}`,
+    guid: `${ARENA_CANDLESTICK_NAME}::${melee_id}::${period}::${start_time}::${version}`,
   }),
 };
 
@@ -1034,7 +1039,9 @@ export type ArenaEventModels =
   | DatabaseModels[TableName.ArenaSwapEvents]
   | DatabaseModels[TableName.ArenaVaultBalanceUpdateEvents];
 
-export type ArenaEventModelWithMeleeID = Exclude<ArenaEventModels, ArenaVaultBalanceUpdateModel>;
+export type ArenaModelWithMeleeID =
+  | Exclude<ArenaEventModels, ArenaVaultBalanceUpdateModel>
+  | ArenaCandlestickModel;
 
 export const isSwapEventModel = (d: BrokerEventModels): d is SwapEventModel =>
   d.eventName === "Swap";

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -9,7 +9,7 @@ import {
   type ArenaSwapModel,
   type ArenaVaultBalanceUpdateModel,
   type ArenaEventModels,
-  type ArenaEventModelWithMeleeID,
+  type ArenaModelWithMeleeID,
   type ArenaCandlestickModel,
   // Note that if you import anything more than a type here, you'll get lots of import issues.
 } from "../indexer-v2/types";
@@ -369,12 +369,14 @@ export const isArenaVaultBalanceUpdateModel = (
   e: BrokerEventModels
 ): e is ArenaVaultBalanceUpdateModel => e.eventName === "ArenaVaultBalanceUpdate";
 
-export const isArenaEventModelWithMeleeID = (
-  e: BrokerEventModels
-): e is ArenaEventModelWithMeleeID =>
-  isArenaEnterModel(e) || isArenaExitModel(e) || isArenaMeleeModel(e) || isArenaSwapModel(e);
+export const isArenaModelWithMeleeID = (e: BrokerEventModels): e is ArenaModelWithMeleeID =>
+  isArenaEnterModel(e) ||
+  isArenaExitModel(e) ||
+  isArenaMeleeModel(e) ||
+  isArenaSwapModel(e) ||
+  isArenaCandlestickModel(e);
 
 export const isArenaEventModel = (e: BrokerEventModels): e is ArenaEventModels =>
-  isArenaEventModelWithMeleeID(e) || isArenaVaultBalanceUpdateModel(e);
+  isArenaModelWithMeleeID(e) || isArenaVaultBalanceUpdateModel(e);
 
 /* eslint-enable import/no-unused-modules */

--- a/src/typescript/sdk/src/utils/misc.ts
+++ b/src/typescript/sdk/src/utils/misc.ts
@@ -5,6 +5,7 @@ import {
   type Period,
   periodEnumToRawDuration,
   toPeriodDuration,
+  type AnyPeriod,
 } from "../const";
 import {
   type AnyNumberString,
@@ -97,7 +98,7 @@ export function getPeriodStartTime(
  */
 export function getPeriodStartTimeFromTime(
   microseconds: AnyNumberString,
-  period: PeriodDuration | Period
+  period: PeriodDuration | AnyPeriod
 ) {
   const periodDuration = typeof period !== "number" ? periodEnumToRawDuration(period) : period;
   const time = BigInt(microseconds);

--- a/src/typescript/sdk/tests/unit/period-boundaries.test.ts
+++ b/src/typescript/sdk/tests/unit/period-boundaries.test.ts
@@ -1,4 +1,4 @@
-import { PERIODS, PeriodDuration, getPeriodStartTime } from "../../src";
+import { NON_ARENA_PERIODS, PeriodDuration, getPeriodStartTime } from "../../src";
 import { calculatePeriodBoundariesCrossed } from "../utils";
 import { SAMPLE_STATE_EVENT, SAMPLE_SWAP_EVENT } from "../utils/sample-data";
 
@@ -210,7 +210,7 @@ describe("calculates period boundaries crossed", () => {
     const endDay = new Date(Number(endMicroseconds / 1000n)).getUTCDate();
     expect(startDay + 1).toEqual(endDay);
     const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
-    expect(numBoundaries).toEqual(PERIODS.length);
+    expect(numBoundaries).toEqual(NON_ARENA_PERIODS.size);
   });
 
   it("calculates that exactly only 1 period boundary is crossed over a 4m59s time period", () => {
@@ -229,7 +229,7 @@ describe("calculates period boundaries crossed", () => {
     expect(startDay + 3).toEqual(endDay);
     const numBoundaries = calculatePeriodBoundariesCrossed({ startMicroseconds, endMicroseconds });
     expect(numBoundaries).toEqual(7);
-    expect(numBoundaries).toEqual(PERIODS.length);
+    expect(numBoundaries).toEqual(NON_ARENA_PERIODS.size);
   });
 
   it("throws if the end time is later than the start time", () => {

--- a/src/typescript/sdk/tests/utils/calculate-periodic-boundaries-crossed.ts
+++ b/src/typescript/sdk/tests/utils/calculate-periodic-boundaries-crossed.ts
@@ -1,4 +1,4 @@
-import { type Period, periodEnumToRawDuration, PERIODS } from "../../src/const";
+import { type Period, periodEnumToRawDuration, NON_ARENA_PERIODS } from "../../src/const";
 import { type AnyNumberString } from "../../src/types";
 import { getPeriodBoundary } from "../../src/utils/misc";
 
@@ -34,7 +34,7 @@ export const calculatePeriodBoundariesCrossed = ({
   if (start > end) {
     throw new Error("End time cannot be later than start time.");
   }
-  const periodsCrossed = PERIODS.reduce(
+  const periodsCrossed = Array.from(NON_ARENA_PERIODS).reduce(
     (acc, period) => {
       // Get each period boundary of the start time; i.e., round it down to the nearest boundary.
       const lowerPeriodBoundary = getPeriodBoundary(start, period);


### PR DESCRIPTION
# Description

Lots of the changes for the new arena candlesticks are simply because the new ArenaPeriod type wasn't properly unioned with Period (on my advice).

I've fixed them to work everywhere applicable so that the utility functions for `Period` types work with both types, but also still requiring that they specifically should only be the base `Period` (non `Arena Period`) type where applicable.

# Testing

Lots of mostly type changes here, but I've been using it in #619 

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
