### PR TITLE
refactor(ECO-3098): Validate Aptos name inputs properly and display u…

### DIFF
--- a/src/typescript/frontend/src/app/wallet/[address]/error.tsx
+++ b/src/typescript/frontend/src/app/wallet/[address]/error.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { emoji } from "utils";
+import { Emoji } from "utils/emoji";
+
+export default function UserNotFound() {
+  return (
+    <div className="flex flex-col justify-center align-middle h-full">
+      <div className="text-warning flex flex-row text-[64px] leading-[64px] !font-forma-bold m-auto gap-2">
+        {"We couldn't find that user."}
+        <Emoji emojis={emoji("sad but relieved face")} />
+      </div>
+    </div>
+  );
+}

--- a/src/typescript/frontend/src/app/wallet/[address]/page.tsx
+++ b/src/typescript/frontend/src/app/wallet/[address]/page.tsx
@@ -5,6 +5,7 @@ import { AptPriceContextProvider } from "context/AptPrice";
 import { getAptPrice } from "lib/queries/get-apt-price";
 import { type Metadata } from "next";
 import { customTruncateAddress, resolveOwnerNameCached } from "../utils";
+import UserNotFound from "./error";
 
 type Props = {
   params: { address: string };
@@ -22,13 +23,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 export default async function WalletPage({ params }: Props) {
-  const aptPrice = await getAptPrice();
   const { address, name } = await resolveOwnerNameCached(params.address);
+
+  if (!(address || name)) {
+    return <UserNotFound />;
+  }
+
+  const aptPrice = await getAptPrice();
 
   return (
     <div className="mx-auto">
       <AptPriceContextProvider aptPrice={aptPrice}>
-        <WalletClientPage address={address ?? "invalid address"} name={name} />
+        <WalletClientPage address={address} name={name} />
       </AptPriceContextProvider>
     </div>
   );

--- a/src/typescript/frontend/src/lib/hooks/queries/use-fetch-owner-emojicoin-balances.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-fetch-owner-emojicoin-balances.ts
@@ -72,14 +72,22 @@ const toFullCoinData = async (balances: AssetBalance[]) => {
  * @returns the @see FullCoinData[] and wallet stats total value
  */
 export const useUserEmojicoinBalances = (owner: AccountAddressInput, max?: number) => {
-  const ownerAddress = useMemo(() => toAccountAddressString(owner), [owner]);
+  const ownerAddress = useMemo(
+    () => owner && AccountAddress.isValid({ input: owner }).valid && toAccountAddressString(owner),
+    [owner]
+  );
 
   const { data, isLoading } = useQuery({
     queryKey: ["user-emojicoin-balances", ownerAddress, max],
     queryFn: () =>
-      withResponseError(fetchOwnerEmojicoinBalances({ ownerAddress, max }).then(toFullCoinData)),
+      withResponseError(
+        (ownerAddress
+          ? fetchOwnerEmojicoinBalances({ ownerAddress, max })
+          : Promise.resolve([])
+        ).then(toFullCoinData)
+      ),
     staleTime: STALE_TIME,
-    enabled: AccountAddress.isValid({ input: owner }).valid,
+    enabled: !!owner && AccountAddress.isValid({ input: owner }).valid,
   });
 
   return {

--- a/src/typescript/sdk/src/utils/validation/ans-name.ts
+++ b/src/typescript/sdk/src/utils/validation/ans-name.ts
@@ -31,7 +31,7 @@ const AnsNameSchema = z
   .transform((s) => s.replace(/\.apt$/, ""))
   .refine((nameWithoutSuffix) => {
     const parts = nameWithoutSuffix.split(".");
-    return parts.length > 2 && parts.every((p) => AnsSegmentSchema.safeParse(p).success);
+    return parts.length <= 2 && parts.every((p) => AnsSegmentSchema.safeParse(p).success);
   });
 
 export const isValidAptosName = (name: unknown): name is ValidAptosName =>

--- a/src/typescript/sdk/src/utils/validation/ans-name.ts
+++ b/src/typescript/sdk/src/utils/validation/ans-name.ts
@@ -1,31 +1,38 @@
+import { z } from "zod";
+
 export type ValidAptosName = string & {
   __brand: "ValidAptosName";
 };
 
 /**
- * - Only lowercase characters `a-z`, digits `0-9`, or a hyphen `-`
- * - Doesn't start with a hyphen
- * - Doesn't end with a hyphen
- * - At least 3 characters
- * - At most 63 characters
+ * Schema validation largely borrowed from the ANS name validation logic in the Aptos TS SDK.
+ *
+ * Unfortunately it is not exported to the TS SDK, but the logic is fairly straightforward.
+ *
+ * @see {@link https://github.com/aptos-labs/aptos-ts-sdk/blob/db88e984528a545a240bad876d9ea832fd0c8348/src/internal/ans.ts#L55}
  */
-const APTOS_NAME_REGEX = /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9](\.[a-z0-9]+)?$/;
 
-/**
- * Checks to see that an ANS name is valid. This means we can skip API calls to the Aptos Name
- * Service for names that are invalid.
- *
- * The rules used here are taken from the
- * {@link [ANS contract on mainnet](https://explorer.aptoslabs.com/account/0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c/modules?network=mainnet)}
- *
- * The rules are written in `v2_1_string_validator`:
- *  - Only allow latin lowercase letters, digits, and hyphens
- *  - Hyphens are not allowed at the beginning or end of a string
- *
- * As well as having the `min_domain_length` and `max_domain_length` set to `3` and `63` specified
- * in the
- * {@link [v2_1_config::Config](https://explorer.aptoslabs.com/account/0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c/resources?network=mainnet)}
- * resource on-chain.
- */
-export const isValidAptosName = (input: unknown): input is ValidAptosName =>
-  typeof input === "string" && APTOS_NAME_REGEX.test(input);
+export const VALIDATION_RULES_DESCRIPTION = [
+  "A name must be between 3 and 63 characters long,",
+  "and can only contain lowercase a-z, 0-9, and hyphens.",
+  "A name may not start or end with a hyphen.",
+].join(" ");
+
+const AnsSegmentSchema = z
+  .string()
+  .min(3, { message: "Name must be at least 3 characters long" })
+  .max(63, { message: "Name cannot exceed 63 characters" })
+  .regex(/^[a-z\d][a-z\d-]{1,61}[a-z\d]$/, {
+    message: VALIDATION_RULES_DESCRIPTION,
+  });
+
+const AnsNameSchema = z
+  .string()
+  .transform((s) => s.replace(/\.apt$/, ""))
+  .refine((nameWithoutSuffix) => {
+    const parts = nameWithoutSuffix.split(".");
+    return parts.length > 2 && parts.every((p) => AnsSegmentSchema.safeParse(p).success);
+  });
+
+export const isValidAptosName = (name: unknown): name is ValidAptosName =>
+  AnsNameSchema.safeParse(name).success;

--- a/src/typescript/sdk/tests/unit/ans-validation.test.ts
+++ b/src/typescript/sdk/tests/unit/ans-validation.test.ts
@@ -1,0 +1,28 @@
+import { isValidAptosName } from "../../src";
+
+describe("ans name validation tests", () => {
+  it("returns true for valid names", () => {
+    expect(isValidAptosName("primary")).toBe(true);
+    expect(isValidAptosName("primary.apt")).toBe(true);
+    expect(isValidAptosName("secondary.primary")).toBe(true);
+    expect(isValidAptosName("secondary.primary.apt")).toBe(true);
+  });
+
+  it("returns false for invalid names", () => {
+    expect(isValidAptosName(".")).toBe(false);
+    expect(isValidAptosName("")).toBe(false);
+    expect(isValidAptosName("..")).toBe(false);
+    expect(isValidAptosName(" . ")).toBe(false);
+    expect(isValidAptosName(" test ")).toBe(false);
+    expect(isValidAptosName(".apt")).toBe(false);
+    expect(isValidAptosName(".apt.apt")).toBe(false);
+    expect(isValidAptosName(".apt.")).toBe(false);
+    expect(isValidAptosName("1")).toBe(false);
+    expect(isValidAptosName("1.apt")).toBe(false);
+    expect(isValidAptosName("bad.bad.bad")).toBe(false);
+    expect(isValidAptosName("-bad-")).toBe(false);
+    expect(isValidAptosName("-bad.apt")).toBe(false);
+    expect(isValidAptosName("bad-.apt")).toBe(false);
+    expect(isValidAptosName("b.a.d.apt")).toBe(false);
+  });
+});


### PR DESCRIPTION
…ser not found page upon error

<!-- markdownlint-disable-file MD025 -->

# Description

I didn't really understand the subdomain/domain parts of the ANS name service before, but the TypeScript SDK has internal validation functions already.

Unfortunately, it doesn't export those functions anywhere, and the only other alternative to skipping ANS name fetching if it's an invalid name is with a `try/catch` block, which is bad for maintainability and readability.

To fix this, I ported over [this logic](https://github.com/aptos-labs/aptos-ts-sdk/blob/db88e984528a545a240bad876d9ea832fd0c8348/src/internal/ans.ts#L26) and put it into a zod schema:

```typescript
export const VALIDATION_RULES_DESCRIPTION = [
  "A name must be between 3 and 63 characters long,",
  "and can only contain lowercase a-z, 0-9, and hyphens.",
  "A name may not start or end with a hyphen.",
].join(" ");

/**
 * Validate if a given fragment is a valid ANS segment.
 * This function checks the length and character constraints of the fragment to ensure it meets the ANS standards.
 *
 * @param fragment - A fragment of a name, either the domain or subdomain.
 * @returns A boolean indicating if the fragment is a valid fragment.
 * @group Implementation
 */
export function isValidANSSegment(fragment: string): boolean {
  if (!fragment) return false;
  if (fragment.length < 3) return false;
  if (fragment.length > 63) return false;
  // only lowercase a-z and 0-9 are allowed, along with -. a domain may not start or end with a hyphen
  if (!/^[a-z\d][a-z\d-]{1,61}[a-z\d]$/.test(fragment)) return false;
  return true;
}

/**
 * Checks if an ANS name is valid or not.
 *
 * @param name - A string of the domain name, which can include or exclude the .apt suffix.
 * @group Implementation
 */
export function isValidANSName(name: string): { domainName: string; subdomainName?: string } {
  const [first, second, ...rest] = name.replace(/\.apt$/, "").split(".");

  if (rest.length > 0) {
    throw new Error(`${name} is invalid. A name can only have two parts, a domain and a subdomain separated by a "."`);
  }

  if (!isValidANSSegment(first)) {
    throw new Error(`${first} is not valid. ${VALIDATION_RULES_DESCRIPTION}`);
  }

  if (second && !isValidANSSegment(second)) {
    throw new Error(`${second} is not valid. ${VALIDATION_RULES_DESCRIPTION}`);
  }

  return {
    domainName: second || first,
    subdomainName: second ? first : undefined,
  };
}
```

I also added an `error.tsx` for `/[wallet]` and return the `UserNotFound` component in it if the address or user are undefined.

# Testing

Testing it manually with various names and subdomains.

Added unit tests for ans name validation (test cases copied from the TS SDK).

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
