### PR TITLE
fix(ECO-3092): Fix first arena candlestick in state not being updated

### DIFF
--- a/src/typescript/frontend/src/lib/store/arena/utils.ts
+++ b/src/typescript/frontend/src/lib/store/arena/utils.ts
@@ -107,6 +107,6 @@ export const handleLatestBarForArenaCandlestick = (
       period,
       nonce,
     };
-    callbackClonedLatestBarIfSubscribed(current.callback, current.latestBar);
   }
+  callbackClonedLatestBarIfSubscribed(current.callback, current.latestBar);
 };


### PR DESCRIPTION
# Description

The function to store the bar data in state was only being called in the else block. To fix it, just needed to move it down a line outside of the if/else, so it always updates with whatever the new current latest bar is.

# Testing

- [x] Tested locally and fixed it.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
