### PR TITLE
fix(ECO-3056): Fix/clean up the BackgroundEmojis component

### DIFF
--- a/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
+++ b/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
@@ -1,14 +1,21 @@
 "use client";
 
-import useNodeDimensions from "@hooks/use-node-dimensions";
 import { getRandomSymbolEmoji } from "@sdk/emoji_data";
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo } from "react";
+import { useWindowScroll, useWindowSize } from "react-use";
 import { Emoji } from "utils/emoji";
 
+const MemoizedRandomEmoji = React.memo(OneRandomEmoji);
+
 function OneRandomEmoji({ emoji }: { emoji: string }) {
-  const mt = useMemo(() => Math.random() * 100, []);
-  const ml = useMemo(() => Math.random() * 100, []);
-  const rotate = useMemo(() => Math.round(Math.random() * 50 - 25), []);
+  const { mt, ml, rotate } = useMemo(
+    () => ({
+      mt: Math.random() * 100,
+      ml: Math.random() * 100,
+      rotate: Math.round(Math.random() * 50 - 25),
+    }),
+    []
+  );
   return (
     <div
       className="flex flex-col w-min h-min text-8xl place-items-center select-none transition-all"
@@ -16,8 +23,8 @@ function OneRandomEmoji({ emoji }: { emoji: string }) {
         marginTop: `${mt}%`,
         marginLeft: `${ml}%`,
         transform: `rotate(${rotate}deg)`,
-        filter: "blur(15px)",
-        opacity: "0.6",
+        filter: "blur(17px)",
+        opacity: "0.4",
       }}
     >
       <Emoji emojis={emoji} />
@@ -25,48 +32,41 @@ function OneRandomEmoji({ emoji }: { emoji: string }) {
   );
 }
 
+const CHANCE = 1 / 8;
+const maybeRandomEmoji = () => (Math.random() < CHANCE ? getRandomSymbolEmoji().emoji : undefined);
+
+const PARALLAX_STRENGTH = 0.2;
+
 export function BackgroundEmojis() {
-  const ref = useRef<HTMLDivElement>(null);
-  const { height, width } = useNodeDimensions(ref);
-  const nRows = useMemo(() => Math.ceil(height / 150), [height]);
-  const nCols = useMemo(() => Math.ceil(width / 150), [width]);
-  const rows = useMemo(
-    () =>
-      Array.from({ length: nCols * nRows }).map(() =>
-        Math.random() < 1 / 8 ? getRandomSymbolEmoji() : undefined
-      ),
-    [nRows, nCols]
-  );
+  const { width, height } = useWindowSize();
+  const { y: scrollY } = useWindowScroll();
 
-  // The margin top value for the parallax effect- used on the overall background.
-  const [mt, setMt] = useState<number>(0);
-
-  useEffect(() => {
-    // The function that creates the parallax effect.
-    const fn = (e: Event) => {
-      setMt(((e.target as HTMLElement | null)?.scrollTop ?? 0) * -0.4);
+  const { rows, cols, emojis } = useMemo(() => {
+    // 1x the width, 3x the height, based on the element dimensions. (h-300% w-100%)
+    const rows = Math.ceil((height * 3) / 150);
+    const cols = Math.ceil(width / 150);
+    const emojis = Array.from({ length: rows * cols }).map(maybeRandomEmoji);
+    return {
+      rows,
+      cols,
+      emojis,
     };
-
-    document.addEventListener("scroll", fn, { passive: true, capture: true });
-
-    return () => document.removeEventListener("scroll", fn);
-  }, []);
+  }, [width, height]);
 
   return (
     <div className="z-[-1] absolute top-0 left-0 h-[100%] w-[100vw] overflow-hidden">
       <div
-        ref={ref}
-        className="absolute top-0 left-0 h-[300%] w-[100%] grid"
+        className="absolute top-0 left-0 h-[300%] w-[100%] grid will-change-transform"
         style={{
-          gridTemplateRows: `repeat(${nRows}, 1fr)`,
-          gridTemplateColumns: `repeat(${nCols}, 1fr)`,
+          gridTemplateRows: `repeat(${rows}, 1fr)`,
+          gridTemplateColumns: `repeat(${cols}, 1fr)`,
           perspective: "20px",
-          top: mt,
+          translate: `0 ${scrollY * -PARALLAX_STRENGTH}px`,
         }}
       >
-        {rows.map((row, i) =>
-          row ? (
-            <OneRandomEmoji key={`random-emoji-bg-${i}`} emoji={row.emoji} />
+        {emojis.map((emoji, i) =>
+          emoji ? (
+            <MemoizedRandomEmoji key={`random-emoji-bg-${i}`} emoji={emoji} />
           ) : (
             <div key={`random-emoji-bg-${i}`} />
           )

--- a/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
+++ b/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
@@ -8,24 +8,20 @@ import { Emoji } from "utils/emoji";
 const MemoizedRandomEmoji = React.memo(OneRandomEmoji);
 
 function OneRandomEmoji({ emoji }: { emoji: string }) {
-  const { mt, ml, rotate } = useMemo(
+  const style = useMemo(
     () => ({
-      mt: Math.random() * 100,
-      ml: Math.random() * 100,
-      rotate: Math.round(Math.random() * 50 - 25),
+      marginTop: Math.random() * 100,
+      marginLeft: Math.random() * 100,
+      transform: `rotate(${Math.round(Math.random() * 50 - 25)}deg)`,
+      filter: "blur(9px)",
+      opacity: 0.2,
     }),
     []
   );
   return (
     <div
       className="flex flex-col w-min h-min text-8xl place-items-center select-none transition-all"
-      style={{
-        marginTop: `${mt}%`,
-        marginLeft: `${ml}%`,
-        transform: `rotate(${rotate}deg)`,
-        filter: "blur(7px)",
-        opacity: 0.1,
-      }}
+      style={style}
     >
       <Emoji emojis={emoji} />
     </div>
@@ -34,7 +30,7 @@ function OneRandomEmoji({ emoji }: { emoji: string }) {
 
 const CHANCE = 1 / 8;
 const maybeRandomEmoji = () => (Math.random() < CHANCE ? getRandomSymbolEmoji().emoji : undefined);
-const PARALLAX_STRENGTH = 0.3;
+const PARALLAX_STRENGTH = 0.15;
 
 export function BackgroundEmojis() {
   const { width, height } = useWindowSize();

--- a/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
+++ b/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { getRandomSymbolEmoji } from "@sdk/emoji_data";
-import React, { useMemo } from "react";
-import { useWindowScroll, useWindowSize } from "react-use";
+import React, { useEffect, useMemo, useState } from "react";
+import { useWindowSize } from "react-use";
 import { Emoji } from "utils/emoji";
 
 const MemoizedRandomEmoji = React.memo(OneRandomEmoji);
@@ -23,8 +23,8 @@ function OneRandomEmoji({ emoji }: { emoji: string }) {
         marginTop: `${mt}%`,
         marginLeft: `${ml}%`,
         transform: `rotate(${rotate}deg)`,
-        filter: "blur(17px)",
-        opacity: "0.4",
+        filter: "blur(7px)",
+        opacity: 0.1,
       }}
     >
       <Emoji emojis={emoji} />
@@ -34,12 +34,21 @@ function OneRandomEmoji({ emoji }: { emoji: string }) {
 
 const CHANCE = 1 / 8;
 const maybeRandomEmoji = () => (Math.random() < CHANCE ? getRandomSymbolEmoji().emoji : undefined);
-
-const PARALLAX_STRENGTH = 0.2;
+const PARALLAX_STRENGTH = 0.3;
 
 export function BackgroundEmojis() {
   const { width, height } = useWindowSize();
-  const { y: scrollY } = useWindowScroll();
+  const [scrollY, setScrollY] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = (e: Event) => setScrollY((e.target as HTMLElement).scrollTop);
+
+    // The page doesn't actually scroll on the `window`, it scrolls inside the content-wrapper.
+    const doc = document.getElementById("content-wrapper");
+
+    doc?.addEventListener("scroll", handleScroll);
+    return () => doc?.removeEventListener("scroll", handleScroll);
+  }, []);
 
   const { rows, cols, emojis } = useMemo(() => {
     // 1x the width, 3x the height, based on the element dimensions. (h-300% w-100%)
@@ -60,7 +69,7 @@ export function BackgroundEmojis() {
         style={{
           gridTemplateRows: `repeat(${rows}, 1fr)`,
           gridTemplateColumns: `repeat(${cols}, 1fr)`,
-          perspective: "20px",
+          perspective: "1000px",
           translate: `0 ${scrollY * -PARALLAX_STRENGTH}px`,
         }}
       >

--- a/src/typescript/frontend/src/context/ContentWrapper.tsx
+++ b/src/typescript/frontend/src/context/ContentWrapper.tsx
@@ -1,6 +1,6 @@
 export const ContentWrapper = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="flex flex-col max-w-[100dvw] pl-0 pr-0 h-[100dvh] overflow-x-hidden">
+    <div id="content-wrapper" className="flex flex-col max-w-[100dvw] pl-0 pr-0 h-[100dvh] overflow-x-hidden">
       {/* eslint-disable-next-line react/no-unknown-property */}
       <style jsx>{`
         div::-webkit-scrollbar {

--- a/src/typescript/frontend/src/context/ContentWrapper.tsx
+++ b/src/typescript/frontend/src/context/ContentWrapper.tsx
@@ -1,6 +1,9 @@
 export const ContentWrapper = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div id="content-wrapper" className="flex flex-col max-w-[100dvw] pl-0 pr-0 h-[100dvh] overflow-x-hidden">
+    <div
+      id="content-wrapper"
+      className="flex flex-col max-w-[100dvw] pl-0 pr-0 h-[100dvh] overflow-x-hidden"
+    >
       {/* eslint-disable-next-line react/no-unknown-property */}
       <style jsx>{`
         div::-webkit-scrollbar {


### PR DESCRIPTION
# Description

- [x] Deleted the use-node-dimensions.ts [this package](https://www.npmjs.com/package/@react-hook/size)
- [x] Decreased parallax strength by half
- [x] Made the emojis more muted, since they interfere with lots of the elements on the page
- [x] Removed the usage of the `use-node-dimensions` hook in favor of a simple `useWindowSize`
- [x] Should fix the issue where it scrolled when *anything* on the page scrolled
- [x] Generally just cleaned up things up a bit

# Testing

Checking it on preview

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
