### PR TITLE
feat(ECO-3027): Add candlestick type support to broker

### DIFF
--- a/src/rust/broker/src/types.rs
+++ b/src/rust/broker/src/types.rs
@@ -22,12 +22,21 @@ pub enum ArenaPeriodRequest {
     Unsubscribe { period: Period },
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum MarketPeriodRequest {
+    Subscribe { market_id: u64, period: Period },
+    Unsubscribe { market_id: u64, period: Period },
+}
+
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 pub struct SubscriptionMessage {
     #[serde(default)]
     pub markets: Vec<u64>,
     #[serde(default)]
     pub event_types: Vec<EmojicoinDbEventType>,
+    #[serde(default)]
+    pub market_period: Option<MarketPeriodRequest>,
     #[serde(default)]
     pub arena: bool,
     #[serde(default)]
@@ -38,109 +47,163 @@ pub struct SubscriptionMessage {
 pub struct ClientSubscription {
     pub markets: HashSet<u64>,
     pub event_types: HashSet<EmojicoinDbEventType>,
+    pub market_candlestick_periods: HashSet<(u64, Period)>,
     pub arena: bool,
     pub arena_candlestick_periods: HashSet<Period>,
 }
 
-#[test]
-fn deserialize_subscription_message() {
-    assert_eq!(
-        serde_json::from_str::<SubscriptionMessage>(
-            r#"{ "markets": [1, 2, 3], "event_types": ["Chat"], "arena": true }"#,
-        )
-        .unwrap(),
-        SubscriptionMessage {
-            markets: vec![1, 2, 3],
-            event_types: vec![EmojicoinDbEventType::Chat],
-            arena: true,
-            arena_period: None,
-        },
-    );
+#[cfg(test)]
+pub mod tests {
+    use super::*;
 
-    assert_eq!(
-        serde_json::from_str::<SubscriptionMessage>(
-            r#"{
+    #[test]
+    fn deserialize_subscription_message() {
+        assert_eq!(
+            serde_json::from_str::<SubscriptionMessage>(
+                r#"{ "markets": [1, 2, 3], "event_types": ["Chat"], "arena": true }"#,
+            )
+            .unwrap(),
+            SubscriptionMessage {
+                markets: vec![1, 2, 3],
+                event_types: vec![EmojicoinDbEventType::Chat],
+                market_period: None,
+                arena: true,
+                arena_period: None,
+            },
+        );
+
+        assert_eq!(
+            serde_json::from_str::<SubscriptionMessage>(
+                r#"{
               "markets": [4, 2],
               "event_types": ["MarketRegistration"],
               "arena": false,
               "arena_period": { "action": "subscribe", "period": "FifteenSeconds" }
             }"#,
-        )
-        .unwrap(),
-        SubscriptionMessage {
-            markets: vec![4, 2],
-            event_types: vec![EmojicoinDbEventType::MarketRegistration],
-            arena: false,
-            arena_period: Some(ArenaPeriodRequest::Subscribe {
-                period: Period::FifteenSeconds
-            }),
-        },
-    );
+            )
+            .unwrap(),
+            SubscriptionMessage {
+                markets: vec![4, 2],
+                event_types: vec![EmojicoinDbEventType::MarketRegistration],
+                market_period: None,
+                arena: false,
+                arena_period: Some(ArenaPeriodRequest::Subscribe {
+                    period: Period::FifteenSeconds
+                }),
+            },
+        );
 
-    assert_eq!(
-        serde_json::from_str::<SubscriptionMessage>(
-            r#"{ "markets": [7, 11], "event_types": ["Swap"], "arena": true }"#,
-        )
-        .unwrap(),
-        SubscriptionMessage {
-            markets: vec![7, 11],
-            event_types: vec![EmojicoinDbEventType::Swap],
-            arena: true,
-            arena_period: None,
-        },
-    );
-}
+        assert_eq!(
+            serde_json::from_str::<SubscriptionMessage>(
+                r#"{ "markets": [7, 11], "event_types": ["Swap"], "arena": true }"#,
+            )
+            .unwrap(),
+            SubscriptionMessage {
+                markets: vec![7, 11],
+                event_types: vec![EmojicoinDbEventType::Swap],
+                market_period: None,
+                arena: true,
+                arena_period: None,
+            },
+        );
+    }
 
-#[test]
-fn deserialize_subscription_happy_path() {
-    let json = r#"{
+    #[test]
+    fn deserialize_subscription_happy_path() {
+        let json = r#"{
         "markets": [1, 2, 3],
         "event_types": [],
         "arena": true
     }"#;
-    let sub: SubscriptionMessage = serde_json::from_str(json).unwrap();
-    assert_eq!(sub.arena_period, None);
+        let sub: SubscriptionMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(sub.arena_period, None);
+        assert_eq!(sub.market_period, None);
 
-    let json2 = r#"{
+        let json2 = r#"{
         "markets": [1, 2, 3],
         "event_types": [],
         "arena_period": { "action": "subscribe", "period": "FifteenSeconds" }
     }"#;
-    let sub2: SubscriptionMessage = serde_json::from_str(json2).unwrap();
-    assert_eq!(
-        sub2.arena_period,
-        Some(ArenaPeriodRequest::Subscribe {
-            period: Period::FifteenSeconds
-        }),
-    );
+        let sub2: SubscriptionMessage = serde_json::from_str(json2).unwrap();
+        assert_eq!(
+            sub2.arena_period,
+            Some(ArenaPeriodRequest::Subscribe {
+                period: Period::FifteenSeconds
+            }),
+        );
+        assert_eq!(sub.market_period, None);
 
-    let json3 = r#"{
+        let json3 = r#"{
         "markets": [1, 2, 3],
         "event_types": [],
         "arena_period": { "action": "unsubscribe", "period": "OneHour" },
         "arena": false
     }"#;
-    let sub3: SubscriptionMessage = serde_json::from_str(json3).unwrap();
-    assert_eq!(
-        sub3.arena_period,
-        Some(ArenaPeriodRequest::Unsubscribe {
-            period: (Period::OneHour)
-        })
-    );
-}
+        let sub3: SubscriptionMessage = serde_json::from_str(json3).unwrap();
+        assert_eq!(
+            sub3.arena_period,
+            Some(ArenaPeriodRequest::Unsubscribe {
+                period: (Period::OneHour)
+            })
+        );
+        assert_eq!(sub.market_period, None);
+    }
 
-#[test]
-fn subscription_idempotent_serialization_happy_path() {
-    let sub = SubscriptionMessage {
-        markets: vec![1, 2, 3],
-        event_types: vec![EmojicoinDbEventType::Chat],
-        arena: true,
-        arena_period: Some(ArenaPeriodRequest::Unsubscribe {
-            period: Period::FifteenMinutes,
-        }),
-    };
+    #[test]
+    fn deserialize_subscription_with_market_period() {
+        let json = r#"{
+        "markets": [1, 2, 3],
+        "event_types": [],
+        "arena": true,
+        "market_period": {
+          "action": "subscribe",
+          "market_id": 12,
+          "period": "OneHour"
+        }
+    }"#;
+        let sub: SubscriptionMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(sub.arena_period, None);
+        assert!(sub.market_period.is_some());
+        assert_eq!(
+            sub.market_period.unwrap(),
+            MarketPeriodRequest::Subscribe {
+                market_id: 12,
+                period: Period::OneHour
+            }
+        );
+    }
 
-    let json = serde_json::to_string(&sub).unwrap();
-    let sub_parsed: SubscriptionMessage = serde_json::from_str(json.as_str()).unwrap();
-    assert_eq!(sub, sub_parsed);
+    #[test]
+    fn deserialize_big_json_number() {
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        struct Data {
+            market_id: u64,
+        }
+
+        let json = r#"{ "market_id": 18446744073709551615 }"#;
+        let data: Data = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            data,
+            Data {
+                market_id: u64::MAX,
+            }
+        );
+    }
+
+    #[test]
+    fn subscription_idempotent_serialization_happy_path() {
+        let sub = SubscriptionMessage {
+            markets: vec![1, 2, 3],
+            event_types: vec![EmojicoinDbEventType::Chat],
+            arena: true,
+            arena_period: Some(ArenaPeriodRequest::Unsubscribe {
+                period: Period::FifteenMinutes,
+            }),
+            market_period: None,
+        };
+
+        let json = serde_json::to_string(&sub).unwrap();
+        let sub_parsed: SubscriptionMessage = serde_json::from_str(json.as_str()).unwrap();
+        assert_eq!(sub, sub_parsed);
+    }
 }

--- a/src/rust/broker/src/types.rs
+++ b/src/rust/broker/src/types.rs
@@ -174,23 +174,6 @@ pub mod tests {
     }
 
     #[test]
-    fn deserialize_big_json_number() {
-        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-        struct Data {
-            market_id: u64,
-        }
-
-        let json = r#"{ "market_id": 18446744073709551615 }"#;
-        let data: Data = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            data,
-            Data {
-                market_id: u64::MAX,
-            }
-        );
-    }
-
-    #[test]
     fn subscription_idempotent_serialization_happy_path() {
         let sub = SubscriptionMessage {
             markets: vec![1, 2, 3],
@@ -199,7 +182,10 @@ pub mod tests {
             arena_period: Some(ArenaPeriodRequest::Unsubscribe {
                 period: Period::FifteenMinutes,
             }),
-            market_period: None,
+            market_period: Some(MarketPeriodRequest::Unsubscribe {
+                market_id: 1,
+                period: Period::FourHours,
+            }),
         };
 
         let json = serde_json::to_string(&sub).unwrap();

--- a/src/rust/broker/src/util.rs
+++ b/src/rust/broker/src/util.rs
@@ -6,7 +6,9 @@ use processor::emojicoin_dot_fun::{EmojicoinDbEvent, EmojicoinDbEventType};
 use serde_json::Error;
 use tokio::signal;
 
-use crate::types::{ArenaPeriodRequest, ClientSubscription, SubscriptionMessage};
+use crate::types::{
+    ArenaPeriodRequest, ClientSubscription, MarketPeriodRequest, SubscriptionMessage,
+};
 
 /// Get the market ID of a EmojicoinDbEvent of a given EventType
 #[allow(dead_code)]
@@ -18,6 +20,7 @@ pub fn get_market_id(event: &EmojicoinDbEvent) -> Result<u64, String> {
         EmojicoinDbEvent::PeriodicState(ps) => &ps.market_id,
         EmojicoinDbEvent::MarketLatestState(mls) => &mls.market_id,
         EmojicoinDbEvent::Liquidity(l) => &l.market_id,
+        EmojicoinDbEvent::Candlestick(candle) => &candle.market_id,
         _ => {
             return Err(
                 "Trying to get market ID from event which does not have a market ID".to_string(),
@@ -51,6 +54,19 @@ pub fn is_match(subscription: &ClientSubscription, event: &EmojicoinDbEvent) -> 
         }
         EmojicoinDbEventType::GlobalState => {
             subscription.event_types.is_empty() || subscription.event_types.contains(&event_type)
+        }
+        EmojicoinDbEventType::Candlestick => {
+            if let EmojicoinDbEvent::Candlestick(event) = &event {
+                subscription.market_candlestick_periods.contains(&(
+                    event
+                        .market_id
+                        .to_u64()
+                        .expect("market_id should be a u64."),
+                    event.period,
+                ))
+            } else {
+                unreachable!("This would only ever be reachable if enums were mapped incorrectly.");
+            }
         }
         _ => {
             let markets_is_empty = subscription.markets.is_empty();
@@ -104,8 +120,21 @@ impl From<SubscriptionMessage> for ClientSubscription {
             arena: val.arena,
             markets: HashSet::from_iter(val.markets),
             event_types: HashSet::from_iter(val.event_types),
+            market_candlestick_periods: match val.market_period {
+                Some(mp_request) => match mp_request {
+                    MarketPeriodRequest::Subscribe { market_id, period } => {
+                        HashSet::from([(market_id, period)])
+                    }
+                    // Ignore whatever period they sent in; there's nothing to unsubscribe from.
+                    MarketPeriodRequest::Unsubscribe {
+                        market_id: _,
+                        period: _,
+                    } => HashSet::new(),
+                },
+                None => HashSet::new(),
+            },
             arena_candlestick_periods: match val.arena_period {
-                Some(period) => match period {
+                Some(ap_request) => match ap_request {
                     ArenaPeriodRequest::Subscribe { period } => HashSet::from([period]),
                     // Ignore whatever period they sent in; there's nothing to unsubscribe from.
                     ArenaPeriodRequest::Unsubscribe { period: _ } => HashSet::new(),
@@ -122,19 +151,37 @@ pub fn update_subscription(
     current_sub_opt: &mut Option<ClientSubscription>,
     msg: &str,
 ) -> Result<(), Error> {
+    dbg!(msg);
     let msg = serde_json::from_str::<SubscriptionMessage>(msg)?;
+    dbg!(&msg);
     match current_sub_opt {
         // Existing subscription; insert/remove from the existing arena candlestick periods.
         Some(current_sub) => {
-            if let Some(period) = msg.arena_period {
-                match period {
+            if let Some(ap_request) = msg.arena_period {
+                match ap_request {
                     ArenaPeriodRequest::Subscribe { period } => {
-                        current_sub.arena_candlestick_periods.insert(period)
+                        current_sub.arena_candlestick_periods.insert(period);
                     }
                     ArenaPeriodRequest::Unsubscribe { period } => {
-                        current_sub.arena_candlestick_periods.remove(&period)
+                        current_sub.arena_candlestick_periods.remove(&period);
                     }
                 };
+            }
+            if let Some(mp_request) = msg.market_period {
+                dbg!("got here?");
+                match mp_request {
+                    MarketPeriodRequest::Subscribe { market_id, period } => {
+                        dbg!((market_id, period));
+                        current_sub
+                            .market_candlestick_periods
+                            .insert((market_id, period));
+                    }
+                    MarketPeriodRequest::Unsubscribe { market_id, period } => {
+                        current_sub
+                            .market_candlestick_periods
+                            .remove(&(market_id, period));
+                    }
+                }
             }
             current_sub.arena = msg.arena;
             current_sub.markets = HashSet::from_iter(msg.markets);
@@ -150,17 +197,19 @@ pub fn update_subscription(
 }
 
 #[cfg(test)]
-use processor::emojicoin_dot_fun::Period;
-
-#[cfg(test)]
 mod tests {
     use super::*;
+    use processor::emojicoin_dot_fun::Period;
 
     #[test]
     fn test_ignore_unsubscribe_on_non_existent_sub() {
         let msg = SubscriptionMessage {
             markets: vec![1, 2, 3],
             event_types: vec![EmojicoinDbEventType::Chat],
+            market_period: Some(MarketPeriodRequest::Subscribe {
+                market_id: 12,
+                period: Period::FifteenMinutes,
+            }),
             arena: true,
             arena_period: Some(ArenaPeriodRequest::Unsubscribe {
                 period: Period::FifteenMinutes,
@@ -171,6 +220,7 @@ mod tests {
             ClientSubscription {
                 markets: HashSet::from([1, 2, 3]),
                 event_types: HashSet::from([EmojicoinDbEventType::Chat]),
+                market_candlestick_periods: HashSet::from([(12, Period::FifteenMinutes)]),
                 arena: true,
                 arena_candlestick_periods: HashSet::new(),
             }
@@ -179,9 +229,11 @@ mod tests {
 
     #[test]
     fn test_new_and_update_happy_path() {
+        let market_periods_original_sub = HashSet::from([(3, Period::FiveMinutes)]);
         let subscription = &mut Some(ClientSubscription {
             markets: HashSet::from([1, 2, 3]),
             event_types: HashSet::from([EmojicoinDbEventType::Chat]),
+            market_candlestick_periods: market_periods_original_sub.clone(),
             arena: true,
             arena_candlestick_periods: HashSet::from([Period::FiveMinutes]),
         });
@@ -193,10 +245,11 @@ mod tests {
         .is_ok());
 
         assert_eq!(
-            subscription.take().unwrap(),
+            *subscription.as_ref().unwrap(),
             ClientSubscription {
                 markets: HashSet::new(),
                 event_types: HashSet::new(),
+                market_candlestick_periods: market_periods_original_sub.clone(),
                 arena: false,
                 arena_candlestick_periods: HashSet::new(),
             }
@@ -220,12 +273,149 @@ mod tests {
         .is_ok());
 
         assert_eq!(
-            subscription.take().unwrap(),
+            *subscription.as_ref().unwrap(),
             ClientSubscription {
                 markets: HashSet::from([4, 2, 13, 14]),
                 event_types: HashSet::from([EmojicoinDbEventType::MarketRegistration]),
+                market_candlestick_periods: market_periods_original_sub,
                 arena: false,
                 arena_candlestick_periods: HashSet::from([Period::FifteenMinutes, Period::OneHour]),
+            }
+        );
+    }
+
+    #[test]
+    fn test_one_market_subscription() {
+        let subscription = &mut Some(ClientSubscription {
+            markets: HashSet::new(),
+            event_types: HashSet::new(),
+            market_candlestick_periods: HashSet::new(),
+            arena: false,
+            arena_candlestick_periods: HashSet::new(),
+        });
+        assert!(update_subscription(
+            subscription,
+            r#"{ "market_period": { "action": "subscribe", "market_id": 33, "period": "OneHour" } }"#,
+        ).is_ok());
+        assert_eq!(
+            *subscription.as_mut().unwrap(),
+            ClientSubscription {
+                markets: HashSet::new(),
+                event_types: HashSet::new(),
+                market_candlestick_periods: HashSet::from([(33, Period::OneHour)]),
+                arena: false,
+                arena_candlestick_periods: HashSet::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_serialize() {
+        let subscribe = MarketPeriodRequest::Subscribe {
+            market_id: 10,
+            period: Period::FifteenSeconds,
+        };
+        dbg!(serde_json::to_string_pretty(&subscribe).unwrap());
+        dbg!(serde_json::from_str::<MarketPeriodRequest>(
+            r#"{ "action": "subscribe", "market_id": 77, "period": "OneMinute" }"#,
+        )
+        .unwrap());
+        dbg!(serde_json::from_str::<SubscriptionMessage>(
+                r#"{ "market_period": { "action": "subscribe", "market_id": 77, "period": "OneMinute" } }"#,
+            ).unwrap());
+    }
+
+    #[test]
+    fn test_market_subscriptions_happy_path() {
+        let subscription = &mut Some(ClientSubscription {
+            markets: HashSet::from([1, 2, 3]),
+            event_types: HashSet::from([EmojicoinDbEventType::Chat]),
+            market_candlestick_periods: HashSet::from([(1234, Period::FiveMinutes)]),
+            arena: true,
+            arena_candlestick_periods: HashSet::from([Period::FiveMinutes]),
+        });
+
+        vec![
+            // -  Start            =>  (1234, 5m)
+            // a. Add (77, 1m)     =>  (1234, 5m), (77, 1m)
+            // b. Add (123, 1m)    =>  (1234, 5m), (77, 1m), (123, 1m)
+            // c. Remove (1, 1m)   =>  (1234, 5m), (77, 1m), (123, 1m)
+            // d. Add (1, 1m)      =>  (1234, 5m), (77, 1m), (123, 1m), (1, 1m)
+            // e. Add (2, 4h)      =>  (1234, 5m), (77, 1m), (123, 1m), (1, 1m), (2, 4h)
+            // f. Remove (1, 1m)   =>  (1234, 5m), (77, 1m), (123, 1m), (2, 4h)
+            // g. Add (77, 5m)     =>  (1234, 5m), (77, 1m), (123, 1m), (2, 4h), (77, 5m)
+            // h. Add (77, 15m)    =>  (1234, 5m), (77, 1m), (123, 1m), (2, 4h), (77, 5m), (77, 15m)
+            // i. Remove (123, 1m) =>  (1234, 5m), (77, 1m), (2, 4h), (77, 5m), (77, 15m)
+            // j. Remove (77, 5m)  =>  (1234, 5m), (77, 1m), (2, 4h), (77, 15m)
+            // k. Add (1923, 15s)  =>  (1234, 5m), (77, 1m), (2, 4h), (77, 15m), (1923, 15s)
+            // -------------------------------------------------------------------------------------
+            // a. Add (77, 1m)
+            r#"{ "market_period": { "action": "subscribe", "market_id": 77, "period": "OneMinute" } }"#,
+            // b. Add (123, 1m)
+            r#"{ "market_period": { "action": "subscribe", "market_id": 123, "period": "OneMinute" } }"#,
+            // c. Remove (1, 1m)
+            r#"{ "market_period": { "action": "unsubscribe", "market_id": 1, "period": "OneMinute" } }"#,
+            // d. Add (1, 1m)
+            r#"{ "market_period": { "action": "subscribe", "market_id": 1, "period": "OneMinute" } }"#,
+            // e. Add (2, 4h)
+            r#"{ "market_period": { "action": "subscribe", "market_id": 2, "period": "FourHours" } }"#,
+            // f. Remove (1, 1m)
+            r#"{ "market_period": { "action": "unsubscribe", "market_id": 1, "period": "OneMinute" } }"#,
+            // g. Add (77, 5m)
+            r#"{ "market_period": { "action": "subscribe", "market_id": 77, "period": "FiveMinutes" } }"#,
+            // h. Add (77, 15m)
+            r#"{ "market_period": { "action": "subscribe", "market_id": 77, "period": "FifteenMinutes" } }"#,
+            // i. Remove (123, 1m)
+            r#"{ "market_period": { "action": "unsubscribe", "market_id": 123, "period": "OneMinute" } }"#,
+            // j. Remove (77, 5m)
+            r#"{ "market_period": { "action": "unsubscribe", "market_id": 77, "period": "FiveMinutes" } }"#,
+            // k. Add (1923, 15s)
+            r#"{ "market_period": { "action": "subscribe", "market_id": 1923, "period": "FifteenSeconds" } }"#,
+        ]
+        .into_iter()
+        .for_each(|msg| {
+            // Check each sub in the interim.
+            let json_res = serde_json::from_str::<SubscriptionMessage>(msg);
+            assert!(json_res.is_ok());
+            let json = json_res.unwrap();
+            assert!(json.market_period.is_some());
+            let market_period_request = json.market_period.unwrap();
+            assert!(update_subscription(subscription, msg).is_ok());
+            assert!(subscription.as_ref().is_some());
+            assert!(subscription.as_ref().is_some_and(|inner_sub| {
+                match market_period_request {
+                    MarketPeriodRequest::Subscribe { market_id, period } => inner_sub
+                        .market_candlestick_periods
+                        .contains(&(market_id, period)),
+                    MarketPeriodRequest::Unsubscribe { market_id, period } => !inner_sub
+                        .market_candlestick_periods
+                        .contains(&(market_id, period)),
+                }
+            }));
+        });
+
+        // Check the final result.
+        assert!(subscription.is_some());
+        assert_eq!(
+            *subscription.as_ref().unwrap(),
+            // Keep in mind it *always* overwrites `markets`, `event_types`, and `arena` with the
+            // last message value, which uses defaults if nothing is there.
+            ClientSubscription {
+                markets: HashSet::new(),
+                event_types: HashSet::new(),
+                market_candlestick_periods: HashSet::from([
+                    (1234, Period::FiveMinutes),
+                    (77, Period::OneMinute),
+                    (2, Period::FourHours),
+                    (77, Period::FifteenMinutes),
+                    (1923, Period::FifteenSeconds)
+                ]),
+                arena: false,
+                arena_candlestick_periods: subscription
+                    .as_ref()
+                    .unwrap()
+                    .arena_candlestick_periods
+                    .clone(),
             }
         );
     }


### PR DESCRIPTION
# Description

This PR may get split up later but for now it is a way to track the following things necessary to use the new candlesticks:

- [x] Update the broker to allow granular subscriptions to regular candlesticks
  - [x] By market ID
  - [x] By period
  
- [ ] @alnoki  once this merges to main, tag the resultant commit with broker-v7.0.0

# Testing

Lots of manual testing. Rust unit tests cover lots of the logic as well

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
