### PR TITLE
chore(ECO-3061): Bump the frontend to `1.6.0` and SDK to `0.5.4`

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -121,5 +121,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -118,5 +118,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.5.3"
+  "version": "0.5.4"
 }


### PR DESCRIPTION
# Description

- [x] Bump frontend to `1.6.0` since this primarily adds new features with no backwards incompatible changes on the frontend
- [x] SDK only needs a bump to `0.5.4` because there were mostly only tests and non-API changes made

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
