### PR TITLE
refactor(ECO-3058): Use Big for arena candlesticks price

### DIFF
--- a/src/typescript/frontend/src/lib/store/arena/utils.ts
+++ b/src/typescript/frontend/src/lib/store/arena/utils.ts
@@ -100,8 +100,8 @@ export const handleLatestBarForArenaCandlestick = (
     current.latestBar = {
       time: model.startTime.getTime(),
       open: current.latestBar?.open ?? model.openPrice,
-      high: Math.max(current.latestBar?.high, model.highPrice),
-      low: Math.min(current.latestBar?.low, model.lowPrice),
+      high: current.latestBar?.high.gt(model.highPrice) ? current.latestBar?.high : model.highPrice,
+      low: current.latestBar?.low.lt(model.lowPrice) ? current.latestBar?.low : model.lowPrice,
       close: model.closePrice,
       volume: (current.latestBar.volume += toNominal(model.volume)),
       period,

--- a/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
+++ b/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
@@ -13,10 +13,10 @@ import { toNominal } from "@sdk/utils";
 
 export type Bar = {
   time: number;
-  open: number;
-  high: number;
-  low: number;
-  close: number;
+  open: Big;
+  high: Big;
+  low: Big;
+  close: Big;
   volume: number;
 };
 
@@ -32,10 +32,10 @@ export const periodicStateTrackerToLatestBar = (
   const { startTime } = tracker;
   return {
     time: Big(startTime.toString()).div(1000).toNumber(),
-    open: q64ToBig(tracker.openPriceQ64).toNumber(),
-    high: q64ToBig(tracker.highPriceQ64).toNumber(),
-    low: q64ToBig(tracker.lowPriceQ64).toNumber(),
-    close: q64ToBig(tracker.closePriceQ64).toNumber(),
+    open: q64ToBig(tracker.openPriceQ64),
+    high: q64ToBig(tracker.highPriceQ64),
+    low: q64ToBig(tracker.lowPriceQ64),
+    close: q64ToBig(tracker.closePriceQ64),
     volume: toNominal(tracker.volumeQuote),
     period: rawPeriodToEnum(tracker.period),
     nonce,
@@ -63,10 +63,10 @@ export function toBar(event: PeriodicStateEventModel | ArenaCandlestickModel): B
   return isPeriodicStateEventModel(event)
     ? {
         time: Number(event.periodicMetadata.startTime / 1000n),
-        open: q64ToBig(event.periodicState.openPriceQ64).toNumber(),
-        high: q64ToBig(event.periodicState.highPriceQ64).toNumber(),
-        low: q64ToBig(event.periodicState.lowPriceQ64).toNumber(),
-        close: q64ToBig(event.periodicState.closePriceQ64).toNumber(),
+        open: q64ToBig(event.periodicState.openPriceQ64),
+        high: q64ToBig(event.periodicState.highPriceQ64),
+        low: q64ToBig(event.periodicState.lowPriceQ64),
+        close: q64ToBig(event.periodicState.closePriceQ64),
         volume: toNominal(event.periodicState.volumeQuote),
       }
     : {
@@ -82,10 +82,10 @@ export function toBar(event: PeriodicStateEventModel | ArenaCandlestickModel): B
 export const createBarFromSwap = (
   event: SwapEventModel,
   period: Period,
-  previousClose?: number
+  previousClose?: Big
 ): LatestBar => {
   const { swap, market } = event;
-  const price = q64ToBig(swap.avgExecutionPriceQ64).toNumber();
+  const price = q64ToBig(swap.avgExecutionPriceQ64);
   const periodStartTime = getPeriodStartTimeFromTime(market.time, period);
   return {
     time: Number(periodStartTime / 1000n),
@@ -103,11 +103,11 @@ export const createBarFromSwap = (
 
 export const createBarFromPeriodicState = (
   event: PeriodicStateEventModel,
-  previousClose?: number
+  previousClose?: Big
 ): LatestBar => {
   const { market, periodicMetadata, periodicState } = event;
   const { period } = periodicMetadata;
-  const price = q64ToBig(periodicState.closePriceQ64).toNumber();
+  const price = q64ToBig(periodicState.closePriceQ64);
   return {
     time: periodEnumToRawDuration(period) / 1000,
     // Only use previousClose if it's a truthy value, otherwise, new bars that follow bars with no

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -54,11 +54,11 @@ export const handleLatestBarForSwapEvent = (
     } else if (!data.latestBar) {
       throw new Error("This should never occur. It is a type guard/hint.");
     } else if (event.market.marketNonce >= data.latestBar.nonce) {
-      const price = q64ToBig(event.swap.avgExecutionPriceQ64).toNumber();
+      const price = q64ToBig(event.swap.avgExecutionPriceQ64);
       data.latestBar.time = Number(getPeriodStartTimeFromTime(event.market.time, period) / 1000n);
       data.latestBar.close = price;
-      data.latestBar.high = Math.max(data.latestBar.high, price);
-      data.latestBar.low = Math.min(data.latestBar.low, price);
+      data.latestBar.high = data.latestBar.high.gt(price) ? data.latestBar.high : price;
+      data.latestBar.low = data.latestBar.low.lt(price) ? data.latestBar.low : price;
       data.latestBar.nonce = event.market.marketNonce;
       data.latestBar.volume += toNominal(event.swap.quoteVolume);
       // Note this results in `time order violation` errors if we set `has_empty_bars`
@@ -96,11 +96,11 @@ export const handleLatestBarForPeriodicStateEvent = (
       // hence why we use `>=` instead of just `>`.
       if (swapInTimeRange && swapEvent.market.marketNonce >= data.latestBar.nonce) {
         if (!data.latestBar) throw new Error("This should never occur. It is a type guard/hint.");
-        const price = q64ToBig(innerSwap.avgExecutionPriceQ64).toNumber();
+        const price = q64ToBig(innerSwap.avgExecutionPriceQ64);
         data.latestBar.time = Number(getPeriodStartTimeFromTime(innerMarket.time, period) / 1000n);
         data.latestBar.close = price;
-        data.latestBar.high = Math.max(data.latestBar.high, price);
-        data.latestBar.low = Math.min(data.latestBar.low, price);
+        data.latestBar.high = data.latestBar.high.gt(price) ? data.latestBar.high : price;
+        data.latestBar.low = data.latestBar.low.lt(price) ? data.latestBar.low : price;
         data.latestBar.nonce = innerMarket.marketNonce;
         data.latestBar.volume += toNominal(innerSwap.quoteVolume);
       }

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -254,10 +254,10 @@ const toArenaCandlestickFromDatabase = (
   volume: BigInt(data.volume),
   period: toArenaPeriod(data.period),
   startTime: safeParseBigIntOrPostgresTimestamp(data.start_time),
-  openPrice: Number(data.open_price),
-  closePrice: Number(data.close_price),
-  highPrice: Number(data.high_price),
-  lowPrice: Number(data.low_price),
+  openPrice: Big(data.open_price),
+  closePrice: Big(data.close_price),
+  highPrice: Big(data.high_price),
+  lowPrice: Big(data.low_price),
   nSwaps: BigInt(data.n_swaps),
 });
 

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -173,10 +173,10 @@ export type ArenaTypes = {
     version: bigint;
     period: ArenaPeriod;
     startTime: Date;
-    openPrice: number;
-    closePrice: number;
-    highPrice: number;
-    lowPrice: number;
+    openPrice: Big;
+    closePrice: Big;
+    highPrice: Big;
+    lowPrice: Big;
     volume: bigint;
     nSwaps: bigint;
   };


### PR DESCRIPTION
# Description

In order to have more precise prices, use Big instead of number to
handle candlestick prices. This can be especially important with markets
that have a price difference of multiple orders of magnitude.
Furthermore this makes it consistent with normal candlesticks.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
