### PR TITLE
fix(ECO-3091): Fix arena hero section not showing up

### DIFF
--- a/src/typescript/frontend/src/app/home/page.tsx
+++ b/src/typescript/frontend/src/app/home/page.tsx
@@ -54,7 +54,7 @@ export default async function Home({ searchParams }: HomePageParams) {
 
   const meleeDataPromise = FEATURE_FLAGS.Arena
     ? fetchCachedMeleeData()
-        .then((res) => (res.arenaInfo ? meleeData : null))
+        .then((res) => (res.arenaInfo ? res : null))
         .catch(() => null)
     : null;
 


### PR DESCRIPTION
# Description

TypeScript closures work in an odd way- they don't necessarily check that a variable has already been declared in a promise closure, because it can technically be executed later.

This meant that accidentally using `meleeData` before it was even declared didn't result in an error at compile/build time.

Simple fix:

- [x] Change `meleeData` to `res` and fix the closure error

# Testing

Tested it locally already.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
