### PR TITLE
chore(ECO-3090): Remove arena index disable flag

### DIFF
--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -21,7 +21,6 @@ parameters:
   EnableWafRulesRestApi: 'false'
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
-  IndexArena: 'false'
   Network: 'mainnet'
   ProcessorImageVersion: '7.0.0'
   VpcStackName: 'emoji-vpc'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -21,7 +21,6 @@ parameters:
   EnableWafRulesRestApi: 'false'
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
-  IndexArena: 'false'
   Network: 'mainnet'
   ProcessorImageVersion: '7.0.0'
   VpcStackName: 'emoji-vpc'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Remove the `IndexArena` flag that currently overloads arena indexing on production and fallback stacks.

Note that without the flag set to false it defaults to indexing arena events.

# Testing

The overload flag in question is already removed from the alpha stack, which has been tested extensively.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
