### PR TITLE
feat(ECO-3085): Add hotkeys

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -99,15 +99,7 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
     [explorerLink]
   );
 
-  useHotkey(
-    "x",
-    "goto",
-    () => {
-      router.push(explorerLink);
-    },
-    {},
-    [explorerLink]
-  );
+  useHotkey("x", "goto", () => router.push(explorerLink), {}, [explorerLink]);
 
   return (
     <Box>

--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useMatchBreakpoints } from "hooks";
 import { Box } from "@containers";
 import DesktopGrid from "./components/desktop-grid";
@@ -18,6 +18,11 @@ import Link from "next/link";
 import { ROUTES } from "router/routes";
 import { darkColors } from "theme";
 import FEATURE_FLAGS from "lib/feature-flags";
+import { toCodePoint } from "@econia-labs/emojicoin-sdk";
+import { toast } from "react-toastify";
+import { toExplorerLink } from "lib/utils/explorer-link";
+import { useRouter } from "next/navigation";
+import { useHotkey } from "context/Hotkeys";
 
 const EVENT_TYPES: SubscribableBrokerEvents[] = ["Chat", "PeriodicState", "Swap"];
 
@@ -38,6 +43,71 @@ const ClientEmojicoinPage = (props: EmojicoinProps) => {
   }, [props.data]);
 
   useReliableSubscribe({ eventTypes: EVENT_TYPES });
+
+  const router = useRouter();
+
+  const explorerLink = useMemo(
+    () =>
+      toExplorerLink({
+        linkType: "coin",
+        value: `${props.data.marketAddress}::coin_factory::Emojicoin`,
+      }),
+    [props.data.marketAddress]
+  );
+
+  useHotkey(
+    "e",
+    "cmd",
+    () => {
+      navigator.clipboard.writeText(props.data.symbolEmojis.join(""));
+      toast("Copied symbol emojis to clipboard.");
+    },
+    {},
+    [props.data.symbolEmojis]
+  );
+
+  useHotkey(
+    "c",
+    "cmd",
+    () => {
+      navigator.clipboard.writeText(toCodePoint(props.data.symbolEmojis));
+      toast("Copied symbol codepoints to clipboard.");
+    },
+    {},
+    [props.data.symbolEmojis]
+  );
+
+  useHotkey(
+    "a",
+    "cmd",
+    () => {
+      navigator.clipboard.writeText(props.data.marketAddress);
+      toast("Copied market address to clipboard.");
+    },
+    {},
+    [props.data.marketAddress]
+  );
+
+  useHotkey(
+    "x",
+    "cmd",
+    () => {
+      navigator.clipboard.writeText(explorerLink);
+      toast("Copied explorer address to clipboard.");
+    },
+    {},
+    [explorerLink]
+  );
+
+  useHotkey(
+    "x",
+    "goto",
+    () => {
+      router.push(explorerLink);
+    },
+    {},
+    [explorerLink]
+  );
 
   return (
     <Box>

--- a/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
@@ -15,6 +15,8 @@ import { useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { ROUTES } from "router/routes";
 import { useEffectOnce } from "react-use";
+import { toExplorerLink } from "lib/utils/explorer-link";
+import { useHotkey } from "context/Hotkeys";
 
 export const WalletClientPage = ({ address, name }: { address: string; name?: ValidAptosName }) => {
   const resolvedName = name ?? address;
@@ -31,6 +33,18 @@ export const WalletClientPage = ({ address, name }: { address: string; name?: Va
       router.replace(`${ROUTES.wallet}/${name}`);
     }
   });
+
+  const explorerLink = toExplorerLink({ value: address, linkType: "account" });
+
+  useHotkey(
+    "x",
+    "goto",
+    () => {
+      router.push(explorerLink);
+    },
+    {},
+    [router]
+  );
 
   return (
     <div className="max-w-[100vw] px-2 sm:min-w-[80vw] md:min-w-[800px]">

--- a/src/typescript/frontend/src/context/Hotkeys.tsx
+++ b/src/typescript/frontend/src/context/Hotkeys.tsx
@@ -1,0 +1,105 @@
+import { useRouter } from "next/navigation";
+import { ROUTES } from "router/routes";
+import { createContext, type DependencyList, type PropsWithChildren, useContext, useEffect, useState } from "react";
+import { useUserSettings } from "./event-store-context";
+import { toast } from "react-toastify";
+
+type HotkeyMode = "*" | "cmd" | "goto" | null;
+
+export const HotkeysContext = createContext<{mode: HotkeyMode, setMode: (mode: HotkeyMode) => void} | null>(null);
+
+export const useHotkey = (
+  key: string,
+  mode: HotkeyMode,
+  action: () => void,
+  ops: {
+    modifiers?: {
+      ctrl?: boolean,
+      shift?: boolean,
+      alt?: boolean,
+    },
+    exitMode?: HotkeyMode
+  },
+  ...deps: DependencyList
+) => {
+  const devMode = useUserSettings((s) => s.devMode);
+  const context = useContext(HotkeysContext);
+  if (context === null) {
+    throw new Error("useHotkey must be used within a HotkeysContext.");
+  }
+  useEffect(() => {
+    const fn = (e: KeyboardEvent) => {
+      if (devMode) {
+        if (e.key === key) {
+          if (ops.modifiers?.ctrl && !e.ctrlKey) return;
+          if (ops.modifiers?.shift && !e.shiftKey) return;
+          if (ops.modifiers?.alt && !e.altKey) return;
+          if (mode !== "*" && mode !== context.mode) return;
+          e.preventDefault();
+          action();
+          context.setMode(ops.exitMode ?? null);
+        }
+      }
+    };
+    document.addEventListener("keydown", fn);
+    return () => document.removeEventListener("keydown", fn);
+  }, deps);
+}
+
+const DefaultHotkeys = ({ children }: PropsWithChildren) => {
+  const router = useRouter();
+  useHotkey("p", null, () => {}, { modifiers: {ctrl: true}, exitMode: "cmd" }, [router]);
+  useHotkey("g", null, () => {}, { modifiers: {ctrl: true}, exitMode: "goto" }, [router]);
+  useHotkey("Escape", "*", () => {}, { exitMode: null }, [router]);
+  useHotkey("h", "goto", () => router.push(ROUTES.home), {}, [router]);
+  useHotkey("p", "goto", () => router.push(ROUTES.pools), {}, [router]);
+  useHotkey("l", "goto", () => router.push(ROUTES.launch), {}, [router]);
+  useHotkey("c", "goto", () => router.push(ROUTES.cult), {}, [router]);
+
+  return children;
+}
+
+export function HotkeysContextProvider({ children }: PropsWithChildren) {
+  const [mode, setMode] = useState<HotkeyMode>(null);
+  const [devModeCount, setDevModeCount] = useState(0);
+  const toggleDevMode = useUserSettings((s) => s.toggleDevMode);
+  const devMode = useUserSettings((s) => s.devMode);
+  useEffect(() => {
+    const fn = (e: KeyboardEvent) => {
+      console.log(e.key)
+      if (e.key === "d" && e.ctrlKey) {
+        e.preventDefault();
+        setDevModeCount((v) => v + 1);
+        setTimeout(() => {
+          setDevModeCount((v) => {
+            if (v > 0) {
+              return v - 1;
+            }
+            return 0;
+          });
+        }, 1300);
+      }
+    };
+    document.addEventListener("keydown", fn);
+    return () => document.removeEventListener("keydown", fn);
+  }, []);
+  useEffect(() => {
+    if (devModeCount > 10) {
+      toggleDevMode();
+      setDevModeCount(0);
+      if (devMode) {
+        toast("Dev mode disabled");
+      } else {
+        toast("Dev mode enabled");
+      }
+    }
+  }, [devModeCount, setDevModeCount]);
+
+  return <HotkeysContext.Provider value={{mode, setMode}}>
+    <DefaultHotkeys>
+      {children}
+    </DefaultHotkeys>
+  </HotkeysContext.Provider>;
+}
+
+export default HotkeysContextProvider;

--- a/src/typescript/frontend/src/context/providers.tsx
+++ b/src/typescript/frontend/src/context/providers.tsx
@@ -36,6 +36,7 @@ import { GeoblockedBanner } from "components/geoblocking";
 import { completePickerData } from "utils/picker-data/complete-picker-data";
 import { type EmojiMartData } from "components/pages/emoji-picker/types";
 import { init } from "emoji-mart";
+import Hotkeys from "./Hotkeys";
 
 /**
  * Initialize the picker data from the CDN- then augment it with the missing emoji data with @see completePickerData.
@@ -91,11 +92,13 @@ const ThemedApp: React.FC<{ userAgent: string; children: React.ReactNode }> = ({
                     <Suspense fallback={<Loader />}>
                       <StyledToaster />
                       <ContentWrapper>
-                        <Header isOpen={isMobileMenuOpen} setIsOpen={setIsOpen} />
-                        <HeaderSpacer />
-                        <GeoblockedBanner />
-                        {children}
-                        <Footer />
+                        <Hotkeys>
+                          <Header isOpen={isMobileMenuOpen} setIsOpen={setIsOpen} />
+                          <HeaderSpacer />
+                          <GeoblockedBanner />
+                          {children}
+                          <Footer />
+                        </Hotkeys>
                       </ContentWrapper>
                     </Suspense>
                   </EmojiPickerProvider>

--- a/src/typescript/pnpm-lock.yaml
+++ b/src/typescript/pnpm-lock.yaml
@@ -270,7 +270,7 @@ importers:
         version: 3.4.13(ts-node@10.9.2(@types/node@20.16.11)(typescript@5.6.2))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@20.16.11)(ts-node@10.9.2(@types/node@20.16.11)(typescript@5.6.2)))(typescript@5.6.2)
+        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.16.11)(ts-node@10.9.2(@types/node@20.16.11)(typescript@5.6.2)))(typescript@5.6.2)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -10880,25 +10880,6 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.25.7)
       esbuild: 0.24.2
-
-  ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@20.16.11)(ts-node@10.9.2(@types/node@20.16.11)(typescript@5.6.2)))(typescript@5.6.2):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.16.11)(ts-node@10.9.2(@types/node@20.16.11)(typescript@5.6.2))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.6.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.25.7
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.25.7)
 
   ts-node@10.9.2(@types/node@20.16.11)(typescript@5.6.2):
     dependencies:

--- a/src/typescript/sdk/src/emoji_data/utils.ts
+++ b/src/typescript/sdk/src/emoji_data/utils.ts
@@ -197,6 +197,19 @@ export const generateRandomSymbol = () => {
 export const namesToEmojis = (...names: SymbolEmojiName[]) =>
   names.map((name) => SYMBOL_EMOJI_DATA.byStrictName(name).emoji);
 
+/**
+ * Convert {@link AnyEmoji} to SCN (standardized codepoint notation).
+ *
+ * `_` is used as a separator between codepoints.
+ *
+ * `+` is used as a separator between emojis.
+ *
+ *  The black cat emoji is composed from the three following codepoints: `U+1F408 U+200D U+2B1B`. It's SCN is `1f408_200d_2b1b`.
+ *
+ *  The moose emoji is composed from one codepoint: 1face.
+ *
+ *  The black cat moose symbol's SCN is `1f408_200d_2b1b+1face`.
+ */
 export function toCodePoint(emoji: AnyEmoji): string;
 export function toCodePoint(emoji: AnyEmoji[]): string;
 export function toCodePoint(emoji: AnyEmoji[] | AnyEmoji) {

--- a/src/typescript/sdk/src/emoji_data/utils.ts
+++ b/src/typescript/sdk/src/emoji_data/utils.ts
@@ -196,3 +196,17 @@ export const generateRandomSymbol = () => {
 
 export const namesToEmojis = (...names: SymbolEmojiName[]) =>
   names.map((name) => SYMBOL_EMOJI_DATA.byStrictName(name).emoji);
+
+export function toCodePoint(emoji: AnyEmoji): string;
+export function toCodePoint(emoji: AnyEmoji[]): string;
+export function toCodePoint(emoji: AnyEmoji[] | AnyEmoji) {
+  if (typeof emoji === "string") {
+    const codepoints: number[] = [];
+    for (const c of emoji) {
+      codepoints.push(c.codePointAt(0)!);
+    }
+    return codepoints.map((c) => c.toString(16)).join("_");
+  } else {
+    return emoji.map((e) => toCodePoint(e)).join("+");
+  }
+}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds numerous hotkeys to navigate and improve QoL while using the website.

- CTRL+P: enter command mode
  - on a market page
    - e: copy emojis
    - c: copy codepoints
    - a: copy address
    - x: copy explorer link
- CTRL+G: enter goto mode
  - globally
    - h: goto home page
    - p: goto pools page
    - l: goto launch page
    - c: goto cult page
  - on a market page:
    - x: go to the explorer page of the market
  - on a wallet page:
    - x: go to the explorer page of the user
- ESC: exit any mode
- CTRL+D ten times in less than 1.3s: enable dev mode

# Testing

Use the hotkeys.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
