### PR TITLE
fix(ECO-3053): Fix emoji clipping on Safari on the trending markets card

### DIFF
--- a/src/typescript/frontend/src/components/pages/home/components/main-card/module.css
+++ b/src/typescript/frontend/src/components/pages/home/components/main-card/module.css
@@ -20,6 +20,7 @@
   left: 61%;
   transform: translateX(-50%);
   padding-top: 8px;
+  line-height: 1.5em;
 }
 
 .styled-single-emoji {


### PR DESCRIPTION
# Description

Emojis have a much taller line-height than their font size. Normally we set the line height to be manually a larger value than the font size, but these were added manually when we updated them to support multi-emoji symbols.

The fix is simple- just pass a line-height of `1.5em` to ensure the emojis don't get clipped.

# Testing

Video on slack, tested on safari alerady. Too big to link the video here though

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
