### PR TITLE
chore(ECO-3119): Change `paths` aliases in `tsconfig.json` files to conform to TS ecosystem standards

### DIFF
--- a/src/typescript/frontend/next.config.mjs
+++ b/src/typescript/frontend/next.config.mjs
@@ -60,7 +60,7 @@ const nextConfig = {
           },
         }
       : undefined,
-  transpilePackages: ["@sdk"],
+  transpilePackages: ["@/sdk"],
   redirects: async () => [
     {
       source: "/",

--- a/src/typescript/frontend/src/app/api/arena/candlesticks/fetch.ts
+++ b/src/typescript/frontend/src/app/api/arena/candlesticks/fetch.ts
@@ -1,13 +1,13 @@
 // cspell:word timespan
 
-import type { ArenaPeriod } from "@sdk/const";
+import type { ArenaPeriod } from "@/sdk/const";
 import {
   type ArenaCandlestickModel,
   fetchArenaCandlesticksSince,
   fetchArenaInfoByMeleeID,
-} from "@sdk/indexer-v2";
-import { getPeriodStartTimeFromTime } from "@sdk/utils/misc";
-import type { AnyNumberString } from "@sdk-types";
+} from "@/sdk/indexer-v2";
+import { getPeriodStartTimeFromTime } from "@/sdk/utils/misc";
+import type { AnyNumberString } from "@/sdk-types";
 import {
   getCachedLatestProcessedEmojicoinTimestamp,
   getPeriodDurationSeconds,

--- a/src/typescript/frontend/src/app/api/arena/candlesticks/fetch.ts
+++ b/src/typescript/frontend/src/app/api/arena/candlesticks/fetch.ts
@@ -1,13 +1,5 @@
 // cspell:word timespan
 
-import type { ArenaPeriod } from "@/sdk/const";
-import {
-  type ArenaCandlestickModel,
-  fetchArenaCandlesticksSince,
-  fetchArenaInfoByMeleeID,
-} from "@/sdk/indexer-v2";
-import { getPeriodStartTimeFromTime } from "@/sdk/utils/misc";
-import type { AnyNumberString } from "@/sdk-types";
 import {
   getCachedLatestProcessedEmojicoinTimestamp,
   getPeriodDurationSeconds,
@@ -21,6 +13,15 @@ import {
 } from "app/api/candlesticks/utils";
 import { unstable_cache } from "next/cache";
 import { parseJSON, stringifyJSON } from "utils";
+
+import type { ArenaPeriod } from "@/sdk/const";
+import {
+  type ArenaCandlestickModel,
+  fetchArenaCandlesticksSince,
+  fetchArenaInfoByMeleeID,
+} from "@/sdk/indexer-v2";
+import { getPeriodStartTimeFromTime } from "@/sdk/utils/misc";
+import type { AnyNumberString } from "@/sdk-types";
 
 import type { ArenaCandlesticksSearchParams } from "./search-params-schema";
 

--- a/src/typescript/frontend/src/app/api/arena/candlesticks/search-params-schema.ts
+++ b/src/typescript/frontend/src/app/api/arena/candlesticks/search-params-schema.ts
@@ -1,6 +1,7 @@
+import { z } from "zod";
+
 import { ArenaPeriod } from "@/sdk/const";
 import { Schemas } from "@/sdk/utils";
-import { z } from "zod";
 
 export const ArenaCandlesticksSearchParamsSchema = z.object({
   meleeID: Schemas["PositiveInteger"].describe("`meleeID` must be a positive integer."),

--- a/src/typescript/frontend/src/app/api/arena/candlesticks/search-params-schema.ts
+++ b/src/typescript/frontend/src/app/api/arena/candlesticks/search-params-schema.ts
@@ -1,5 +1,5 @@
-import { ArenaPeriod } from "@sdk/const";
-import { Schemas } from "@sdk/utils";
+import { ArenaPeriod } from "@/sdk/const";
+import { Schemas } from "@/sdk/utils";
 import { z } from "zod";
 
 export const ArenaCandlesticksSearchParamsSchema = z.object({

--- a/src/typescript/frontend/src/app/api/candlesticks/search-params-schema.ts
+++ b/src/typescript/frontend/src/app/api/candlesticks/search-params-schema.ts
@@ -1,5 +1,5 @@
-import { Period } from "@sdk/const";
-import { Schemas } from "@sdk/utils";
+import { Period } from "@/sdk/const";
+import { Schemas } from "@/sdk/utils";
 import { z } from "zod";
 
 export const CandlesticksSearchParamsSchema = z.object({

--- a/src/typescript/frontend/src/app/api/candlesticks/search-params-schema.ts
+++ b/src/typescript/frontend/src/app/api/candlesticks/search-params-schema.ts
@@ -1,6 +1,7 @@
+import { z } from "zod";
+
 import { Period } from "@/sdk/const";
 import { Schemas } from "@/sdk/utils";
-import { z } from "zod";
 
 export const CandlesticksSearchParamsSchema = z.object({
   marketID: Schemas["PositiveInteger"].describe("`marketID` must be a positive integer."),

--- a/src/typescript/frontend/src/app/api/candlesticks/utils.ts
+++ b/src/typescript/frontend/src/app/api/candlesticks/utils.ts
@@ -7,8 +7,8 @@ import {
   type Period,
   PeriodDuration,
   periodEnumToRawDuration,
-} from "@sdk/index";
-import { getLatestProcessedEmojicoinTimestamp } from "@sdk/indexer-v2/queries/utils";
+} from "@/sdk/index";
+import { getLatestProcessedEmojicoinTimestamp } from "@/sdk/indexer-v2/queries/utils";
 import { unstable_cache } from "next/cache";
 import { parseJSON, stringifyJSON } from "utils";
 

--- a/src/typescript/frontend/src/app/api/candlesticks/utils.ts
+++ b/src/typescript/frontend/src/app/api/candlesticks/utils.ts
@@ -1,5 +1,9 @@
 // cspell:word timespan
 
+import { unstable_cache } from "next/cache";
+import { parseJSON, stringifyJSON } from "utils";
+
+import { fetchMarketRegistration, fetchPeriodicEventsSince } from "@/queries/market";
 import {
   type AnyNumberString,
   type AnyPeriod,
@@ -9,10 +13,6 @@ import {
   periodEnumToRawDuration,
 } from "@/sdk/index";
 import { getLatestProcessedEmojicoinTimestamp } from "@/sdk/indexer-v2/queries/utils";
-import { unstable_cache } from "next/cache";
-import { parseJSON, stringifyJSON } from "utils";
-
-import { fetchMarketRegistration, fetchPeriodicEventsSince } from "@/queries/market";
 
 import type { CandlesticksSearchParams } from "./search-params-schema";
 

--- a/src/typescript/frontend/src/app/api/coingecko/historical_trades/route.ts
+++ b/src/typescript/frontend/src/app/api/coingecko/historical_trades/route.ts
@@ -1,5 +1,5 @@
-import { postgrest } from "@sdk/indexer-v2/queries/client";
-import { TableName } from "@sdk/indexer-v2/types";
+import { postgrest } from "@/sdk/indexer-v2/queries/client";
+import { TableName } from "@/sdk/indexer-v2/types";
 import Big from "big.js";
 import type { NextRequest } from "next/server";
 import { stringifyJSON } from "utils";

--- a/src/typescript/frontend/src/app/api/coingecko/historical_trades/route.ts
+++ b/src/typescript/frontend/src/app/api/coingecko/historical_trades/route.ts
@@ -1,8 +1,9 @@
-import { postgrest } from "@/sdk/indexer-v2/queries/client";
-import { TableName } from "@/sdk/indexer-v2/types";
 import Big from "big.js";
 import type { NextRequest } from "next/server";
 import { stringifyJSON } from "utils";
+
+import { postgrest } from "@/sdk/indexer-v2/queries/client";
+import { TableName } from "@/sdk/indexer-v2/types";
 
 /**
  * @see {@link https://docs.google.com/document/d/1v27QFoQq1SKT3Priq3aqPgB70Xd_PnDzbOCiuoCyixw/edit?tab=t.0}

--- a/src/typescript/frontend/src/app/api/coingecko/tickers/route.ts
+++ b/src/typescript/frontend/src/app/api/coingecko/tickers/route.ts
@@ -1,10 +1,11 @@
+import { getAptPrice } from "lib/queries/get-apt-price";
+import type { NextRequest } from "next/server";
+import { stringifyJSON } from "utils";
+
 import { APTOS_COIN_TYPE_TAG } from "@/sdk/const";
 import { postgrest } from "@/sdk/indexer-v2/queries/client";
 import { TableName } from "@/sdk/indexer-v2/types";
 import { toNominal, toNominalPrice } from "@/sdk/utils";
-import { getAptPrice } from "lib/queries/get-apt-price";
-import type { NextRequest } from "next/server";
-import { stringifyJSON } from "utils";
 
 import { estimateLiquidityInUSD } from "./utils";
 

--- a/src/typescript/frontend/src/app/api/coingecko/tickers/route.ts
+++ b/src/typescript/frontend/src/app/api/coingecko/tickers/route.ts
@@ -1,7 +1,7 @@
-import { APTOS_COIN_TYPE_TAG } from "@sdk/const";
-import { postgrest } from "@sdk/indexer-v2/queries/client";
-import { TableName } from "@sdk/indexer-v2/types";
-import { toNominal, toNominalPrice } from "@sdk/utils";
+import { APTOS_COIN_TYPE_TAG } from "@/sdk/const";
+import { postgrest } from "@/sdk/indexer-v2/queries/client";
+import { TableName } from "@/sdk/indexer-v2/types";
+import { toNominal, toNominalPrice } from "@/sdk/utils";
 import { getAptPrice } from "lib/queries/get-apt-price";
 import type { NextRequest } from "next/server";
 import { stringifyJSON } from "utils";

--- a/src/typescript/frontend/src/app/api/coingecko/tickers/utils.ts
+++ b/src/typescript/frontend/src/app/api/coingecko/tickers/utils.ts
@@ -1,9 +1,10 @@
 import "server-only";
 
+import Big from "big.js";
+
 import type { Uint64String } from "@/sdk/emojicoin_dot_fun";
 import { calculateCurvePrice, calculateRealReserves } from "@/sdk/markets";
 import { toReserves } from "@/sdk-types";
-import Big from "big.js";
 
 export const estimateLiquidityInUSD = (
   e: {

--- a/src/typescript/frontend/src/app/api/coingecko/tickers/utils.ts
+++ b/src/typescript/frontend/src/app/api/coingecko/tickers/utils.ts
@@ -1,8 +1,8 @@
 import "server-only";
 
-import type { Uint64String } from "@sdk/emojicoin_dot_fun";
-import { calculateCurvePrice, calculateRealReserves } from "@sdk/markets";
-import { toReserves } from "@sdk-types";
+import type { Uint64String } from "@/sdk/emojicoin_dot_fun";
+import { calculateCurvePrice, calculateRealReserves } from "@/sdk/markets";
+import { toReserves } from "@/sdk-types";
 import Big from "big.js";
 
 export const estimateLiquidityInUSD = (

--- a/src/typescript/frontend/src/app/api/dexscreener/asset/route.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/asset/route.ts
@@ -20,10 +20,10 @@
  // }
  **/
 
-import { EMOJICOIN_SUPPLY } from "@sdk/const";
-import { toMarketEmojiData } from "@sdk/emoji_data";
-import { calculateCirculatingSupply } from "@sdk/markets";
-import { toNominal } from "@sdk/utils";
+import { EMOJICOIN_SUPPLY } from "@/sdk/const";
+import { toMarketEmojiData } from "@/sdk/emoji_data";
+import { calculateCirculatingSupply } from "@/sdk/markets";
+import { toNominal } from "@/sdk/utils";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { fetchMarketState } from "@/queries/market";

--- a/src/typescript/frontend/src/app/api/dexscreener/asset/route.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/asset/route.ts
@@ -20,13 +20,13 @@
  // }
  **/
 
+import { type NextRequest, NextResponse } from "next/server";
+
+import { fetchMarketState } from "@/queries/market";
 import { EMOJICOIN_SUPPLY } from "@/sdk/const";
 import { toMarketEmojiData } from "@/sdk/emoji_data";
 import { calculateCirculatingSupply } from "@/sdk/markets";
 import { toNominal } from "@/sdk/utils";
-import { type NextRequest, NextResponse } from "next/server";
-
-import { fetchMarketState } from "@/queries/market";
 
 import { symbolEmojiStringToArray } from "../util";
 

--- a/src/typescript/frontend/src/app/api/dexscreener/events/route.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/events/route.ts
@@ -73,20 +73,20 @@
  // }
  **/
 
-import { DECIMALS } from "@sdk/const";
+import { DECIMALS } from "@/sdk/const";
 import {
   fetchLiquidityEventsByBlock,
   fetchSwapEventsByBlock,
-} from "@sdk/indexer-v2/queries/app/dexscreener";
+} from "@/sdk/indexer-v2/queries/app/dexscreener";
 import {
   isLiquidityEventModel,
   type toLiquidityEventModel,
   type toSwapEventModel,
-} from "@sdk/indexer-v2/types";
-import { calculateCurvePrice, calculateRealReserves } from "@sdk/markets";
-import { compareBigInt } from "@sdk/utils/compare-bigint";
-import type { XOR } from "@sdk/utils/utility-types";
-import type { Flatten } from "@sdk-types";
+} from "@/sdk/indexer-v2/types";
+import { calculateCurvePrice, calculateRealReserves } from "@/sdk/markets";
+import { compareBigInt } from "@/sdk/utils/compare-bigint";
+import type { XOR } from "@/sdk/utils/utility-types";
+import type { Flatten } from "@/sdk-types";
 import { toCoinDecimalString } from "lib/utils/decimals";
 import { type NextRequest, NextResponse } from "next/server";
 

--- a/src/typescript/frontend/src/app/api/dexscreener/events/route.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/events/route.ts
@@ -73,6 +73,9 @@
  // }
  **/
 
+import { toCoinDecimalString } from "lib/utils/decimals";
+import { type NextRequest, NextResponse } from "next/server";
+
 import { DECIMALS } from "@/sdk/const";
 import {
   fetchLiquidityEventsByBlock,
@@ -87,8 +90,6 @@ import { calculateCurvePrice, calculateRealReserves } from "@/sdk/markets";
 import { compareBigInt } from "@/sdk/utils/compare-bigint";
 import type { XOR } from "@/sdk/utils/utility-types";
 import type { Flatten } from "@/sdk-types";
-import { toCoinDecimalString } from "lib/utils/decimals";
-import { type NextRequest, NextResponse } from "next/server";
 
 import type { Block } from "../latest-block/route";
 import { symbolEmojisToPairId } from "../util";

--- a/src/typescript/frontend/src/app/api/dexscreener/latest-block/route.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/latest-block/route.ts
@@ -16,9 +16,10 @@
  // }
  **/
 
+import { type NextRequest, NextResponse } from "next/server";
+
 import { getProcessorStatus } from "@/sdk/indexer-v2/queries";
 import { getAptosClient } from "@/sdk/utils/aptos-client";
-import { type NextRequest, NextResponse } from "next/server";
 
 /**
  * - `blockTimestamp` should be a UNIX timestamp, **not** including milliseconds

--- a/src/typescript/frontend/src/app/api/dexscreener/latest-block/route.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/latest-block/route.ts
@@ -16,8 +16,8 @@
  // }
  **/
 
-import { getProcessorStatus } from "@sdk/indexer-v2/queries";
-import { getAptosClient } from "@sdk/utils/aptos-client";
+import { getProcessorStatus } from "@/sdk/indexer-v2/queries";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 import { type NextRequest, NextResponse } from "next/server";
 
 /**

--- a/src/typescript/frontend/src/app/api/dexscreener/pair/route.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/pair/route.ts
@@ -22,9 +22,9 @@
  // }
  **/
 
-import { INTEGRATOR_FEE_RATE_BPS } from "@sdk/const";
-import { fetchMarketRegistrationEventBySymbolEmojis } from "@sdk/indexer-v2/queries/app/dexscreener";
-import { getAptosClient } from "@sdk/utils/aptos-client";
+import { INTEGRATOR_FEE_RATE_BPS } from "@/sdk/const";
+import { fetchMarketRegistrationEventBySymbolEmojis } from "@/sdk/indexer-v2/queries/app/dexscreener";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 import { type NextRequest, NextResponse } from "next/server";
 
 import { pairIdToSymbolEmojis, symbolEmojisToString } from "../util";

--- a/src/typescript/frontend/src/app/api/dexscreener/pair/route.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/pair/route.ts
@@ -22,10 +22,11 @@
  // }
  **/
 
+import { type NextRequest, NextResponse } from "next/server";
+
 import { INTEGRATOR_FEE_RATE_BPS } from "@/sdk/const";
 import { fetchMarketRegistrationEventBySymbolEmojis } from "@/sdk/indexer-v2/queries/app/dexscreener";
 import { getAptosClient } from "@/sdk/utils/aptos-client";
-import { type NextRequest, NextResponse } from "next/server";
 
 import { pairIdToSymbolEmojis, symbolEmojisToString } from "../util";
 

--- a/src/typescript/frontend/src/app/api/dexscreener/util.test.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/util.test.ts
@@ -2,6 +2,7 @@
 import { describe, it } from "node:test";
 
 import { expect } from "@playwright/test";
+
 import type { SymbolEmoji } from "@/sdk/emoji_data";
 
 import { pairIdToSymbolEmojis, symbolEmojisToPairId, symbolEmojisToString } from "./util";

--- a/src/typescript/frontend/src/app/api/dexscreener/util.test.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/util.test.ts
@@ -2,7 +2,7 @@
 import { describe, it } from "node:test";
 
 import { expect } from "@playwright/test";
-import type { SymbolEmoji } from "@sdk/emoji_data";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
 
 import { pairIdToSymbolEmojis, symbolEmojisToPairId, symbolEmojisToString } from "./util";
 

--- a/src/typescript/frontend/src/app/api/dexscreener/util.ts
+++ b/src/typescript/frontend/src/app/api/dexscreener/util.ts
@@ -1,4 +1,4 @@
-import { type SymbolEmoji, toMarketEmojiData } from "@sdk/emoji_data";
+import { type SymbolEmoji, toMarketEmojiData } from "@/sdk/emoji_data";
 
 function pairIdToSymbolEmojiString(pairId: string): string {
   return pairId.split("-")[0];

--- a/src/typescript/frontend/src/app/api/pools/getPoolDataQuery.ts
+++ b/src/typescript/frontend/src/app/api/pools/getPoolDataQuery.ts
@@ -1,10 +1,10 @@
-import { toOrderBy } from "@/sdk/indexer-v2/const";
-import type { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import { MARKETS_PER_PAGE } from "lib/queries/sorting/const";
 import { stringifyJSON } from "utils";
 
 import { fetchMarkets } from "@/queries/home";
 import { fetchUserLiquidityPools } from "@/queries/pools";
+import { toOrderBy } from "@/sdk/indexer-v2/const";
+import type { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 
 export async function getPoolData(
   page: number,

--- a/src/typescript/frontend/src/app/api/pools/getPoolDataQuery.ts
+++ b/src/typescript/frontend/src/app/api/pools/getPoolDataQuery.ts
@@ -1,5 +1,5 @@
-import { toOrderBy } from "@sdk/indexer-v2/const";
-import type { SortMarketsBy } from "@sdk/indexer-v2/types/common";
+import { toOrderBy } from "@/sdk/indexer-v2/const";
+import type { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import { MARKETS_PER_PAGE } from "lib/queries/sorting/const";
 import { stringifyJSON } from "utils";
 

--- a/src/typescript/frontend/src/app/api/pools/route.ts
+++ b/src/typescript/frontend/src/app/api/pools/route.ts
@@ -1,5 +1,5 @@
-import { symbolBytesToEmojis } from "@sdk/emoji_data/utils";
-import { getValidSortByForPoolsPage } from "@sdk/indexer-v2/queries/query-params";
+import { symbolBytesToEmojis } from "@/sdk/emoji_data/utils";
+import { getValidSortByForPoolsPage } from "@/sdk/indexer-v2/queries/query-params";
 import { handleEmptySearchBytes, safeParsePageWithDefault } from "lib/routes/home-page-params";
 import { unstable_cache } from "next/cache";
 

--- a/src/typescript/frontend/src/app/api/pools/route.ts
+++ b/src/typescript/frontend/src/app/api/pools/route.ts
@@ -1,7 +1,8 @@
-import { symbolBytesToEmojis } from "@/sdk/emoji_data/utils";
-import { getValidSortByForPoolsPage } from "@/sdk/indexer-v2/queries/query-params";
 import { handleEmptySearchBytes, safeParsePageWithDefault } from "lib/routes/home-page-params";
 import { unstable_cache } from "next/cache";
+
+import { symbolBytesToEmojis } from "@/sdk/emoji_data/utils";
+import { getValidSortByForPoolsPage } from "@/sdk/indexer-v2/queries/query-params";
 
 import { getPoolData } from "./getPoolDataQuery";
 

--- a/src/typescript/frontend/src/app/api/trades/schema.ts
+++ b/src/typescript/frontend/src/app/api/trades/schema.ts
@@ -1,7 +1,8 @@
 import { AccountAddress } from "@aptos-labs/ts-sdk";
-import { isValidEmojiHex, symbolBytesToEmojis } from "@/sdk/emoji_data";
 import { PaginationSchema } from "lib/api/schemas/api-pagination";
 import { z } from "zod";
+
+import { isValidEmojiHex, symbolBytesToEmojis } from "@/sdk/emoji_data";
 
 export const GetTradesSchema = PaginationSchema.extend({
   sender: z

--- a/src/typescript/frontend/src/app/api/trades/schema.ts
+++ b/src/typescript/frontend/src/app/api/trades/schema.ts
@@ -1,5 +1,5 @@
 import { AccountAddress } from "@aptos-labs/ts-sdk";
-import { isValidEmojiHex, symbolBytesToEmojis } from "@sdk/emoji_data";
+import { isValidEmojiHex, symbolBytesToEmojis } from "@/sdk/emoji_data";
 import { PaginationSchema } from "lib/api/schemas/api-pagination";
 import { z } from "zod";
 

--- a/src/typescript/frontend/src/app/api/trending/route.ts
+++ b/src/typescript/frontend/src/app/api/trending/route.ts
@@ -1,13 +1,13 @@
 // Disable to allow for doc-comment links and sorted imports.
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { AccountAddress } from "@aptos-labs/ts-sdk";
-import type { DECIMALS } from "@sdk/const";
+import type { DECIMALS } from "@/sdk/const";
 import {
   toTrendingMarket,
   type TrendingMarket,
   type TrendingMarketArgs,
-} from "@sdk/indexer-v2/queries";
-import type { q64ToBig } from "@sdk/utils";
+} from "@/sdk/indexer-v2/queries";
+import type { q64ToBig } from "@/sdk/utils";
 import { getAptPrice } from "lib/queries/get-apt-price";
 import { fetchCachedPriceFeed, type NUM_MARKETS_ON_PRICE_FEED } from "lib/queries/price-feed";
 import { NextResponse } from "next/server";

--- a/src/typescript/frontend/src/app/api/trending/route.ts
+++ b/src/typescript/frontend/src/app/api/trending/route.ts
@@ -1,6 +1,10 @@
 // Disable to allow for doc-comment links and sorted imports.
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { AccountAddress } from "@aptos-labs/ts-sdk";
+import { getAptPrice } from "lib/queries/get-apt-price";
+import { fetchCachedPriceFeed, type NUM_MARKETS_ON_PRICE_FEED } from "lib/queries/price-feed";
+import { NextResponse } from "next/server";
+
 import type { DECIMALS } from "@/sdk/const";
 import {
   toTrendingMarket,
@@ -8,9 +12,6 @@ import {
   type TrendingMarketArgs,
 } from "@/sdk/indexer-v2/queries";
 import type { q64ToBig } from "@/sdk/utils";
-import { getAptPrice } from "lib/queries/get-apt-price";
-import { fetchCachedPriceFeed, type NUM_MARKETS_ON_PRICE_FEED } from "lib/queries/price-feed";
-import { NextResponse } from "next/server";
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 export const revalidate = 10;

--- a/src/typescript/frontend/src/app/dev/verify-api-keys/page.tsx
+++ b/src/typescript/frontend/src/app/dev/verify-api-keys/page.tsx
@@ -1,6 +1,6 @@
 import { AccountAddress } from "@aptos-labs/ts-sdk";
-import { VERCEL } from "@sdk/const";
-import { getAptosClient } from "@sdk/utils/aptos-client";
+import { VERCEL } from "@/sdk/const";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 import { CDN_URL } from "lib/env";
 import { getAptPrice } from "lib/queries/get-apt-price";
 

--- a/src/typescript/frontend/src/app/dev/verify-api-keys/page.tsx
+++ b/src/typescript/frontend/src/app/dev/verify-api-keys/page.tsx
@@ -1,10 +1,10 @@
 import { AccountAddress } from "@aptos-labs/ts-sdk";
-import { VERCEL } from "@/sdk/const";
-import { getAptosClient } from "@/sdk/utils/aptos-client";
 import { CDN_URL } from "lib/env";
 import { getAptPrice } from "lib/queries/get-apt-price";
 
 import { fetchMarketsWithCount } from "@/queries/home";
+import { VERCEL } from "@/sdk/const";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 
 export const dynamic = "force-static";
 export const revalidate = 600;

--- a/src/typescript/frontend/src/app/dev/verify-arena-module/check.ts
+++ b/src/typescript/frontend/src/app/dev/verify-arena-module/check.ts
@@ -1,6 +1,6 @@
-import { ARENA_MODULE_ADDRESS, ARENA_MODULE_NAME } from "@sdk/const";
-import { toArenaRegistry } from "@sdk/types/arena-types";
-import { getAptosClient } from "@sdk/utils";
+import { ARENA_MODULE_ADDRESS, ARENA_MODULE_NAME } from "@/sdk/const";
+import { toArenaRegistry } from "@/sdk/types/arena-types";
+import { getAptosClient } from "@/sdk/utils";
 
 import { EmojicoinArena } from "@/contract-apis";
 

--- a/src/typescript/frontend/src/app/dev/verify-arena-module/check.ts
+++ b/src/typescript/frontend/src/app/dev/verify-arena-module/check.ts
@@ -1,8 +1,7 @@
+import { EmojicoinArena } from "@/contract-apis";
 import { ARENA_MODULE_ADDRESS, ARENA_MODULE_NAME } from "@/sdk/const";
 import { toArenaRegistry } from "@/sdk/types/arena-types";
 import { getAptosClient } from "@/sdk/utils";
-
-import { EmojicoinArena } from "@/contract-apis";
 
 const runArenaChecks = async () => {
   const aptos = getAptosClient();

--- a/src/typescript/frontend/src/app/dev/verify-arena-module/page.tsx
+++ b/src/typescript/frontend/src/app/dev/verify-arena-module/page.tsx
@@ -1,4 +1,4 @@
-import { VERCEL } from "@sdk/const";
+import { VERCEL } from "@/sdk/const";
 import FEATURE_FLAGS from "lib/feature-flags";
 
 import runArenaChecks from "./check";

--- a/src/typescript/frontend/src/app/dev/verify-arena-module/page.tsx
+++ b/src/typescript/frontend/src/app/dev/verify-arena-module/page.tsx
@@ -1,5 +1,6 @@
-import { VERCEL } from "@/sdk/const";
 import FEATURE_FLAGS from "lib/feature-flags";
+
+import { VERCEL } from "@/sdk/const";
 
 import runArenaChecks from "./check";
 

--- a/src/typescript/frontend/src/app/home/HomePage.tsx
+++ b/src/typescript/frontend/src/app/home/HomePage.tsx
@@ -1,4 +1,3 @@
-import type { ArenaInfoModel, DatabaseModels, MarketStateModel } from "@/sdk/indexer-v2/types";
 import { ArenaCard } from "components/pages/home/components/arena-card";
 import EmojiTable from "components/pages/home/components/emoji-table";
 import MainCard from "components/pages/home/components/main-card/MainCard";
@@ -8,6 +7,7 @@ import FEATURE_FLAGS from "lib/feature-flags";
 import type { MarketDataSortByHomePage } from "lib/queries/sorting/types";
 
 import { SubscribeToHomePageEvents } from "@/components/pages/home/components/SubscribeToHomePageEvents";
+import type { ArenaInfoModel, DatabaseModels, MarketStateModel } from "@/sdk/indexer-v2/types";
 
 export interface HomePageProps {
   markets: Array<DatabaseModels["market_state"]>;

--- a/src/typescript/frontend/src/app/home/HomePage.tsx
+++ b/src/typescript/frontend/src/app/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import type { ArenaInfoModel, DatabaseModels, MarketStateModel } from "@sdk/indexer-v2/types";
+import type { ArenaInfoModel, DatabaseModels, MarketStateModel } from "@/sdk/indexer-v2/types";
 import { ArenaCard } from "components/pages/home/components/arena-card";
 import EmojiTable from "components/pages/home/components/emoji-table";
 import MainCard from "components/pages/home/components/main-card/MainCard";

--- a/src/typescript/frontend/src/app/home/fetch-melee-data.ts
+++ b/src/typescript/frontend/src/app/home/fetch-melee-data.ts
@@ -1,4 +1,4 @@
-import { fetchArenaInfo, fetchSpecificMarkets } from "@sdk/indexer-v2";
+import { fetchArenaInfo, fetchSpecificMarkets } from "@/sdk/indexer-v2";
 import FEATURE_FLAGS from "lib/feature-flags";
 import { unstable_cache } from "next/cache";
 import { parseJSON, stringifyJSON } from "utils";

--- a/src/typescript/frontend/src/app/home/fetch-melee-data.ts
+++ b/src/typescript/frontend/src/app/home/fetch-melee-data.ts
@@ -1,7 +1,8 @@
-import { fetchArenaInfo, fetchSpecificMarkets } from "@/sdk/indexer-v2";
 import FEATURE_FLAGS from "lib/feature-flags";
 import { unstable_cache } from "next/cache";
 import { parseJSON, stringifyJSON } from "utils";
+
+import { fetchArenaInfo, fetchSpecificMarkets } from "@/sdk/indexer-v2";
 
 const logAndDefault = (e: unknown) => {
   console.error(e);

--- a/src/typescript/frontend/src/app/home/page.tsx
+++ b/src/typescript/frontend/src/app/home/page.tsx
@@ -1,5 +1,5 @@
-import { symbolBytesToEmojis } from "@sdk/emoji_data";
-import { type DatabaseModels, toPriceFeed } from "@sdk/indexer-v2/types";
+import { symbolBytesToEmojis } from "@/sdk/emoji_data";
+import { type DatabaseModels, toPriceFeed } from "@/sdk/indexer-v2/types";
 import { AptPriceContextProvider } from "context/AptPrice";
 import FEATURE_FLAGS from "lib/feature-flags";
 import { getAptPrice } from "lib/queries/get-apt-price";

--- a/src/typescript/frontend/src/app/home/page.tsx
+++ b/src/typescript/frontend/src/app/home/page.tsx
@@ -1,5 +1,3 @@
-import { symbolBytesToEmojis } from "@/sdk/emoji_data";
-import { type DatabaseModels, toPriceFeed } from "@/sdk/indexer-v2/types";
 import { AptPriceContextProvider } from "context/AptPrice";
 import FEATURE_FLAGS from "lib/feature-flags";
 import { getAptPrice } from "lib/queries/get-apt-price";
@@ -9,6 +7,8 @@ import { MARKETS_PER_PAGE } from "lib/queries/sorting/const";
 import { type HomePageParams, toHomePageParamsWithDefault } from "lib/routes/home-page-params";
 
 import { fetchMarkets, fetchMarketsWithCount } from "@/queries/home";
+import { symbolBytesToEmojis } from "@/sdk/emoji_data";
+import { type DatabaseModels, toPriceFeed } from "@/sdk/indexer-v2/types";
 
 import { fetchCachedMeleeData } from "./fetch-melee-data";
 import HomePageComponent from "./HomePage";

--- a/src/typescript/frontend/src/app/launching-soon/page.tsx
+++ b/src/typescript/frontend/src/app/launching-soon/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getRandomChatEmoji } from "@sdk/emoji_data";
+import { getRandomChatEmoji } from "@/sdk/emoji_data";
 import { Text } from "components";
 import React, { useMemo } from "react";
 import { useScramble } from "use-scramble";

--- a/src/typescript/frontend/src/app/launching-soon/page.tsx
+++ b/src/typescript/frontend/src/app/launching-soon/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { getRandomChatEmoji } from "@/sdk/emoji_data";
 import { Text } from "components";
 import React, { useMemo } from "react";
 import { useScramble } from "use-scramble";
+
+import { getRandomChatEmoji } from "@/sdk/emoji_data";
 
 import MatrixRain from "../maintenance/matrix";
 

--- a/src/typescript/frontend/src/app/maintenance/matrix.tsx
+++ b/src/typescript/frontend/src/app/maintenance/matrix.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import useNodeDimensions from "@/hooks/use-node-dimensions";
-import { getRandomSymbolEmoji, type SymbolEmoji } from "@/sdk/emoji_data";
 import React, { useEffect, useRef, useState } from "react";
 import { useInterval } from "react-use";
+
+import useNodeDimensions from "@/hooks/use-node-dimensions";
+import { getRandomSymbolEmoji, type SymbolEmoji } from "@/sdk/emoji_data";
 
 // Constants
 const STREAM_MUTATION_ODDS = 0.02;

--- a/src/typescript/frontend/src/app/maintenance/matrix.tsx
+++ b/src/typescript/frontend/src/app/maintenance/matrix.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import useNodeDimensions from "@hooks/use-node-dimensions";
-import { getRandomSymbolEmoji, type SymbolEmoji } from "@sdk/emoji_data";
+import useNodeDimensions from "@/hooks/use-node-dimensions";
+import { getRandomSymbolEmoji, type SymbolEmoji } from "@/sdk/emoji_data";
 import React, { useEffect, useRef, useState } from "react";
 import { useInterval } from "react-use";
 

--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -1,5 +1,3 @@
-import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
-import { getMarketAddress } from "@/sdk/emojicoin_dot_fun";
 import ClientEmojicoinPage from "components/pages/emojicoin/ClientEmojicoinPage";
 import { AptPriceContextProvider } from "context/AptPrice";
 import FEATURE_FLAGS from "lib/feature-flags";
@@ -11,6 +9,8 @@ import { pathToEmojiNames } from "utils/pathname-helpers";
 
 import { fetchMelee } from "@/queries/arena";
 import { fetchMarketState, fetchSwapEvents } from "@/queries/market";
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
+import { getMarketAddress } from "@/sdk/emojicoin_dot_fun";
 
 import EmojiNotFoundPage from "./not-found";
 

--- a/src/typescript/frontend/src/app/market/[market]/page.tsx
+++ b/src/typescript/frontend/src/app/market/[market]/page.tsx
@@ -1,5 +1,5 @@
-import { SYMBOL_EMOJI_DATA } from "@sdk/emoji_data";
-import { getMarketAddress } from "@sdk/emojicoin_dot_fun";
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
+import { getMarketAddress } from "@/sdk/emojicoin_dot_fun";
 import ClientEmojicoinPage from "components/pages/emojicoin/ClientEmojicoinPage";
 import { AptPriceContextProvider } from "context/AptPrice";
 import FEATURE_FLAGS from "lib/feature-flags";

--- a/src/typescript/frontend/src/app/pools/page.tsx
+++ b/src/typescript/frontend/src/app/pools/page.tsx
@@ -1,10 +1,11 @@
-import { symbolBytesToEmojis } from "@/sdk/emoji_data/utils";
-import { getValidSortByForPoolsPage } from "@/sdk/indexer-v2/queries/query-params";
 import { getPoolData } from "app/api/pools/getPoolDataQuery";
 import ClientPoolsPage, { type PoolsData } from "components/pages/pools/ClientPoolsPage";
 import { handleEmptySearchBytes, safeParsePageWithDefault } from "lib/routes/home-page-params";
 import type { Metadata } from "next";
 import { emoji, parseJSON } from "utils";
+
+import { symbolBytesToEmojis } from "@/sdk/emoji_data/utils";
+import { getValidSortByForPoolsPage } from "@/sdk/indexer-v2/queries/query-params";
 
 export const revalidate = 2;
 

--- a/src/typescript/frontend/src/app/pools/page.tsx
+++ b/src/typescript/frontend/src/app/pools/page.tsx
@@ -1,5 +1,5 @@
-import { symbolBytesToEmojis } from "@sdk/emoji_data/utils";
-import { getValidSortByForPoolsPage } from "@sdk/indexer-v2/queries/query-params";
+import { symbolBytesToEmojis } from "@/sdk/emoji_data/utils";
+import { getValidSortByForPoolsPage } from "@/sdk/indexer-v2/queries/query-params";
 import { getPoolData } from "app/api/pools/getPoolDataQuery";
 import ClientPoolsPage, { type PoolsData } from "components/pages/pools/ClientPoolsPage";
 import { handleEmptySearchBytes, safeParsePageWithDefault } from "lib/routes/home-page-params";

--- a/src/typescript/frontend/src/app/stats/ClientTable.tsx
+++ b/src/typescript/frontend/src/app/stats/ClientTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import AptosIconBlack from "@icons/AptosBlack";
-import type { DatabaseModels } from "@sdk/indexer-v2/types";
+import AptosIconBlack from "@/icons/AptosBlack";
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
 

--- a/src/typescript/frontend/src/app/stats/ClientTable.tsx
+++ b/src/typescript/frontend/src/app/stats/ClientTable.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import AptosIconBlack from "@/icons/AptosBlack";
-import type { DatabaseModels } from "@/sdk/indexer-v2/types";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
+
+import AptosIconBlack from "@/icons/AptosBlack";
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
 
 import { Column, TableData } from "./TableData";
 

--- a/src/typescript/frontend/src/app/stats/GlobalStats.tsx
+++ b/src/typescript/frontend/src/app/stats/GlobalStats.tsx
@@ -1,7 +1,7 @@
-import AptosIconBlack from "@icons/AptosBlack";
-import { ONE_APT_BIGINT } from "@sdk/const";
-import { compareBigInt, compareNumber, sum } from "@sdk/utils";
-import type { AnyNumberString, Types } from "@sdk-types";
+import AptosIconBlack from "@/icons/AptosBlack";
+import { ONE_APT_BIGINT } from "@/sdk/const";
+import { compareBigInt, compareNumber, sum } from "@/sdk/utils";
+import type { AnyNumberString, Types } from "@/sdk-types";
 import Big from "big.js";
 import { MS_IN_ONE_DAY } from "components/charts/const";
 import { cn } from "lib/utils/class-name";

--- a/src/typescript/frontend/src/app/stats/GlobalStats.tsx
+++ b/src/typescript/frontend/src/app/stats/GlobalStats.tsx
@@ -1,12 +1,13 @@
-import AptosIconBlack from "@/icons/AptosBlack";
-import { ONE_APT_BIGINT } from "@/sdk/const";
-import { compareBigInt, compareNumber, sum } from "@/sdk/utils";
-import type { AnyNumberString, Types } from "@/sdk-types";
 import Big from "big.js";
 import { MS_IN_ONE_DAY } from "components/charts/const";
 import { cn } from "lib/utils/class-name";
 import { toCoinDecimalString } from "lib/utils/decimals";
 import { useMemo } from "react";
+
+import AptosIconBlack from "@/icons/AptosBlack";
+import { ONE_APT_BIGINT } from "@/sdk/const";
+import { compareBigInt, compareNumber, sum } from "@/sdk/utils";
+import type { AnyNumberString, Types } from "@/sdk-types";
 
 import type { StatsPageProps } from "./StatsPage";
 

--- a/src/typescript/frontend/src/app/stats/MiniBondingCurveProgress.tsx
+++ b/src/typescript/frontend/src/app/stats/MiniBondingCurveProgress.tsx
@@ -1,5 +1,5 @@
-import type { StateEventData } from "@sdk/indexer-v2/types";
-import { getBondingCurveProgress } from "@sdk/utils";
+import type { StateEventData } from "@/sdk/indexer-v2/types";
+import { getBondingCurveProgress } from "@/sdk/utils";
 import { Progress } from "components/ui/Progress";
 
 export const MiniBondingCurveProgress = ({ state }: { state: StateEventData }) => {

--- a/src/typescript/frontend/src/app/stats/MiniBondingCurveProgress.tsx
+++ b/src/typescript/frontend/src/app/stats/MiniBondingCurveProgress.tsx
@@ -1,6 +1,7 @@
+import { Progress } from "components/ui/Progress";
+
 import type { StateEventData } from "@/sdk/indexer-v2/types";
 import { getBondingCurveProgress } from "@/sdk/utils";
-import { Progress } from "components/ui/Progress";
 
 export const MiniBondingCurveProgress = ({ state }: { state: StateEventData }) => {
   const progress = getBondingCurveProgress(state.clammVirtualReserves.quote);

--- a/src/typescript/frontend/src/app/stats/StatsPage.tsx
+++ b/src/typescript/frontend/src/app/stats/StatsPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { DatabaseModels } from "@sdk/indexer-v2/types";
-import type { Types } from "@sdk-types";
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
+import type { Types } from "@/sdk-types";
 import {
   Select,
   SelectContent,

--- a/src/typescript/frontend/src/app/stats/StatsPage.tsx
+++ b/src/typescript/frontend/src/app/stats/StatsPage.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import type { DatabaseModels } from "@/sdk/indexer-v2/types";
-import type { Types } from "@/sdk-types";
 import {
   Select,
   SelectContent,
@@ -12,6 +10,9 @@ import {
 import { useInView } from "framer-motion";
 import React, { useRef, useState } from "react";
 import { useDebounce } from "react-use";
+
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
+import type { Types } from "@/sdk-types";
 
 import { ClientTable } from "./ClientTable";
 import { GlobalStats } from "./GlobalStats";

--- a/src/typescript/frontend/src/app/stats/TableData.tsx
+++ b/src/typescript/frontend/src/app/stats/TableData.tsx
@@ -1,12 +1,13 @@
-import type { DatabaseModels } from "@/sdk/indexer-v2/types";
-import { calculateCirculatingSupply, calculateCurvePrice } from "@/sdk/markets";
-import { toNominal, toNominalPrice } from "@/sdk/utils";
 import { ExplorerLink } from "components/explorer-link/ExplorerLink";
 import { EXTERNAL_LINK_PROPS } from "components/link/const";
 import { ColoredPriceDisplay } from "components/misc/ColoredPriceDisplay";
 import { PriceDelta } from "components/price-feed/inner";
 import { useCallback, useMemo } from "react";
 import { ROUTES } from "router/routes";
+
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
+import { calculateCirculatingSupply, calculateCurvePrice } from "@/sdk/markets";
+import { toNominal, toNominalPrice } from "@/sdk/utils";
 
 import { MiniBondingCurveProgress } from "./MiniBondingCurveProgress";
 

--- a/src/typescript/frontend/src/app/stats/TableData.tsx
+++ b/src/typescript/frontend/src/app/stats/TableData.tsx
@@ -1,6 +1,6 @@
-import type { DatabaseModels } from "@sdk/indexer-v2/types";
-import { calculateCirculatingSupply, calculateCurvePrice } from "@sdk/markets";
-import { toNominal, toNominalPrice } from "@sdk/utils";
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
+import { calculateCirculatingSupply, calculateCurvePrice } from "@/sdk/markets";
+import { toNominal, toNominalPrice } from "@/sdk/utils";
 import { ExplorerLink } from "components/explorer-link/ExplorerLink";
 import { EXTERNAL_LINK_PROPS } from "components/link/const";
 import { ColoredPriceDisplay } from "components/misc/ColoredPriceDisplay";

--- a/src/typescript/frontend/src/app/stats/page.tsx
+++ b/src/typescript/frontend/src/app/stats/page.tsx
@@ -1,8 +1,8 @@
-import { ORDER_BY } from "@sdk/indexer-v2/const";
-import { toPriceFeed } from "@sdk/indexer-v2/types";
-import { SortMarketsBy } from "@sdk/indexer-v2/types/common";
-import { compareNumber, getAptosClient } from "@sdk/utils";
-import { toRegistryView } from "@sdk-types";
+import { ORDER_BY } from "@/sdk/indexer-v2/const";
+import { toPriceFeed } from "@/sdk/indexer-v2/types";
+import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
+import { compareNumber, getAptosClient } from "@/sdk/utils";
+import { toRegistryView } from "@/sdk-types";
 
 import { RegistryView } from "@/contract-apis";
 import { fetchMarkets, fetchPriceFeedWithMarketState } from "@/queries/home";

--- a/src/typescript/frontend/src/app/stats/page.tsx
+++ b/src/typescript/frontend/src/app/stats/page.tsx
@@ -1,11 +1,10 @@
+import { RegistryView } from "@/contract-apis";
+import { fetchMarkets, fetchPriceFeedWithMarketState } from "@/queries/home";
 import { ORDER_BY } from "@/sdk/indexer-v2/const";
 import { toPriceFeed } from "@/sdk/indexer-v2/types";
 import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import { compareNumber, getAptosClient } from "@/sdk/utils";
 import { toRegistryView } from "@/sdk-types";
-
-import { RegistryView } from "@/contract-apis";
-import { fetchMarkets, fetchPriceFeedWithMarketState } from "@/queries/home";
 
 import StatsPageComponent from "./StatsPage";
 

--- a/src/typescript/frontend/src/app/test-utils/page.tsx
+++ b/src/typescript/frontend/src/app/test-utils/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Network } from "@aptos-labs/ts-sdk";
-import { APTOS_NETWORK } from "@sdk/const";
+import { APTOS_NETWORK } from "@/sdk/const";
 import FEATURE_FLAGS from "lib/feature-flags";
 
 import { MarketAddressConversionForm } from "@/components/pages/test-utils/market-address-conversion";

--- a/src/typescript/frontend/src/app/test-utils/page.tsx
+++ b/src/typescript/frontend/src/app/test-utils/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { Network } from "@aptos-labs/ts-sdk";
-import { APTOS_NETWORK } from "@/sdk/const";
 import FEATURE_FLAGS from "lib/feature-flags";
 
 import { MarketAddressConversionForm } from "@/components/pages/test-utils/market-address-conversion";
 import { SetMeleeDurationForm } from "@/components/pages/test-utils/SetNewMeleeDuration";
+import { APTOS_NETWORK } from "@/sdk/const";
 
 export default function TestUtilsPage() {
   return (

--- a/src/typescript/frontend/src/app/test/route.ts
+++ b/src/typescript/frontend/src/app/test/route.ts
@@ -1,5 +1,6 @@
-import { getAptosClient } from "@/sdk/utils/aptos-client";
 import { NextResponse } from "next/server";
+
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 
 export const revalidate = 2;
 export const fetchCache = "default-cache";

--- a/src/typescript/frontend/src/app/test/route.ts
+++ b/src/typescript/frontend/src/app/test/route.ts
@@ -1,4 +1,4 @@
-import { getAptosClient } from "@sdk/utils/aptos-client";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 import { NextResponse } from "next/server";
 
 export const revalidate = 2;

--- a/src/typescript/frontend/src/app/wallet/utils.ts
+++ b/src/typescript/frontend/src/app/wallet/utils.ts
@@ -1,11 +1,12 @@
 import { AccountAddress, type AccountAddressInput } from "@aptos-labs/ts-sdk";
+import { cache } from "react";
+
 import {
   getAptosClient,
   isValidAptosName,
   removeLeadingZeros,
   type ValidAptosName,
 } from "@/sdk/utils";
-import { cache } from "react";
 
 const INVALID_INPUT_RESULT = {
   address: undefined,

--- a/src/typescript/frontend/src/app/wallet/utils.ts
+++ b/src/typescript/frontend/src/app/wallet/utils.ts
@@ -4,7 +4,7 @@ import {
   isValidAptosName,
   removeLeadingZeros,
   type ValidAptosName,
-} from "@sdk/utils";
+} from "@/sdk/utils";
 import { cache } from "react";
 
 const INVALID_INPUT_RESULT = {

--- a/src/typescript/frontend/src/components/EmojiPill.tsx
+++ b/src/typescript/frontend/src/components/EmojiPill.tsx
@@ -1,7 +1,8 @@
-import type { AnyEmojiName } from "@/sdk/emoji_data/types";
 import type { MouseEventHandler } from "react";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
+
+import type { AnyEmojiName } from "@/sdk/emoji_data/types";
 
 import Popup from "./popup";
 

--- a/src/typescript/frontend/src/components/EmojiPill.tsx
+++ b/src/typescript/frontend/src/components/EmojiPill.tsx
@@ -1,4 +1,4 @@
-import type { AnyEmojiName } from "@sdk/emoji_data/types";
+import type { AnyEmojiName } from "@/sdk/emoji_data/types";
 import type { MouseEventHandler } from "react";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";

--- a/src/typescript/frontend/src/components/FormattedNumber.tsx
+++ b/src/typescript/frontend/src/components/FormattedNumber.tsx
@@ -1,6 +1,7 @@
-import { useLabelScrambler } from "@/hooks/use-label-scrambler";
 import { formatNumberString, type FormatNumberStringProps } from "lib/utils/format-number-string";
 import { useEffect, useMemo } from "react";
+
+import { useLabelScrambler } from "@/hooks/use-label-scrambler";
 
 const ScrambledNumberLabel = ({
   value,

--- a/src/typescript/frontend/src/components/FormattedNumber.tsx
+++ b/src/typescript/frontend/src/components/FormattedNumber.tsx
@@ -1,4 +1,4 @@
-import { useLabelScrambler } from "@hooks/use-label-scrambler";
+import { useLabelScrambler } from "@/hooks/use-label-scrambler";
 import { formatNumberString, type FormatNumberStringProps } from "lib/utils/format-number-string";
 import { useEffect, useMemo } from "react";
 

--- a/src/typescript/frontend/src/components/ProgressBar.tsx
+++ b/src/typescript/frontend/src/components/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import BondingCurveArrow from "@icons/BondingCurveArrow";
+import BondingCurveArrow from "@/icons/BondingCurveArrow";
 import React from "react";
 import { emoji } from "utils";
 import { EmojiAsImage } from "utils/emoji";

--- a/src/typescript/frontend/src/components/ProgressBar.tsx
+++ b/src/typescript/frontend/src/components/ProgressBar.tsx
@@ -1,7 +1,8 @@
-import BondingCurveArrow from "@/icons/BondingCurveArrow";
 import React from "react";
 import { emoji } from "utils";
 import { EmojiAsImage } from "utils/emoji";
+
+import BondingCurveArrow from "@/icons/BondingCurveArrow";
 
 const ProgressBar = ({ length, position }: { length: number; position: number }) => {
   const aspectRatio = (115 / 30) * length;

--- a/src/typescript/frontend/src/components/button/index.tsx
+++ b/src/typescript/frontend/src/components/button/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FlexGap } from "@containers";
+import { FlexGap } from "@/containers";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 import SpinnerIcon from "components/svg/icons/Spinner";
 import Text from "components/text";

--- a/src/typescript/frontend/src/components/button/index.tsx
+++ b/src/typescript/frontend/src/components/button/index.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { FlexGap } from "@/containers";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 import SpinnerIcon from "components/svg/icons/Spinner";
 import Text from "components/text";
 import React from "react";
 import { useScramble, type UseScrambleProps } from "use-scramble";
+
+import { FlexGap } from "@/containers";
 
 import StyledButton from "./styled";
 import type { ButtonProps } from "./types";

--- a/src/typescript/frontend/src/components/carousel/Carousel.tsx
+++ b/src/typescript/frontend/src/components/carousel/Carousel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import useNodeDimensions from "@/hooks/use-node-dimensions";
 import { useEffect, useRef, useState } from "react";
 import { useWindowSize } from "react-use";
+
+import useNodeDimensions from "@/hooks/use-node-dimensions";
 
 import styles from "./Carousel.module.css";
 

--- a/src/typescript/frontend/src/components/carousel/Carousel.tsx
+++ b/src/typescript/frontend/src/components/carousel/Carousel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import useNodeDimensions from "@hooks/use-node-dimensions";
+import useNodeDimensions from "@/hooks/use-node-dimensions";
 import { useEffect, useRef, useState } from "react";
 import { useWindowSize } from "react-use";
 

--- a/src/typescript/frontend/src/components/charts/ChartContainer.tsx
+++ b/src/typescript/frontend/src/components/charts/ChartContainer.tsx
@@ -1,8 +1,9 @@
 // cspell:word datafeeds
-import { symbolToEmojis } from "@/sdk/emoji_data/utils";
 import Loading from "components/loading";
 import Script from "next/script";
 import React, { Suspense, useMemo } from "react";
+
+import { symbolToEmojis } from "@/sdk/emoji_data/utils";
 
 import PrivateChart from "./PrivateChart";
 import type { ChartContainerProps } from "./types";

--- a/src/typescript/frontend/src/components/charts/ChartContainer.tsx
+++ b/src/typescript/frontend/src/components/charts/ChartContainer.tsx
@@ -1,5 +1,5 @@
 // cspell:word datafeeds
-import { symbolToEmojis } from "@sdk/emoji_data/utils";
+import { symbolToEmojis } from "@/sdk/emoji_data/utils";
 import Loading from "components/loading";
 import Script from "next/script";
 import React, { Suspense, useMemo } from "react";

--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -1,4 +1,4 @@
-import { type IChartingLibraryWidget, type Timezone, widget } from "@static/charting_library";
+import { type IChartingLibraryWidget, type Timezone, widget } from "@/static/charting_library";
 import { createSwitch } from "components/charts/EmptyCandlesSwitch";
 import { useUserSettings } from "context/event-store-context";
 import { encodeSymbolsForChart, formatSymbolWithParams } from "lib/chart-utils";

--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -1,9 +1,10 @@
-import { type IChartingLibraryWidget, type Timezone, widget } from "@/static/charting_library";
 import { createSwitch } from "components/charts/EmptyCandlesSwitch";
 import { useUserSettings } from "context/event-store-context";
 import { encodeSymbolsForChart, formatSymbolWithParams } from "lib/chart-utils";
 import { cn } from "lib/utils/class-name";
 import { useEffect, useRef } from "react";
+
+import { type IChartingLibraryWidget, type Timezone, widget } from "@/static/charting_library";
 
 import { BrowserNotSupported } from "./BrowserNotSupported";
 import { WIDGET_OPTIONS } from "./const";

--- a/src/typescript/frontend/src/components/charts/const.ts
+++ b/src/typescript/frontend/src/components/charts/const.ts
@@ -1,12 +1,12 @@
 // cspell:word localstorage
 
-import { ArenaPeriod, Period } from "@sdk/const";
+import { ArenaPeriod, Period } from "@/sdk/const";
 import type {
   ChartingLibraryWidgetOptions,
   LanguageCode,
   ResolutionString,
   ThemeName,
-} from "@static/charting_library";
+} from "@/static/charting_library";
 import { CDN_URL } from "lib/env";
 import { GREEN as GREEN_HEX, PINK as PINK_HEX } from "theme/colors";
 import { hexToRgba } from "utils/hex-to-rgba";

--- a/src/typescript/frontend/src/components/charts/const.ts
+++ b/src/typescript/frontend/src/components/charts/const.ts
@@ -1,5 +1,9 @@
 // cspell:word localstorage
 
+import { CDN_URL } from "lib/env";
+import { GREEN as GREEN_HEX, PINK as PINK_HEX } from "theme/colors";
+import { hexToRgba } from "utils/hex-to-rgba";
+
 import { ArenaPeriod, Period } from "@/sdk/const";
 import type {
   ChartingLibraryWidgetOptions,
@@ -7,9 +11,6 @@ import type {
   ResolutionString,
   ThemeName,
 } from "@/static/charting_library";
-import { CDN_URL } from "lib/env";
-import { GREEN as GREEN_HEX, PINK as PINK_HEX } from "theme/colors";
-import { hexToRgba } from "utils/hex-to-rgba";
 
 export const TV_CHARTING_LIBRARY_RESOLUTIONS = [
   "15S",

--- a/src/typescript/frontend/src/components/charts/get-bars.ts
+++ b/src/typescript/frontend/src/components/charts/get-bars.ts
@@ -4,19 +4,19 @@ import {
   type PeriodDuration,
   periodEnumToRawDuration,
   Trigger,
-} from "@sdk/const";
-import { toMarketEmojiData } from "@sdk/emoji_data/utils";
+} from "@/sdk/const";
+import { toMarketEmojiData } from "@/sdk/emoji_data/utils";
 import type {
   ArenaCandlestickModel,
   MarketMetadataModel,
   PeriodicStateEventModel,
-} from "@sdk/indexer-v2";
-import { getMarketResource } from "@sdk/markets/utils";
-import { getAptosClient } from "@sdk/utils/aptos-client";
-import { getPeriodStartTimeFromTime } from "@sdk/utils/misc";
-import type { XOR } from "@sdk/utils/utility-types";
-import type { Flatten, Types } from "@sdk-types";
-import type { Bar, PeriodParams } from "@static/charting_library";
+} from "@/sdk/indexer-v2";
+import { getMarketResource } from "@/sdk/markets/utils";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
+import { getPeriodStartTimeFromTime } from "@/sdk/utils/misc";
+import type { XOR } from "@/sdk/utils/utility-types";
+import type { Flatten, Types } from "@/sdk-types";
+import type { Bar, PeriodParams } from "@/static/charting_library";
 import { type ArenaChartSymbol, hasTradingActivity, isArenaChartSymbol } from "lib/chart-utils";
 import { ROUTES } from "router/routes";
 import { fetchRateLimited } from "utils";

--- a/src/typescript/frontend/src/components/charts/get-bars.ts
+++ b/src/typescript/frontend/src/components/charts/get-bars.ts
@@ -1,3 +1,7 @@
+import { type ArenaChartSymbol, hasTradingActivity, isArenaChartSymbol } from "lib/chart-utils";
+import { ROUTES } from "router/routes";
+import { fetchRateLimited } from "utils";
+
 import {
   type ArenaPeriod,
   type Period,
@@ -17,10 +21,6 @@ import { getPeriodStartTimeFromTime } from "@/sdk/utils/misc";
 import type { XOR } from "@/sdk/utils/utility-types";
 import type { Flatten, Types } from "@/sdk-types";
 import type { Bar, PeriodParams } from "@/static/charting_library";
-import { type ArenaChartSymbol, hasTradingActivity, isArenaChartSymbol } from "lib/chart-utils";
-import { ROUTES } from "router/routes";
-import { fetchRateLimited } from "utils";
-
 import {
   marketToLatestBars,
   periodicStateTrackerToLatestBar,

--- a/src/typescript/frontend/src/components/charts/trading-view-utils.ts
+++ b/src/typescript/frontend/src/components/charts/trading-view-utils.ts
@@ -2,15 +2,15 @@
 // cspell:word minmov
 // cspell:word pricescale
 
+import { getClientTimezone } from "lib/chart-utils";
+import { emojisToName } from "lib/utils/emojis-to-name-or-symbol";
+
 import type {
   DatafeedConfiguration,
   LibrarySymbolInfo,
   SearchSymbolResultItem,
   Timezone,
 } from "@/static/charting_library";
-import { getClientTimezone } from "lib/chart-utils";
-import { emojisToName } from "lib/utils/emojis-to-name-or-symbol";
-
 import type { EventStore } from "@/store/event/types";
 
 import { EXCHANGE_NAME, TV_CHARTING_LIBRARY_RESOLUTIONS } from "./const";

--- a/src/typescript/frontend/src/components/charts/trading-view-utils.ts
+++ b/src/typescript/frontend/src/components/charts/trading-view-utils.ts
@@ -7,7 +7,7 @@ import type {
   LibrarySymbolInfo,
   SearchSymbolResultItem,
   Timezone,
-} from "@static/charting_library";
+} from "@/static/charting_library";
 import { getClientTimezone } from "lib/chart-utils";
 import { emojisToName } from "lib/utils/emojis-to-name-or-symbol";
 

--- a/src/typescript/frontend/src/components/charts/use-datafeed.ts
+++ b/src/typescript/frontend/src/components/charts/use-datafeed.ts
@@ -1,5 +1,5 @@
-import { isNonArenaPeriod, periodEnumToRawDuration } from "@sdk/const";
-import type { Bar, IBasicDataFeed } from "@static/charting_library";
+import { isNonArenaPeriod, periodEnumToRawDuration } from "@/sdk/const";
+import type { Bar, IBasicDataFeed } from "@/static/charting_library";
 import { useEventStore, useUserSettings } from "context/event-store-context";
 import { decodeSymbolsForChart, isArenaChartSymbol, parseSymbolWithParams } from "lib/chart-utils";
 import { useRouter } from "next/navigation";

--- a/src/typescript/frontend/src/components/charts/use-datafeed.ts
+++ b/src/typescript/frontend/src/components/charts/use-datafeed.ts
@@ -1,11 +1,12 @@
-import { isNonArenaPeriod, periodEnumToRawDuration } from "@/sdk/const";
-import type { Bar, IBasicDataFeed } from "@/static/charting_library";
 import { useEventStore, useUserSettings } from "context/event-store-context";
 import { decodeSymbolsForChart, isArenaChartSymbol, parseSymbolWithParams } from "lib/chart-utils";
 import { useRouter } from "next/navigation";
 import path from "path";
 import { useMemo } from "react";
 import { ROUTES } from "router/routes";
+
+import { isNonArenaPeriod, periodEnumToRawDuration } from "@/sdk/const";
+import type { Bar, IBasicDataFeed } from "@/static/charting_library";
 
 import { ResolutionStringToPeriod } from "./const";
 import {

--- a/src/typescript/frontend/src/components/emoji-picker/ColoredBytesIndicator.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/ColoredBytesIndicator.tsx
@@ -1,4 +1,4 @@
-import { sumBytes } from "@sdk/utils/sum-emoji-bytes";
+import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 import { MAX_NUM_CHAT_EMOJIS, MAX_SYMBOL_LENGTH } from "components/pages/emoji-picker/const";
 import { AnimatedLoadingBoxes } from "components/pages/launch-emojicoin/animated-loading-boxes";
 import { useEmojiPicker } from "context/emoji-picker-context";

--- a/src/typescript/frontend/src/components/emoji-picker/ColoredBytesIndicator.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/ColoredBytesIndicator.tsx
@@ -1,9 +1,10 @@
-import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 import { MAX_NUM_CHAT_EMOJIS, MAX_SYMBOL_LENGTH } from "components/pages/emoji-picker/const";
 import { AnimatedLoadingBoxes } from "components/pages/launch-emojicoin/animated-loading-boxes";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
+
+import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 
 const isInvalidLength = (sum: number, threshold: number) => {
   return sum === 0 || sum > threshold;

--- a/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
@@ -1,9 +1,9 @@
 import "./triangle.css";
 
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import { Flex } from "@containers";
-import ClosePixelated from "@icons/ClosePixelated";
-import { getEmojisInString } from "@sdk/emoji_data";
+import { Flex } from "@/containers";
+import ClosePixelated from "@/icons/ClosePixelated";
+import { getEmojisInString } from "@/sdk/emoji_data";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import { InputGroup, Textarea } from "components/inputs";
 import { MAX_NUM_CHAT_EMOJIS } from "components/pages/emoji-picker/const";

--- a/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
@@ -1,9 +1,6 @@
 import "./triangle.css";
 
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import { Flex } from "@/containers";
-import ClosePixelated from "@/icons/ClosePixelated";
-import { getEmojisInString } from "@/sdk/emoji_data";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import { InputGroup, Textarea } from "components/inputs";
 import { MAX_NUM_CHAT_EMOJIS } from "components/pages/emoji-picker/const";
@@ -16,6 +13,10 @@ import { cn } from "lib/utils/class-name";
 import React, { useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { isDisallowedEventKey } from "utils";
+
+import { Flex } from "@/containers";
+import ClosePixelated from "@/icons/ClosePixelated";
+import { getEmojisInString } from "@/sdk/emoji_data";
 
 import { variants } from "./animation-variants";
 import { MarketValidityIndicator } from "./ColoredBytesIndicator";

--- a/src/typescript/frontend/src/components/explorer-link/ExplorerLink.tsx
+++ b/src/typescript/frontend/src/components/explorer-link/ExplorerLink.tsx
@@ -1,4 +1,4 @@
-import type { AnyNumberString } from "@sdk-types";
+import type { AnyNumberString } from "@/sdk-types";
 import { toExplorerLink } from "lib/utils/explorer-link";
 
 import { EXTERNAL_LINK_PROPS } from "../link/const";

--- a/src/typescript/frontend/src/components/explorer-link/ExplorerLink.tsx
+++ b/src/typescript/frontend/src/components/explorer-link/ExplorerLink.tsx
@@ -1,5 +1,6 @@
-import type { AnyNumberString } from "@/sdk-types";
 import { toExplorerLink } from "lib/utils/explorer-link";
+
+import type { AnyNumberString } from "@/sdk-types";
 
 import { EXTERNAL_LINK_PROPS } from "../link/const";
 

--- a/src/typescript/frontend/src/components/footer/components/social-links/index.tsx
+++ b/src/typescript/frontend/src/components/footer/components/social-links/index.tsx
@@ -1,4 +1,4 @@
-import { FlexGap } from "@containers";
+import { FlexGap } from "@/containers";
 import { SOCIAL_ICONS } from "components/footer/constants";
 import type { FlexGapProps } from "components/layout/components/types";
 import React from "react";

--- a/src/typescript/frontend/src/components/footer/components/social-links/index.tsx
+++ b/src/typescript/frontend/src/components/footer/components/social-links/index.tsx
@@ -1,7 +1,8 @@
-import { FlexGap } from "@/containers";
 import { SOCIAL_ICONS } from "components/footer/constants";
 import type { FlexGapProps } from "components/layout/components/types";
 import React from "react";
+
+import { FlexGap } from "@/containers";
 
 import { StyledIcon } from "./styled";
 

--- a/src/typescript/frontend/src/components/footer/constants.tsx
+++ b/src/typescript/frontend/src/components/footer/constants.tsx
@@ -1,4 +1,4 @@
-import Discord from "@icons/Discord";
+import Discord from "@/icons/Discord";
 import Twitter from "components/svg/icons/Twitter";
 import { LINKS } from "lib/env";
 import { ROUTES } from "router/routes";

--- a/src/typescript/frontend/src/components/footer/constants.tsx
+++ b/src/typescript/frontend/src/components/footer/constants.tsx
@@ -1,7 +1,8 @@
-import Discord from "@/icons/Discord";
 import Twitter from "components/svg/icons/Twitter";
 import { LINKS } from "lib/env";
 import { ROUTES } from "router/routes";
+
+import Discord from "@/icons/Discord";
 
 export const SOCIAL_ICONS = [
   { icon: Discord, href: LINKS?.discord ?? ROUTES["not-found"] },

--- a/src/typescript/frontend/src/components/footer/index.tsx
+++ b/src/typescript/frontend/src/components/footer/index.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Container, Flex, FlexGap } from "@/containers";
 import LogoIcon from "components/svg/icons/LogoIcon";
 import Text from "components/text";
 import { LINKS } from "lib/env";
 import Link from "next/link";
 import React from "react";
 import { ROUTES } from "router/routes";
+
+import { Container, Flex, FlexGap } from "@/containers";
 
 import { SocialLinks } from "./components/social-links";
 import { StyledClickItem, StyledContainer, StyledSocialWrapper } from "./styled";

--- a/src/typescript/frontend/src/components/footer/index.tsx
+++ b/src/typescript/frontend/src/components/footer/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Container, Flex, FlexGap } from "@containers";
+import { Container, Flex, FlexGap } from "@/containers";
 import LogoIcon from "components/svg/icons/LogoIcon";
 import Text from "components/text";
 import { LINKS } from "lib/env";

--- a/src/typescript/frontend/src/components/geoblocking/index.tsx
+++ b/src/typescript/frontend/src/components/geoblocking/index.tsx
@@ -1,4 +1,4 @@
-import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
 import Carousel from "components/carousel";
 import Text from "components/text";
 import React from "react";

--- a/src/typescript/frontend/src/components/geoblocking/index.tsx
+++ b/src/typescript/frontend/src/components/geoblocking/index.tsx
@@ -1,7 +1,8 @@
-import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
 import Carousel from "components/carousel";
 import Text from "components/text";
 import React from "react";
+
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
 
 export const GeoblockedBanner = () => {
   // Don't show the banner unless `geoblocked` is explicitly true, not just true or undefined.

--- a/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
@@ -1,4 +1,4 @@
-import { FlexGap } from "@containers";
+import { FlexGap } from "@/containers";
 import Text from "components/text";
 import { translationFunction } from "context/language-context";
 import React from "react";

--- a/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/menu-item/index.tsx
@@ -1,8 +1,9 @@
-import { FlexGap } from "@/containers";
 import Text from "components/text";
 import { translationFunction } from "context/language-context";
 import React from "react";
 import { useScramble } from "use-scramble";
+
+import { FlexGap } from "@/containers";
 
 import type { MenuItemProps } from "./types";
 

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/components/mobile-social-links/constants.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/components/mobile-social-links/constants.tsx
@@ -1,7 +1,8 @@
-import DiscordOutlineIcon from "@/icons/DiscordOutlineIcon";
 import TwitterOutlineIcon from "components/svg/icons/TwitterOutlineIcon";
 import { LINKS } from "lib/env";
 import { ROUTES } from "router/routes";
+
+import DiscordOutlineIcon from "@/icons/DiscordOutlineIcon";
 
 export const SOCIAL_ICONS = [
   { icon: DiscordOutlineIcon, href: LINKS?.discord ?? ROUTES["not-found"] },

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/components/mobile-social-links/constants.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/components/mobile-social-links/constants.tsx
@@ -1,4 +1,4 @@
-import DiscordOutlineIcon from "@icons/DiscordOutlineIcon";
+import DiscordOutlineIcon from "@/icons/DiscordOutlineIcon";
 import TwitterOutlineIcon from "components/svg/icons/TwitterOutlineIcon";
 import { LINKS } from "lib/env";
 import { ROUTES } from "router/routes";

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/components/mobile-social-links/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/components/mobile-social-links/index.tsx
@@ -1,4 +1,4 @@
-import { FlexGap } from "@containers";
+import { FlexGap } from "@/containers";
 import type { FlexGapProps } from "components/layout/components/types";
 import React from "react";
 

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/components/mobile-social-links/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/components/mobile-social-links/index.tsx
@@ -1,6 +1,7 @@
-import { FlexGap } from "@/containers";
 import type { FlexGapProps } from "components/layout/components/types";
 import React from "react";
+
+import { FlexGap } from "@/containers";
 
 import { SOCIAL_ICONS } from "./constants";
 import { StyledIcon } from "./styled";

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -3,7 +3,7 @@ import {
   isAptosConnectWallet,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
-import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
 import { Badge } from "components/Badge";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import { EXTERNAL_LINK_PROPS, Link } from "components/link";

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -3,7 +3,6 @@ import {
   isAptosConnectWallet,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
-import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
 import { Badge } from "components/Badge";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import { EXTERNAL_LINK_PROPS, Link } from "components/link";
@@ -14,6 +13,8 @@ import { Copy, LogOut, User, UserRound } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useEffect, useState } from "react";
 import { ROUTES } from "router/routes";
+
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
 
 import { MobileMenuItem } from "../index";
 import { slideVariants } from "./animations";

--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Container, Flex, FlexGap } from "@/containers";
 import { Badge } from "components/Badge";
 import Button from "components/button";
 import MenuItem from "components/header/components/menu-item";
@@ -13,6 +12,8 @@ import Link, { type LinkProps } from "next/link";
 import { useSearchParams } from "next/navigation";
 import React, { useCallback, useMemo, useState } from "react";
 import { ROUTES } from "router/routes";
+
+import { Container, Flex, FlexGap } from "@/containers";
 
 import CloseIcon from "../svg/icons/Close";
 import LogoIcon from "../svg/icons/LogoIcon";

--- a/src/typescript/frontend/src/components/header/index.tsx
+++ b/src/typescript/frontend/src/components/header/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Container, Flex, FlexGap } from "@containers";
+import { Container, Flex, FlexGap } from "@/containers";
 import { Badge } from "components/Badge";
 import Button from "components/button";
 import MenuItem from "components/header/components/menu-item";

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -1,14 +1,15 @@
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { Button } from "@headlessui/react";
-import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
-import Arrow from "@/icons/Arrow";
-import { formatDisplayName } from "@/sdk/utils/misc";
 import Popup from "components/popup";
 import { translationFunction } from "context/language-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useWalletModal } from "context/wallet-context/WalletModalContext";
 import { type PropsWithChildren, useMemo, useState } from "react";
 import { useScramble } from "use-scramble";
+
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
+import Arrow from "@/icons/Arrow";
+import { formatDisplayName } from "@/sdk/utils/misc";
 
 import OuterConnectText from "./OuterConnectText";
 

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -1,8 +1,8 @@
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { Button } from "@headlessui/react";
-import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
-import Arrow from "@icons/Arrow";
-import { formatDisplayName } from "@sdk/utils/misc";
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
+import Arrow from "@/icons/Arrow";
+import { formatDisplayName } from "@/sdk/utils/misc";
 import Popup from "components/popup";
 import { translationFunction } from "context/language-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";

--- a/src/typescript/frontend/src/components/inputs/input-group/styled.tsx
+++ b/src/typescript/frontend/src/components/inputs/input-group/styled.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@containers";
+import { Box } from "@/containers";
 import { type Scales, scales as inputScales } from "components/inputs/input/types";
 import Text from "components/text";
 import styled, { css, type DefaultTheme } from "styled-components";

--- a/src/typescript/frontend/src/components/inputs/input-group/styled.tsx
+++ b/src/typescript/frontend/src/components/inputs/input-group/styled.tsx
@@ -1,7 +1,8 @@
-import { Box } from "@/containers";
 import { type Scales, scales as inputScales } from "components/inputs/input/types";
 import Text from "components/text";
 import styled, { css, type DefaultTheme } from "styled-components";
+
+import { Box } from "@/containers";
 
 import type {
   InputGroupProps,

--- a/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
+++ b/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
@@ -1,4 +1,4 @@
-import { countDigitsAfterDecimal, isNumberInConstruction, sanitizeNumber } from "@sdk/utils";
+import { countDigitsAfterDecimal, isNumberInConstruction, sanitizeNumber } from "@/sdk/utils";
 import Big from "big.js";
 import React, { useEffect, useState } from "react";
 

--- a/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
+++ b/src/typescript/frontend/src/components/inputs/input-numeric/index.tsx
@@ -1,6 +1,7 @@
-import { countDigitsAfterDecimal, isNumberInConstruction, sanitizeNumber } from "@/sdk/utils";
 import Big from "big.js";
 import React, { useEffect, useState } from "react";
+
+import { countDigitsAfterDecimal, isNumberInConstruction, sanitizeNumber } from "@/sdk/utils";
 
 const intToStr = (value: bigint, decimals?: number) =>
   (Number(value) / 10 ** (decimals ?? 0)).toString();

--- a/src/typescript/frontend/src/components/layout/components/containers/index.tsx
+++ b/src/typescript/frontend/src/components/layout/components/containers/index.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import type { BoxProps, BoxThemedProps, ColumnProps, FlexGapProps, FlexProps } from "@/containers";
 import React, { type PropsWithChildren } from "react";
 import styled, { css } from "styled-components";
 import { border, flexbox, layout, position, space, system } from "styled-system";
 import { siteWidth } from "theme/base";
+
+import type { BoxProps, BoxThemedProps, ColumnProps, FlexGapProps, FlexProps } from "@/containers";
 
 const getEllipsis = ({ ellipsis }: BoxThemedProps) => {
   if (ellipsis) {

--- a/src/typescript/frontend/src/components/layout/components/containers/index.tsx
+++ b/src/typescript/frontend/src/components/layout/components/containers/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { BoxProps, BoxThemedProps, ColumnProps, FlexGapProps, FlexProps } from "@containers";
+import type { BoxProps, BoxThemedProps, ColumnProps, FlexGapProps, FlexProps } from "@/containers";
 import React, { type PropsWithChildren } from "react";
 import styled, { css } from "styled-components";
 import { border, flexbox, layout, position, space, system } from "styled-system";

--- a/src/typescript/frontend/src/components/layout/components/page/index.tsx
+++ b/src/typescript/frontend/src/components/layout/components/page/index.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Container } from "@/containers";
 import React from "react";
+
+import { Container } from "@/containers";
 
 import type { PageProps } from "../types";
 

--- a/src/typescript/frontend/src/components/layout/components/page/index.tsx
+++ b/src/typescript/frontend/src/components/layout/components/page/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Container } from "@containers";
+import { Container } from "@/containers";
 import React from "react";
 
 import type { PageProps } from "../types";

--- a/src/typescript/frontend/src/components/loader/index.tsx
+++ b/src/typescript/frontend/src/components/loader/index.tsx
@@ -1,7 +1,8 @@
-import { Flex } from "@/containers";
 import type { FlexProps } from "components/layout/components/types";
 import SpinnerIcon from "components/svg/icons/Spinner";
 import React from "react";
+
+import { Flex } from "@/containers";
 
 const Loader: React.FC<FlexProps> = (props) => {
   return (

--- a/src/typescript/frontend/src/components/loader/index.tsx
+++ b/src/typescript/frontend/src/components/loader/index.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@containers";
+import { Flex } from "@/containers";
 import type { FlexProps } from "components/layout/components/types";
 import SpinnerIcon from "components/svg/icons/Spinner";
 import React from "react";

--- a/src/typescript/frontend/src/components/loading.tsx
+++ b/src/typescript/frontend/src/components/loading.tsx
@@ -1,7 +1,7 @@
 "use client";
 // cspell:word unpathify
 
-import { getRandomSymbolEmoji, SYMBOL_EMOJI_DATA, type SymbolEmojiData } from "@sdk/emoji_data";
+import { getRandomSymbolEmoji, SYMBOL_EMOJI_DATA, type SymbolEmojiData } from "@/sdk/emoji_data";
 import { usePathname } from "next/navigation";
 import React, { useEffect, useMemo } from "react";
 import { Emoji } from "utils/emoji";

--- a/src/typescript/frontend/src/components/loading.tsx
+++ b/src/typescript/frontend/src/components/loading.tsx
@@ -1,11 +1,12 @@
 "use client";
 // cspell:word unpathify
 
-import { getRandomSymbolEmoji, SYMBOL_EMOJI_DATA, type SymbolEmojiData } from "@/sdk/emoji_data";
 import { usePathname } from "next/navigation";
 import React, { useEffect, useMemo } from "react";
 import { Emoji } from "utils/emoji";
 import { EMOJI_PATH_INTRA_SEGMENT_DELIMITER, ONE_SPACE } from "utils/pathname-helpers";
+
+import { getRandomSymbolEmoji, SYMBOL_EMOJI_DATA, type SymbolEmojiData } from "@/sdk/emoji_data";
 
 import AnimatedEmojiCircle from "./pages/launch-emojicoin/animated-emoji-circle";
 

--- a/src/typescript/frontend/src/components/misc/ColoredPriceDisplay.tsx
+++ b/src/typescript/frontend/src/components/misc/ColoredPriceDisplay.tsx
@@ -1,9 +1,10 @@
-import type { AnyNumber } from "@/sdk/emojicoin_dot_fun/types";
-import { toNominalPrice } from "@/sdk/utils";
 import type { ClassValue } from "clsx";
 import { cn } from "lib/utils/class-name";
 import { formatNumberString, type FormatNumberStringProps } from "lib/utils/format-number-string";
 import React, { type HTMLAttributes } from "react";
+
+import type { AnyNumber } from "@/sdk/emojicoin_dot_fun/types";
+import { toNominalPrice } from "@/sdk/utils";
 
 type PriceColors = "neutral" | "buy" | "sell";
 export const PriceColors: { [key in PriceColors]: { color: ClassValue; brightness: ClassValue } } =

--- a/src/typescript/frontend/src/components/misc/ColoredPriceDisplay.tsx
+++ b/src/typescript/frontend/src/components/misc/ColoredPriceDisplay.tsx
@@ -1,5 +1,5 @@
-import type { AnyNumber } from "@sdk/emojicoin_dot_fun/types";
-import { toNominalPrice } from "@sdk/utils";
+import type { AnyNumber } from "@/sdk/emojicoin_dot_fun/types";
+import { toNominalPrice } from "@/sdk/utils";
 import type { ClassValue } from "clsx";
 import { cn } from "lib/utils/class-name";
 import { formatNumberString, type FormatNumberStringProps } from "lib/utils/format-number-string";

--- a/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
+++ b/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { getRandomSymbolEmoji } from "@/sdk/emoji_data";
 import React, { useEffect, useMemo, useState } from "react";
 import { useWindowSize } from "react-use";
 import { Emoji } from "utils/emoji";
+
+import { getRandomSymbolEmoji } from "@/sdk/emoji_data";
 
 const MemoizedRandomEmoji = React.memo(OneRandomEmoji);
 

--- a/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
+++ b/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getRandomSymbolEmoji } from "@sdk/emoji_data";
+import { getRandomSymbolEmoji } from "@/sdk/emoji_data";
 import React, { useEffect, useMemo, useState } from "react";
 import { useWindowSize } from "react-use";
 import { Emoji } from "utils/emoji";

--- a/src/typescript/frontend/src/components/modal/BaseModal.tsx
+++ b/src/typescript/frontend/src/components/modal/BaseModal.tsx
@@ -1,7 +1,8 @@
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
-import ClosePixelated from "@/icons/ClosePixelated";
 import { Arrow } from "components/svg";
 import React, { Fragment, type PropsWithChildren } from "react";
+
+import ClosePixelated from "@/icons/ClosePixelated";
 
 export const BaseModal: React.FC<
   PropsWithChildren<{

--- a/src/typescript/frontend/src/components/modal/BaseModal.tsx
+++ b/src/typescript/frontend/src/components/modal/BaseModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
-import ClosePixelated from "@icons/ClosePixelated";
+import ClosePixelated from "@/icons/ClosePixelated";
 import { Arrow } from "components/svg";
 import React, { Fragment, type PropsWithChildren } from "react";
 

--- a/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
@@ -1,12 +1,5 @@
 "use client";
 
-import { useMatchBreakpoints } from "@/hooks/index";
-import { useLatestMeleeID } from "@/hooks/use-latest-melee-id";
-import { useReliableSubscribe } from "@/hooks/use-reliable-subscribe";
-import type {
-  ArenaLeaderboardHistoryWithArenaInfoModel,
-  ArenaPositionModel,
-} from "@/sdk/indexer-v2/types";
 import type { ClassValue } from "clsx";
 import { Countdown } from "components/Countdown";
 import { FormattedNumber } from "components/FormattedNumber";
@@ -19,6 +12,13 @@ import { ROUTES } from "router/routes";
 import { parseJSON } from "utils";
 
 import ChartContainer from "@/components/charts/ChartContainer";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { useLatestMeleeID } from "@/hooks/use-latest-melee-id";
+import { useReliableSubscribe } from "@/hooks/use-reliable-subscribe";
+import type {
+  ArenaLeaderboardHistoryWithArenaInfoModel,
+  ArenaPositionModel,
+} from "@/sdk/indexer-v2/types";
 
 import { BottomNavigation, TabContainer } from "./tabs";
 import {

--- a/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useMatchBreakpoints } from "@hooks/index";
-import { useLatestMeleeID } from "@hooks/use-latest-melee-id";
-import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { useLatestMeleeID } from "@/hooks/use-latest-melee-id";
+import { useReliableSubscribe } from "@/hooks/use-reliable-subscribe";
 import type {
   ArenaLeaderboardHistoryWithArenaInfoModel,
   ArenaPositionModel,
-} from "@sdk/indexer-v2/types";
+} from "@/sdk/indexer-v2/types";
 import type { ClassValue } from "clsx";
 import { Countdown } from "components/Countdown";
 import { FormattedNumber } from "components/FormattedNumber";

--- a/src/typescript/frontend/src/components/pages/arena/tabs/EnterTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/EnterTab.tsx
@@ -1,7 +1,4 @@
 import { isUserTransactionResponse, type UserTransactionResponse } from "@aptos-labs/ts-sdk";
-import { ARENA_MODULE_ADDRESS } from "@/sdk/const";
-import type { ArenaPositionModel, MarketStateModel } from "@/sdk/indexer-v2/types";
-import { q64ToBig } from "@/sdk/utils";
 import Button from "components/button";
 import { FormattedNumber } from "components/FormattedNumber";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
@@ -18,6 +15,10 @@ import { useExitTransactionBuilder } from "lib/hooks/transaction-builders/use-ex
 import React, { type PropsWithChildren, useCallback, useEffect, useState } from "react";
 import { emoji } from "utils";
 import { GlowingEmoji } from "utils/emoji";
+
+import { ARENA_MODULE_ADDRESS } from "@/sdk/const";
+import type { ArenaPositionModel, MarketStateModel } from "@/sdk/indexer-v2/types";
+import { q64ToBig } from "@/sdk/utils";
 
 import { EmojiTitle, lockedTernary, marketTernary } from "../utils";
 

--- a/src/typescript/frontend/src/components/pages/arena/tabs/EnterTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/EnterTab.tsx
@@ -1,7 +1,7 @@
 import { isUserTransactionResponse, type UserTransactionResponse } from "@aptos-labs/ts-sdk";
-import { ARENA_MODULE_ADDRESS } from "@sdk/const";
-import type { ArenaPositionModel, MarketStateModel } from "@sdk/indexer-v2/types";
-import { q64ToBig } from "@sdk/utils";
+import { ARENA_MODULE_ADDRESS } from "@/sdk/const";
+import type { ArenaPositionModel, MarketStateModel } from "@/sdk/indexer-v2/types";
+import { q64ToBig } from "@/sdk/utils";
 import Button from "components/button";
 import { FormattedNumber } from "components/FormattedNumber";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";

--- a/src/typescript/frontend/src/components/pages/arena/tabs/ProfileTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/ProfileTab.tsx
@@ -1,11 +1,3 @@
-import { useMatchBreakpoints } from "@/hooks/index";
-import type {
-  ArenaInfoModel,
-  ArenaLeaderboardHistoryWithArenaInfoModel,
-  ArenaPositionModel,
-  MarketStateModel,
-} from "@/sdk/indexer-v2/types";
-import { q64ToBig } from "@/sdk/utils";
 import Big from "big.js";
 import Button from "components/button";
 import { FormattedNumber } from "components/FormattedNumber";
@@ -14,6 +6,15 @@ import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useExitTransactionBuilder } from "lib/hooks/transaction-builders/use-exit-builder";
 import { useMemo, useState } from "react";
 import { Emoji } from "utils/emoji";
+
+import { useMatchBreakpoints } from "@/hooks/index";
+import type {
+  ArenaInfoModel,
+  ArenaLeaderboardHistoryWithArenaInfoModel,
+  ArenaPositionModel,
+  MarketStateModel,
+} from "@/sdk/indexer-v2/types";
+import { q64ToBig } from "@/sdk/utils";
 
 import styles from "./ProfileTab.module.css";
 

--- a/src/typescript/frontend/src/components/pages/arena/tabs/ProfileTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/ProfileTab.tsx
@@ -1,11 +1,11 @@
-import { useMatchBreakpoints } from "@hooks/index";
+import { useMatchBreakpoints } from "@/hooks/index";
 import type {
   ArenaInfoModel,
   ArenaLeaderboardHistoryWithArenaInfoModel,
   ArenaPositionModel,
   MarketStateModel,
-} from "@sdk/indexer-v2/types";
-import { q64ToBig } from "@sdk/utils";
+} from "@/sdk/indexer-v2/types";
+import { q64ToBig } from "@/sdk/utils";
 import Big from "big.js";
 import Button from "components/button";
 import { FormattedNumber } from "components/FormattedNumber";

--- a/src/typescript/frontend/src/components/pages/arena/utils.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/utils.tsx
@@ -1,3 +1,8 @@
+import type { ClassValue } from "clsx";
+import React, { useState } from "react";
+import darkTheme from "theme/dark";
+import { GlowingEmoji } from "utils/emoji";
+
 import { useMatchBreakpoints } from "@/hooks/index";
 import type {
   ArenaInfoModel,
@@ -5,10 +10,6 @@ import type {
   ArenaPositionModel,
   MarketStateModel,
 } from "@/sdk/indexer-v2/types";
-import type { ClassValue } from "clsx";
-import React, { useState } from "react";
-import darkTheme from "theme/dark";
-import { GlowingEmoji } from "utils/emoji";
 
 export type ArenaProps = {
   arenaInfo: ArenaInfoModel;

--- a/src/typescript/frontend/src/components/pages/arena/utils.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/utils.tsx
@@ -1,10 +1,10 @@
-import { useMatchBreakpoints } from "@hooks/index";
+import { useMatchBreakpoints } from "@/hooks/index";
 import type {
   ArenaInfoModel,
   ArenaLeaderboardHistoryWithArenaInfoModel,
   ArenaPositionModel,
   MarketStateModel,
-} from "@sdk/indexer-v2/types";
+} from "@/sdk/indexer-v2/types";
 import type { ClassValue } from "clsx";
 import React, { useState } from "react";
 import darkTheme from "theme/dark";

--- a/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
+++ b/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
@@ -2,10 +2,10 @@
 // cspell:word couldn
 
 import { default as Picker } from "@emoji-mart/react";
-import RoundButton from "@icons/Minimize";
-import { MAX_SYMBOL_LENGTH } from "@sdk/const";
-import { getEmojiData, isSymbolEmoji, isValidChatMessageEmoji } from "@sdk/emoji_data";
-import { sumBytes } from "@sdk/utils/sum-emoji-bytes";
+import RoundButton from "@/icons/Minimize";
+import { MAX_SYMBOL_LENGTH } from "@/sdk/const";
+import { getEmojiData, isSymbolEmoji, isValidChatMessageEmoji } from "@/sdk/emoji_data";
+import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import {
   type HTMLAttributes,

--- a/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
+++ b/src/typescript/frontend/src/components/pages/emoji-picker/EmojiPicker.tsx
@@ -2,10 +2,6 @@
 // cspell:word couldn
 
 import { default as Picker } from "@emoji-mart/react";
-import RoundButton from "@/icons/Minimize";
-import { MAX_SYMBOL_LENGTH } from "@/sdk/const";
-import { getEmojiData, isSymbolEmoji, isValidChatMessageEmoji } from "@/sdk/emoji_data";
-import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import {
   type HTMLAttributes,
@@ -19,6 +15,11 @@ import { isIOS, isMacOs } from "react-device-detect";
 import { notoColorEmoji } from "styles/fonts";
 import { ECONIA_BLUE, ERROR_RED } from "theme/colors";
 import { unifiedCodepointsToEmoji } from "utils/unified-codepoint-to-emoji";
+
+import RoundButton from "@/icons/Minimize";
+import { MAX_SYMBOL_LENGTH } from "@/sdk/const";
+import { getEmojiData, isSymbolEmoji, isValidChatMessageEmoji } from "@/sdk/emoji_data";
+import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 
 import type { EmojiMartData, EmojiSelectorData } from "./types";
 

--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Box } from "@containers";
-import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
+import { Box } from "@/containers";
+import { useReliableSubscribe } from "@/hooks/use-reliable-subscribe";
 import { Text } from "components";
 import Carousel from "components/carousel";
 import { useEventStore } from "context/event-store-context";

--- a/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/ClientEmojicoinPage.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Box } from "@/containers";
-import { useReliableSubscribe } from "@/hooks/use-reliable-subscribe";
 import { Text } from "components";
 import Carousel from "components/carousel";
 import { useEventStore } from "context/event-store-context";
@@ -14,6 +12,8 @@ import { ROUTES } from "router/routes";
 import { darkColors } from "theme";
 
 import type { SubscribableBrokerEvents } from "@/broker/types";
+import { Box } from "@/containers";
+import { useReliableSubscribe } from "@/hooks/use-reliable-subscribe";
 import { marketToLatestBars } from "@/store/event/candlestick-bars";
 
 import DesktopGrid from "./components/desktop-grid";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { isUserTransactionResponse } from "@aptos-labs/ts-sdk";
-import { Column, Flex } from "@/containers";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
@@ -13,6 +12,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 
 import Loading from "@/components/loading";
 import { LoadMore } from "@/components/ui/table/loadMore";
+import { Column, Flex } from "@/containers";
 
 import EmojiPickerWithInput from "../../../../emoji-picker/EmojiPickerWithInput";
 import type { ChatProps } from "../../types";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { isUserTransactionResponse } from "@aptos-labs/ts-sdk";
-import { Column, Flex } from "@containers";
+import { Column, Flex } from "@/containers";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
@@ -1,6 +1,6 @@
-import { FlexGap } from "@containers";
-import { useNameResolver } from "@hooks/use-name-resolver";
-import { formatDisplayName } from "@sdk/utils";
+import { FlexGap } from "@/containers";
+import { useNameResolver } from "@/hooks/use-name-resolver";
+import { formatDisplayName } from "@/sdk/utils";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { motion } from "framer-motion";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/components/message-container/index.tsx
@@ -1,12 +1,13 @@
-import { FlexGap } from "@/containers";
-import { useNameResolver } from "@/hooks/use-name-resolver";
-import { formatDisplayName } from "@/sdk/utils";
 import { EXTERNAL_LINK_PROPS } from "components/link";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { motion } from "framer-motion";
 import { toExplorerLink } from "lib/utils/explorer-link";
 import React, { useMemo } from "react";
 import { Emoji } from "utils/emoji";
+
+import { FlexGap } from "@/containers";
+import { useNameResolver } from "@/hooks/use-name-resolver";
+import { formatDisplayName } from "@/sdk/utils";
 
 import {
   Arrow,

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/useChatEventsQuery.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/useChatEventsQuery.tsx
@@ -1,11 +1,12 @@
-import type { fetchChatEvents } from "@/sdk/indexer-v2";
-import { LIMIT } from "@/sdk/indexer-v2/const";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import type { GetChatsSchema } from "app/api/chats/schema";
 import { ROUTES } from "router/routes";
 import { parseJSON } from "utils";
 import { addSearchParams } from "utils/url-utils";
 import type { z } from "zod";
+
+import type { fetchChatEvents } from "@/sdk/indexer-v2";
+import { LIMIT } from "@/sdk/indexer-v2/const";
 
 type ChatEvent = Awaited<ReturnType<typeof fetchChatEvents>>[number];
 

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/useChatEventsQuery.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/useChatEventsQuery.tsx
@@ -1,5 +1,5 @@
-import type { fetchChatEvents } from "@sdk/indexer-v2";
-import { LIMIT } from "@sdk/indexer-v2/const";
+import type { fetchChatEvents } from "@/sdk/indexer-v2";
+import { LIMIT } from "@/sdk/indexer-v2/const";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import type { GetChatsSchema } from "app/api/chats/schema";
 import { ROUTES } from "router/routes";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
@@ -1,9 +1,10 @@
-import { Flex, FlexGap } from "@/containers";
 import ChartContainer from "components/charts/ChartContainer";
 import Loading from "components/loading";
 import Text from "components/text";
 import { translationFunction } from "context/language-context";
 import React, { Suspense, useState } from "react";
+
+import { Flex, FlexGap } from "@/containers";
 
 import type { GridProps } from "../../types";
 import ChatBox from "../chat/ChatBox";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, FlexGap } from "@containers";
+import { Flex, FlexGap } from "@/containers";
 import ChartContainer from "components/charts/ChartContainer";
 import Loading from "components/loading";
 import Text from "components/text";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/styled.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/styled.tsx
@@ -1,5 +1,6 @@
-import { Flex } from "@/containers";
 import styled from "styled-components";
+
+import { Flex } from "@/containers";
 
 export const StyledContentWrapper = styled.div`
   display: flex;

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/styled.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/styled.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@containers";
+import { Flex } from "@/containers";
 import styled from "styled-components";
 
 export const StyledContentWrapper = styled.div`

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/emoji-not-found/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/emoji-not-found/index.tsx
@@ -1,8 +1,9 @@
-import { Flex } from "@/containers";
 import Text from "components/text";
 import { translationFunction } from "context/language-context";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
+
+import { Flex } from "@/containers";
 
 export const EmojiNotFound = () => {
   const { t } = translationFunction();

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/emoji-not-found/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/emoji-not-found/index.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@containers";
+import { Flex } from "@/containers";
 import Text from "components/text";
 import { translationFunction } from "context/language-context";
 import { emoji } from "utils";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/holders/coin-holders.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/holders/coin-holders.tsx
@@ -1,6 +1,3 @@
-import { calculateCirculatingSupply } from "@/sdk/markets";
-import { toNominal, toNominalPrice } from "@/sdk/utils";
-import type { Types } from "@/sdk-types";
 import { FormattedNumber } from "components/FormattedNumber";
 import { EcTable, type EcTableColumn } from "components/ui/table/ecTable";
 import { AptCell } from "components/ui/table-cells/apt-cell";
@@ -10,6 +7,10 @@ import type { AssetBalance } from "lib/queries/aptos-indexer/fetch-emojicoin-bal
 import { useRouter } from "next/navigation";
 import { type FC, useMemo } from "react";
 import { ROUTES } from "router/routes";
+
+import { calculateCirculatingSupply } from "@/sdk/markets";
+import { toNominal, toNominalPrice } from "@/sdk/utils";
+import type { Types } from "@/sdk-types";
 
 interface Props {
   emojicoin: string;

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/holders/coin-holders.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/holders/coin-holders.tsx
@@ -1,6 +1,6 @@
-import { calculateCirculatingSupply } from "@sdk/markets";
-import { toNominal, toNominalPrice } from "@sdk/utils";
-import type { Types } from "@sdk-types";
+import { calculateCirculatingSupply } from "@/sdk/markets";
+import { toNominal, toNominalPrice } from "@/sdk/utils";
+import type { Types } from "@/sdk-types";
 import { FormattedNumber } from "components/FormattedNumber";
 import { EcTable, type EcTableColumn } from "components/ui/table/ecTable";
 import { AptCell } from "components/ui/table-cells/apt-cell";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/BondingProgress.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/BondingProgress.tsx
@@ -1,9 +1,10 @@
-import { getBondingCurveProgress } from "@/sdk/utils/bonding-curve";
 import { FormattedNumber } from "components/FormattedNumber";
 import ProgressBar from "components/ProgressBar";
 import { useEventStore } from "context/event-store-context";
 import { translationFunction } from "context/language-context";
 import React, { useEffect, useState } from "react";
+
+import { getBondingCurveProgress } from "@/sdk/utils/bonding-curve";
 
 import type { MainInfoProps } from "../../types";
 

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/BondingProgress.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/BondingProgress.tsx
@@ -1,4 +1,4 @@
-import { getBondingCurveProgress } from "@sdk/utils/bonding-curve";
+import { getBondingCurveProgress } from "@/sdk/utils/bonding-curve";
 import { FormattedNumber } from "components/FormattedNumber";
 import ProgressBar from "components/ProgressBar";
 import { useEventStore } from "context/event-store-context";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -1,7 +1,7 @@
-import { useMatchBreakpoints } from "@hooks/index";
-import { useUsdMarketCap, useUSDValue } from "@hooks/use-usd-market-cap";
-import TelegramOutlineIcon from "@icons/TelegramOutlineIcon";
-import { isMarketStateModel } from "@sdk/indexer-v2/types";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { useUsdMarketCap, useUSDValue } from "@/hooks/use-usd-market-cap";
+import TelegramOutlineIcon from "@/icons/TelegramOutlineIcon";
+import { isMarketStateModel } from "@/sdk/indexer-v2/types";
 import Button from "components/button";
 import { FormattedNumber } from "components/FormattedNumber";
 import Popup from "components/popup";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -1,7 +1,3 @@
-import { useMatchBreakpoints } from "@/hooks/index";
-import { useUsdMarketCap, useUSDValue } from "@/hooks/use-usd-market-cap";
-import TelegramOutlineIcon from "@/icons/TelegramOutlineIcon";
-import { isMarketStateModel } from "@/sdk/indexer-v2/types";
 import Button from "components/button";
 import { FormattedNumber } from "components/FormattedNumber";
 import Popup from "components/popup";
@@ -20,6 +16,10 @@ import type { Colors } from "theme/types";
 import { Emoji } from "utils/emoji";
 
 import { MarketProperties } from "@/contract-apis";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { useUsdMarketCap, useUSDValue } from "@/hooks/use-usd-market-cap";
+import TelegramOutlineIcon from "@/icons/TelegramOutlineIcon";
+import { isMarketStateModel } from "@/sdk/indexer-v2/types";
 
 import { Switcher } from "../../../../switcher";
 import type { MainInfoProps } from "../../types";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@containers";
+import { Flex } from "@/containers";
 import { Text } from "components";
 import ChartContainer from "components/charts/ChartContainer";
 import Loading from "components/loading";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
@@ -1,9 +1,10 @@
-import { Flex } from "@/containers";
 import { Text } from "components";
 import ChartContainer from "components/charts/ChartContainer";
 import Loading from "components/loading";
 import { translationFunction } from "context/language-context";
 import React, { Suspense, useState } from "react";
+
+import { Flex } from "@/containers";
 
 import type { GridProps } from "../../types";
 import ChatBox from "../chat/ChatBox";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/personal-trade-history/personal-trade-history.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/personal-trade-history/personal-trade-history.tsx
@@ -1,5 +1,5 @@
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import { toNominal } from "@sdk/utils";
+import { toNominal } from "@/sdk/utils";
 import { FormattedNumber } from "components/FormattedNumber";
 import { ColoredPriceDisplay } from "components/misc/ColoredPriceDisplay";
 import { type SwapEvent, useSwapEventsQuery } from "components/pages/wallet/useSwapEventsQuery";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/personal-trade-history/personal-trade-history.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/personal-trade-history/personal-trade-history.tsx
@@ -1,5 +1,4 @@
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import { toNominal } from "@/sdk/utils";
 import { FormattedNumber } from "components/FormattedNumber";
 import { ColoredPriceDisplay } from "components/misc/ColoredPriceDisplay";
 import { type SwapEvent, useSwapEventsQuery } from "components/pages/wallet/useSwapEventsQuery";
@@ -9,6 +8,8 @@ import { TimeCell } from "components/ui/table-cells/time-cell";
 import { toExplorerLink } from "lib/utils/explorer-link";
 import { useMemo } from "react";
 import { Emoji } from "utils/emoji";
+
+import { toNominal } from "@/sdk/utils";
 
 import type { TradeHistoryProps } from "../../types";
 

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/AnimatedProgressBar.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/AnimatedProgressBar.tsx
@@ -1,11 +1,12 @@
-import { useMatchBreakpoints } from "@/hooks/index";
-import { getBondingCurveProgress } from "@/sdk/utils/bonding-curve";
 import { Text } from "components";
 import type { GridProps } from "components/pages/emojicoin/types";
 import { useEventStore } from "context/event-store-context";
 import { motion, useAnimation } from "framer-motion";
 import { useEffect, useState } from "react";
 import { darkColors } from "theme/colors";
+
+import { useMatchBreakpoints } from "@/hooks/index";
+import { getBondingCurveProgress } from "@/sdk/utils/bonding-curve";
 
 export const AnimatedProgressBar = (props: GridProps) => {
   const { isDesktop } = useMatchBreakpoints();

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/AnimatedProgressBar.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/AnimatedProgressBar.tsx
@@ -1,5 +1,5 @@
-import { useMatchBreakpoints } from "@hooks/index";
-import { getBondingCurveProgress } from "@sdk/utils/bonding-curve";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { getBondingCurveProgress } from "@/sdk/utils/bonding-curve";
 import { Text } from "components";
 import type { GridProps } from "components/pages/emojicoin/types";
 import { useEventStore } from "context/event-store-context";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/CongratulationsToast.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/CongratulationsToast.tsx
@@ -1,5 +1,5 @@
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import type { AnyNumberString } from "@sdk/types/types";
+import type { AnyNumberString } from "@/sdk/types/types";
 import { ExplorerLink } from "components/explorer-link/ExplorerLink";
 import { APTOS_NETWORK } from "lib/env";
 import { toDisplayCoinDecimals } from "lib/utils/decimals";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/CongratulationsToast.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/CongratulationsToast.tsx
@@ -1,10 +1,11 @@
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import type { AnyNumberString } from "@/sdk/types/types";
 import { ExplorerLink } from "components/explorer-link/ExplorerLink";
 import { APTOS_NETWORK } from "lib/env";
 import { toDisplayCoinDecimals } from "lib/utils/decimals";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
+
+import type { AnyNumberString } from "@/sdk/types/types";
 
 export const CongratulationsToast = ({
   transactionHash,

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/FlipInputsArrow.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/FlipInputsArrow.tsx
@@ -1,4 +1,4 @@
-import BidirectionalArrowIcon from "@icons/BidirectionalArrow";
+import BidirectionalArrowIcon from "@/icons/BidirectionalArrow";
 import { useState } from "react";
 
 const arrowWrapper = `

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/FlipInputsArrow.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/FlipInputsArrow.tsx
@@ -1,5 +1,6 @@
-import BidirectionalArrowIcon from "@/icons/BidirectionalArrow";
 import { useState } from "react";
+
+import BidirectionalArrowIcon from "@/icons/BidirectionalArrow";
 
 const arrowWrapper = `
   flex border border-solid border-dark-gray radii-circle p-[12px] justify-center items-center

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/InputLabels.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/InputLabels.tsx
@@ -1,4 +1,4 @@
-import AptosIconBlack from "@icons/AptosBlack";
+import AptosIconBlack from "@/icons/AptosBlack";
 import { Emoji } from "utils/emoji";
 
 export const AptosInputLabel = () => (

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/InputLabels.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/InputLabels.tsx
@@ -1,5 +1,6 @@
-import AptosIconBlack from "@/icons/AptosBlack";
 import { Emoji } from "utils/emoji";
+
+import AptosIconBlack from "@/icons/AptosBlack";
 
 export const AptosInputLabel = () => (
   <div className="pixel-heading-4 md:pixel-heading-3 text-light-gray">

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
@@ -1,6 +1,6 @@
-import { Flex } from "@containers";
-import { useMatchBreakpoints } from "@hooks/index";
-import { isInBondingCurve } from "@sdk/utils/bonding-curve";
+import { Flex } from "@/containers";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { isInBondingCurve } from "@/sdk/utils/bonding-curve";
 import Button from "components/button";
 import type { GridProps } from "components/pages/emojicoin/types";
 import Text from "components/text";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/LiquidityButton.tsx
@@ -1,6 +1,3 @@
-import { Flex } from "@/containers";
-import { useMatchBreakpoints } from "@/hooks/index";
-import { isInBondingCurve } from "@/sdk/utils/bonding-curve";
 import Button from "components/button";
 import type { GridProps } from "components/pages/emojicoin/types";
 import Text from "components/text";
@@ -8,6 +5,10 @@ import { translationFunction } from "context/language-context";
 import { useCanTradeMarket } from "lib/hooks/queries/use-grace-period";
 import Link from "next/link";
 import { ROUTES } from "router/routes";
+
+import { Flex } from "@/containers";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { isInBondingCurve } from "@/sdk/utils/bonding-curve";
 
 import { StyledContentHeader } from "../desktop-grid/styled";
 import { AnimatedProgressBar } from "./AnimatedProgressBar";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/RewardsAnimation.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/RewardsAnimation.tsx
@@ -1,9 +1,10 @@
-import { sleep } from "@/sdk/utils";
 import { type AnimationControls, type HTMLMotionProps, motion } from "framer-motion";
 import { type Dispatch, type MutableRefObject, type SetStateAction, useRef, useState } from "react";
 import Confetti from "react-confetti";
 import { createPortal } from "react-dom";
 import { useWindowSize } from "react-use";
+
+import { sleep } from "@/sdk/utils";
 
 /**
  * The tween duration for the confetti animation is very inaccurate- a few stray confetti fall after 1/3 of the way

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/RewardsAnimation.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/RewardsAnimation.tsx
@@ -1,4 +1,4 @@
-import { sleep } from "@sdk/utils";
+import { sleep } from "@/sdk/utils";
 import { type AnimationControls, type HTMLMotionProps, motion } from "framer-motion";
 import { type Dispatch, type MutableRefObject, type SetStateAction, useRef, useState } from "react";
 import Confetti from "react-confetti";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
@@ -1,6 +1,6 @@
 import { isUserTransactionResponse } from "@aptos-labs/ts-sdk";
-import type { AccountAddressString } from "@sdk/emojicoin_dot_fun";
-import { STRUCT_STRINGS } from "@sdk/utils";
+import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
+import { STRUCT_STRINGS } from "@/sdk/utils";
 import Button from "components/button";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import Popup from "components/popup";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapButton.tsx
@@ -1,6 +1,4 @@
 import { isUserTransactionResponse } from "@aptos-labs/ts-sdk";
-import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
-import { STRUCT_STRINGS } from "@/sdk/utils";
 import Button from "components/button";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import Popup from "components/popup";
@@ -11,6 +9,9 @@ import { useCanTradeMarket } from "lib/hooks/queries/use-grace-period";
 import { useSwapTransactionBuilder } from "lib/hooks/transaction-builders/use-swap-builder";
 import { type Dispatch, type SetStateAction, useCallback, useEffect } from "react";
 import { toast } from "react-toastify";
+
+import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
+import { STRUCT_STRINGS } from "@/sdk/utils";
 
 import { CongratulationsToast } from "./CongratulationsToast";
 import { RewardsAnimation } from "./RewardsAnimation";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Flex, FlexGap } from "@containers";
-import { useTooltip } from "@hooks/index";
-import { toCoinTypes } from "@sdk/markets/utils";
+import { Flex, FlexGap } from "@/containers";
+import { useTooltip } from "@/hooks/index";
+import { toCoinTypes } from "@/sdk/markets/utils";
 import { EmojiPill } from "components/EmojiPill";
 import { FormattedNumber } from "components/FormattedNumber";
 import { InputNumeric } from "components/inputs";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { Flex, FlexGap } from "@/containers";
-import { useTooltip } from "@/hooks/index";
-import { toCoinTypes } from "@/sdk/markets/utils";
 import { EmojiPill } from "components/EmojiPill";
 import { FormattedNumber } from "components/FormattedNumber";
 import { InputNumeric } from "components/inputs";
@@ -23,6 +20,10 @@ import { type PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
 import { getMaxSlippageSettings } from "utils/slippage";
+
+import { Flex, FlexGap } from "@/containers";
+import { useTooltip } from "@/hooks/index";
+import { toCoinTypes } from "@/sdk/markets/utils";
 
 import FlipInputsArrow from "./FlipInputsArrow";
 import { AptosInputLabel, EmojiInputLabel } from "./InputLabels";

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.tsx
@@ -1,5 +1,3 @@
-import type { SwapEventModel } from "@/sdk/indexer-v2";
-import { toNominal } from "@/sdk/utils";
 import { FormattedNumber } from "components/FormattedNumber";
 import { ColoredPriceDisplay } from "components/misc/ColoredPriceDisplay";
 import Popup from "components/popup";
@@ -16,6 +14,8 @@ import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
 
 import { useSwapEventsQuery } from "@/components/pages/wallet/useSwapEventsQuery";
+import type { SwapEventModel } from "@/sdk/indexer-v2";
+import { toNominal } from "@/sdk/utils";
 
 import type { TradeHistoryProps } from "../../types";
 

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.tsx
@@ -1,5 +1,5 @@
-import type { SwapEventModel } from "@sdk/indexer-v2";
-import { toNominal } from "@sdk/utils";
+import type { SwapEventModel } from "@/sdk/indexer-v2";
+import { toNominal } from "@/sdk/utils";
 import { FormattedNumber } from "components/FormattedNumber";
 import { ColoredPriceDisplay } from "components/misc/ColoredPriceDisplay";
 import Popup from "components/popup";

--- a/src/typescript/frontend/src/components/pages/emojicoin/types.ts
+++ b/src/typescript/frontend/src/components/pages/emojicoin/types.ts
@@ -1,7 +1,7 @@
-import type { SymbolEmoji } from "@sdk/emoji_data/types";
-import type { AccountAddressString } from "@sdk/emojicoin_dot_fun";
-import type { DatabaseModels, MarketMetadataModel } from "@sdk/indexer-v2/types";
-import type { Types } from "@sdk/types";
+import type { SymbolEmoji } from "@/sdk/emoji_data/types";
+import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
+import type { DatabaseModels, MarketMetadataModel } from "@/sdk/indexer-v2/types";
+import type { Types } from "@/sdk/types";
 import type { AssetBalance } from "lib/queries/aptos-indexer/fetch-emojicoin-balances";
 
 import type { SymbolString } from "@/store/event/types";

--- a/src/typescript/frontend/src/components/pages/emojicoin/types.ts
+++ b/src/typescript/frontend/src/components/pages/emojicoin/types.ts
@@ -1,9 +1,9 @@
+import type { AssetBalance } from "lib/queries/aptos-indexer/fetch-emojicoin-balances";
+
 import type { SymbolEmoji } from "@/sdk/emoji_data/types";
 import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 import type { DatabaseModels, MarketMetadataModel } from "@/sdk/indexer-v2/types";
 import type { Types } from "@/sdk/types";
-import type { AssetBalance } from "lib/queries/aptos-indexer/fetch-emojicoin-balances";
-
 import type { SymbolString } from "@/store/event/types";
 
 type DataProps = MarketMetadataModel & {

--- a/src/typescript/frontend/src/components/pages/home/components/SubscribeToHomePageEvents.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/SubscribeToHomePageEvents.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useLatestMeleeID } from "@hooks/use-latest-melee-id";
-import { useReliableSubscribe } from "@hooks/use-reliable-subscribe";
-import type { ArenaInfoModel } from "@sdk/indexer-v2";
+import { useLatestMeleeID } from "@/hooks/use-latest-melee-id";
+import { useReliableSubscribe } from "@/hooks/use-reliable-subscribe";
+import type { ArenaInfoModel } from "@/sdk/indexer-v2";
 import { useEventStore } from "context/event-store-context";
 import FEATURE_FLAGS from "lib/feature-flags";
 import { useRouter } from "next/navigation";

--- a/src/typescript/frontend/src/components/pages/home/components/SubscribeToHomePageEvents.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/SubscribeToHomePageEvents.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useLatestMeleeID } from "@/hooks/use-latest-melee-id";
-import { useReliableSubscribe } from "@/hooks/use-reliable-subscribe";
-import type { ArenaInfoModel } from "@/sdk/indexer-v2";
 import { useEventStore } from "context/event-store-context";
 import FEATURE_FLAGS from "lib/feature-flags";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+
+import { useLatestMeleeID } from "@/hooks/use-latest-melee-id";
+import { useReliableSubscribe } from "@/hooks/use-reliable-subscribe";
+import type { ArenaInfoModel } from "@/sdk/indexer-v2";
 
 export const SubscribeToHomePageEvents = ({ info }: { info?: ArenaInfoModel }) => {
   const loadArenaInfoFromServer = useEventStore((s) => s.loadArenaInfoFromServer);

--- a/src/typescript/frontend/src/components/pages/home/components/arena-card/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/arena-card/index.tsx
@@ -2,10 +2,10 @@
 
 import "./module.css";
 
-import { FlexGap } from "@containers";
-import { useMatchBreakpoints } from "@hooks/index";
-import { getEmojisInString } from "@sdk/emoji_data";
-import { toTotalAptLocked } from "@sdk/indexer-v2/types";
+import { FlexGap } from "@/containers";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { getEmojisInString } from "@/sdk/emoji_data";
+import { toTotalAptLocked } from "@/sdk/indexer-v2/types";
 import type { HomePageProps } from "app/home/HomePage";
 import Button from "components/button";
 import { Countdown } from "components/Countdown";

--- a/src/typescript/frontend/src/components/pages/home/components/arena-card/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/arena-card/index.tsx
@@ -2,10 +2,6 @@
 
 import "./module.css";
 
-import { FlexGap } from "@/containers";
-import { useMatchBreakpoints } from "@/hooks/index";
-import { getEmojisInString } from "@/sdk/emoji_data";
-import { toTotalAptLocked } from "@/sdk/indexer-v2/types";
 import type { HomePageProps } from "app/home/HomePage";
 import Button from "components/button";
 import { Countdown } from "components/Countdown";
@@ -14,6 +10,11 @@ import Link from "next/link";
 import { useMemo } from "react";
 import { ROUTES } from "router/routes";
 import { GlowingEmoji } from "utils/emoji";
+
+import { FlexGap } from "@/containers";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { getEmojisInString } from "@/sdk/emoji_data";
+import { toTotalAptLocked } from "@/sdk/indexer-v2/types";
 
 type ArenaCardProps = {
   meleeData: NonNullable<HomePageProps["meleeData"]>;

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
@@ -2,7 +2,7 @@
 
 import "./module.css";
 
-import useEvent from "@hooks/use-event";
+import useEvent from "@/hooks/use-event";
 import type { HomePageProps } from "app/home/HomePage";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useEventStore } from "context/event-store-context";

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/AnimatedClientGrid.tsx
@@ -2,12 +2,13 @@
 
 import "./module.css";
 
-import useEvent from "@/hooks/use-event";
 import type { HomePageProps } from "app/home/HomePage";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useEventStore } from "context/event-store-context";
 import type { MarketDataSortByHomePage } from "lib/queries/sorting/types";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import useEvent from "@/hooks/use-event";
 
 import { ANIMATION_DEBOUNCE_TIME } from "../table-card/animation-variants/grid-variants";
 import TableCard from "../table-card/TableCard";

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/components/FilterOptions.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/components/FilterOptions.tsx
@@ -1,5 +1,3 @@
-import { FlexGap } from "@/containers";
-import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import { DropdownMenu, SingleSelect } from "components/selects";
 import type { Option } from "components/selects/types";
 import { Switcher } from "components/switcher";
@@ -7,6 +5,9 @@ import Text from "components/text";
 import { useUserSettings } from "context/event-store-context";
 import { translationFunction } from "context/language-context";
 import { useMatchBreakpoints } from "hooks";
+
+import { FlexGap } from "@/containers";
+import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 
 import { StyledTHFilters } from "../styled";
 

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/components/FilterOptions.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/components/FilterOptions.tsx
@@ -1,5 +1,5 @@
-import { FlexGap } from "@containers";
-import { SortMarketsBy } from "@sdk/indexer-v2/types/common";
+import { FlexGap } from "@/containers";
+import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import { DropdownMenu, SingleSelect } from "components/selects";
 import type { Option } from "components/selects/types";
 import { Switcher } from "components/switcher";

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/components/buttons-block/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/components/buttons-block/index.tsx
@@ -1,7 +1,8 @@
-import { FlexGap } from "@/containers";
-import { useMatchBreakpoints } from "@/hooks/index";
 import { Arrow } from "components/svg";
 import React from "react";
+
+import { FlexGap } from "@/containers";
+import { useMatchBreakpoints } from "@/hooks/index";
 
 import { StyledBtn } from "./styled";
 

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/components/buttons-block/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/components/buttons-block/index.tsx
@@ -1,5 +1,5 @@
-import { FlexGap } from "@containers";
-import { useMatchBreakpoints } from "@hooks/index";
+import { FlexGap } from "@/containers";
+import { useMatchBreakpoints } from "@/hooks/index";
 import { Arrow } from "components/svg";
 import React from "react";
 

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import useEvent from "@/hooks/use-event";
-import { encodeEmojis, symbolBytesToEmojis } from "@/sdk/emoji_data";
-import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import type { HomePageProps } from "app/home/HomePage";
 import SearchBar from "components/inputs/search-bar";
 import Text from "components/text";
@@ -16,6 +13,10 @@ import { useRouter } from "next/navigation";
 import React, { useEffect, useMemo } from "react";
 import { ROUTES } from "router/routes";
 import { Emoji } from "utils/emoji";
+
+import useEvent from "@/hooks/use-event";
+import { encodeEmojis, symbolBytesToEmojis } from "@/sdk/emoji_data";
+import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 
 import { EMOJI_GRID_ITEM_WIDTH } from "../const";
 import { LiveClientGrid } from "./AnimatedClientGrid";

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import useEvent from "@hooks/use-event";
-import { encodeEmojis, symbolBytesToEmojis } from "@sdk/emoji_data";
-import { SortMarketsBy } from "@sdk/indexer-v2/types/common";
+import useEvent from "@/hooks/use-event";
+import { encodeEmojis, symbolBytesToEmojis } from "@/sdk/emoji_data";
+import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import type { HomePageProps } from "app/home/HomePage";
 import SearchBar from "components/inputs/search-bar";
 import Text from "components/text";

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
@@ -1,7 +1,7 @@
-import type { SymbolEmoji } from "@/sdk/emoji_data";
 import type { HomePageProps } from "app/home/HomePage";
 import { MARKETS_PER_PAGE } from "lib/queries/sorting/const";
 
+import type { SymbolEmoji } from "@/sdk/emoji_data";
 import type { EmojiPickerStore } from "@/store/emoji-picker-store";
 import type { EventStore } from "@/store/event/types";
 

--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/utils.ts
@@ -1,4 +1,4 @@
-import type { SymbolEmoji } from "@sdk/emoji_data";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
 import type { HomePageProps } from "app/home/HomePage";
 import { MARKETS_PER_PAGE } from "lib/queries/sorting/const";
 

--- a/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
@@ -2,8 +2,6 @@
 
 import "./module.css";
 
-import { FlexGap } from "@/containers";
-import { useUsdMarketCap } from "@/hooks/use-usd-market-cap";
 import type { HomePageProps } from "app/home/HomePage";
 import { FormattedNumber } from "components/FormattedNumber";
 import { PriceDelta } from "components/price-feed/inner";
@@ -19,6 +17,9 @@ import { ROUTES } from "router/routes";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
 import { emojiNamesToPath } from "utils/pathname-helpers";
+
+import { FlexGap } from "@/containers";
+import { useUsdMarketCap } from "@/hooks/use-usd-market-cap";
 
 import planetHome from "../../../../../../public/images/planet-home.png";
 

--- a/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/main-card/MainCard.tsx
@@ -2,8 +2,8 @@
 
 import "./module.css";
 
-import { FlexGap } from "@containers";
-import { useUsdMarketCap } from "@hooks/use-usd-market-cap";
+import { FlexGap } from "@/containers";
+import { useUsdMarketCap } from "@/hooks/use-usd-market-cap";
 import type { HomePageProps } from "app/home/HomePage";
 import { FormattedNumber } from "components/FormattedNumber";
 import { PriceDelta } from "components/price-feed/inner";

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/LinkOrAnimationTrigger.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/LinkOrAnimationTrigger.tsx
@@ -1,4 +1,4 @@
-import type { SymbolEmojiData } from "@sdk/emoji_data/types";
+import type { SymbolEmojiData } from "@/sdk/emoji_data/types";
 import Link from "next/link";
 import type { PropsWithChildren } from "react";
 import React from "react";

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/LinkOrAnimationTrigger.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/LinkOrAnimationTrigger.tsx
@@ -1,9 +1,10 @@
-import type { SymbolEmojiData } from "@/sdk/emoji_data/types";
 import Link from "next/link";
 import type { PropsWithChildren } from "react";
 import React from "react";
 import { ROUTES } from "router/routes";
 import { emojiNamesToPath } from "utils/pathname-helpers";
+
+import type { SymbolEmojiData } from "@/sdk/emoji_data/types";
 
 export const EmojiMarketPageLink = ({
   emojis,

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
@@ -2,9 +2,9 @@
 
 import "./module.css";
 
-import { Column, Flex } from "@containers";
-import { useUsdMarketCap } from "@hooks/use-usd-market-cap";
-import { SortMarketsBy } from "@sdk/indexer-v2/types/common";
+import { Column, Flex } from "@/containers";
+import { useUsdMarketCap } from "@/hooks/use-usd-market-cap";
+import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import { FormattedNumber } from "components/FormattedNumber";
 import { Arrow } from "components/svg";
 import Text from "components/text";

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
@@ -2,9 +2,6 @@
 
 import "./module.css";
 
-import { Column, Flex } from "@/containers";
-import { useUsdMarketCap } from "@/hooks/use-usd-market-cap";
-import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import { FormattedNumber } from "components/FormattedNumber";
 import { Arrow } from "components/svg";
 import Text from "components/text";
@@ -14,6 +11,10 @@ import { motion, type MotionProps, useAnimationControls, useMotionValue } from "
 import { emojisToName } from "lib/utils/emojis-to-name-or-symbol";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { Emoji } from "utils/emoji";
+
+import { Column, Flex } from "@/containers";
+import { useUsdMarketCap } from "@/hooks/use-usd-market-cap";
+import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 
 import {
   borderVariants,

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/event-variants.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/event-variants.ts
@@ -1,3 +1,5 @@
+import { ECONIA_BLUE, GREEN, PINK, WHITE } from "theme/colors";
+
 import { Trigger } from "@/sdk/const";
 import {
   type ChatEventModel,
@@ -11,7 +13,6 @@ import {
   type MarketRegistrationEventModel,
   type SwapEventModel,
 } from "@/sdk/indexer-v2/types";
-import { ECONIA_BLUE, GREEN, PINK, WHITE } from "theme/colors";
 
 const transitionIn = {
   duration: 0,

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/event-variants.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/event-variants.ts
@@ -1,4 +1,4 @@
-import { Trigger } from "@sdk/const";
+import { Trigger } from "@/sdk/const";
 import {
   type ChatEventModel,
   isChatEventModel,
@@ -10,7 +10,7 @@ import {
   type MarketLatestStateEventModel,
   type MarketRegistrationEventModel,
   type SwapEventModel,
-} from "@sdk/indexer-v2/types";
+} from "@/sdk/indexer-v2/types";
 import { ECONIA_BLUE, GREEN, PINK, WHITE } from "theme/colors";
 
 const transitionIn = {

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/grid-variants.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/grid-variants.ts
@@ -4,7 +4,7 @@ import type {
   MarketLatestStateEventModel,
   MarketRegistrationEventModel,
   SwapEventModel,
-} from "@sdk/indexer-v2/types";
+} from "@/sdk/indexer-v2/types";
 
 export const ANIMATION_DEBOUNCE_TIME = 1111;
 

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/types.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/types.ts
@@ -1,5 +1,6 @@
-import type { SymbolEmojiData } from "@/sdk/emoji_data";
 import type { MarketDataSortByHomePage } from "lib/queries/sorting/types";
+
+import type { SymbolEmojiData } from "@/sdk/emoji_data";
 
 export type TableCardProps = {
   index: number;

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/types.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/types.ts
@@ -1,4 +1,4 @@
-import type { SymbolEmojiData } from "@sdk/emoji_data";
+import type { SymbolEmojiData } from "@/sdk/emoji_data";
 import type { MarketDataSortByHomePage } from "lib/queries/sorting/types";
 
 export type TableCardProps = {

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/ClientLaunchEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/ClientLaunchEmojicoinPage.tsx
@@ -5,8 +5,8 @@ import {
   type PendingTransactionResponse,
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
-import { getEmojisInString, symbolBytesToEmojis } from "@sdk/emoji_data";
-import { getEvents } from "@sdk/emojicoin_dot_fun";
+import { getEmojisInString, symbolBytesToEmojis } from "@/sdk/emoji_data";
+import { getEvents } from "@/sdk/emojicoin_dot_fun";
 import TextCarousel from "components/text-carousel/TextCarousel";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/ClientLaunchEmojicoinPage.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/ClientLaunchEmojicoinPage.tsx
@@ -5,8 +5,6 @@ import {
   type PendingTransactionResponse,
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
-import { getEmojisInString, symbolBytesToEmojis } from "@/sdk/emoji_data";
-import { getEvents } from "@/sdk/emojicoin_dot_fun";
 import TextCarousel from "components/text-carousel/TextCarousel";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
@@ -14,6 +12,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import path from "path";
 import { startTransition, useCallback, useEffect, useRef, useState } from "react";
 import { ROUTES } from "router/routes";
+
+import { getEmojisInString, symbolBytesToEmojis } from "@/sdk/emoji_data";
+import { getEvents } from "@/sdk/emojicoin_dot_fun";
 
 import MemoizedLaunchAnimation from "./memoized-launch";
 

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/animated-emoji-circle/index.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/animated-emoji-circle/index.tsx
@@ -1,4 +1,4 @@
-import { getRandomSymbolEmoji } from "@sdk/emoji_data";
+import { getRandomSymbolEmoji } from "@/sdk/emoji_data";
 import { motion } from "framer-motion";
 import React, { useMemo } from "react";
 import { Emoji } from "utils/emoji";

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/animated-emoji-circle/index.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/animated-emoji-circle/index.tsx
@@ -1,7 +1,8 @@
-import { getRandomSymbolEmoji } from "@/sdk/emoji_data";
 import { motion } from "framer-motion";
 import React, { useMemo } from "react";
 import { Emoji } from "utils/emoji";
+
+import { getRandomSymbolEmoji } from "@/sdk/emoji_data";
 
 export const AnimatedEmojiCircle = ({
   numEmojis = 14,

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
@@ -1,12 +1,12 @@
-import { SYMBOL_EMOJI_DATA, type SymbolEmoji } from "@/sdk/emoji_data";
-import { normalizeHex } from "@/sdk/utils";
-import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 import { useQuery } from "@tanstack/react-query";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 
 import { MarketMetadataByEmojiBytes } from "@/contract-apis/emojicoin-dot-fun";
+import { SYMBOL_EMOJI_DATA, type SymbolEmoji } from "@/sdk/emoji_data";
+import { normalizeHex } from "@/sdk/utils";
+import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 
 const encoder = new TextEncoder();
 

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
@@ -1,6 +1,6 @@
-import { SYMBOL_EMOJI_DATA, type SymbolEmoji } from "@sdk/emoji_data";
-import { normalizeHex } from "@sdk/utils";
-import { sumBytes } from "@sdk/utils/sum-emoji-bytes";
+import { SYMBOL_EMOJI_DATA, type SymbolEmoji } from "@/sdk/emoji_data";
+import { normalizeHex } from "@/sdk/utils";
+import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 import { useQuery } from "@tanstack/react-query";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useEventStore } from "context/event-store-context";

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
@@ -5,12 +5,6 @@ import {
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
-import {
-  MARKET_REGISTRATION_FEE,
-  MARKET_REGISTRATION_GAS_ESTIMATION_FIRST,
-  MARKET_REGISTRATION_GAS_ESTIMATION_NOT_FIRST,
-} from "@/sdk/const";
-import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
 import { useQuery } from "@tanstack/react-query";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
@@ -19,6 +13,12 @@ import { useMarketRegisterTransactionBuilder } from "lib/hooks/transaction-build
 import { useCallback, useMemo } from "react";
 
 import { RegisterMarket } from "@/contract-apis/emojicoin-dot-fun";
+import {
+  MARKET_REGISTRATION_FEE,
+  MARKET_REGISTRATION_GAS_ESTIMATION_FIRST,
+  MARKET_REGISTRATION_GAS_ESTIMATION_NOT_FIRST,
+} from "@/sdk/const";
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
 
 export const tryEd25519PublicKey = (account: AccountInfo) => {
   try {

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
@@ -9,8 +9,8 @@ import {
   MARKET_REGISTRATION_FEE,
   MARKET_REGISTRATION_GAS_ESTIMATION_FIRST,
   MARKET_REGISTRATION_GAS_ESTIMATION_NOT_FIRST,
-} from "@sdk/const";
-import { SYMBOL_EMOJI_DATA } from "@sdk/emoji_data";
+} from "@/sdk/const";
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
 import { useQuery } from "@tanstack/react-query";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
@@ -1,6 +1,3 @@
-import { MARKET_REGISTRATION_DEPOSIT, ONE_APT_BIGINT } from "@/sdk/const";
-import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
-import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 import { MarketValidityIndicator } from "components/emoji-picker/ColoredBytesIndicator";
 import EmojiPickerWithInput from "components/emoji-picker/EmojiPickerWithInput";
 import Info from "components/info";
@@ -14,6 +11,10 @@ import React, { useEffect, useMemo } from "react";
 import { useScramble } from "use-scramble";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
+
+import { MARKET_REGISTRATION_DEPOSIT, ONE_APT_BIGINT } from "@/sdk/const";
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
+import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 
 import { useIsMarketRegistered } from "../hooks/use-is-market-registered";
 import { useRegisterMarket } from "../hooks/use-register-market";

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/memoized-launch/index.tsx
@@ -1,6 +1,6 @@
-import { MARKET_REGISTRATION_DEPOSIT, ONE_APT_BIGINT } from "@sdk/const";
-import { SYMBOL_EMOJI_DATA } from "@sdk/emoji_data";
-import { sumBytes } from "@sdk/utils/sum-emoji-bytes";
+import { MARKET_REGISTRATION_DEPOSIT, ONE_APT_BIGINT } from "@/sdk/const";
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
+import { sumBytes } from "@/sdk/utils/sum-emoji-bytes";
 import { MarketValidityIndicator } from "components/emoji-picker/ColoredBytesIndicator";
 import EmojiPickerWithInput from "components/emoji-picker/EmojiPickerWithInput";
 import Info from "components/info";

--- a/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { FlexGap } from "@/containers";
-import { encodeEmojis, getEmojisInString, type SymbolEmoji } from "@/sdk/emoji_data";
-import { DEFAULT_POOLS_SORT_BY } from "@/sdk/indexer-v2/queries/query-params";
-import type { MarketStateModel, UserPoolsRPCModel } from "@/sdk/indexer-v2/types";
 import SearchBar from "components/inputs/search-bar";
 import { Liquidity, PoolsTable, TableHeaderSwitcher } from "components/pages/pools/components";
 import {
@@ -23,6 +19,11 @@ import { useSearchParams } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import { ROUTES } from "router/routes";
 import { parseJSON } from "utils";
+
+import { FlexGap } from "@/containers";
+import { encodeEmojis, getEmojisInString, type SymbolEmoji } from "@/sdk/emoji_data";
+import { DEFAULT_POOLS_SORT_BY } from "@/sdk/indexer-v2/queries/query-params";
+import type { MarketStateModel, UserPoolsRPCModel } from "@/sdk/indexer-v2/types";
 
 export type PoolsData = MarketStateModel | UserPoolsRPCModel;
 

--- a/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { FlexGap } from "@containers";
-import { encodeEmojis, getEmojisInString, type SymbolEmoji } from "@sdk/emoji_data";
-import { DEFAULT_POOLS_SORT_BY } from "@sdk/indexer-v2/queries/query-params";
-import type { MarketStateModel, UserPoolsRPCModel } from "@sdk/indexer-v2/types";
+import { FlexGap } from "@/containers";
+import { encodeEmojis, getEmojisInString, type SymbolEmoji } from "@/sdk/emoji_data";
+import { DEFAULT_POOLS_SORT_BY } from "@/sdk/indexer-v2/queries/query-params";
+import type { MarketStateModel, UserPoolsRPCModel } from "@/sdk/indexer-v2/types";
 import SearchBar from "components/inputs/search-bar";
 import { Liquidity, PoolsTable, TableHeaderSwitcher } from "components/pages/pools/components";
 import {

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { TypeTag } from "@aptos-labs/ts-sdk";
-import { Column, Flex, FlexGap } from "@containers";
-import { useMatchBreakpoints } from "@hooks/index";
-import { toCoinTypes } from "@sdk/markets/utils";
+import { Column, Flex, FlexGap } from "@/containers";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { toCoinTypes } from "@/sdk/markets/utils";
 import { Button, InputNumeric, Text } from "components";
 import { EmojiPill } from "components/EmojiPill";
 import { FormattedNumber } from "components/FormattedNumber";

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -1,9 +1,6 @@
 "use client";
 
 import { TypeTag } from "@aptos-labs/ts-sdk";
-import { Column, Flex, FlexGap } from "@/containers";
-import { useMatchBreakpoints } from "@/hooks/index";
-import { toCoinTypes } from "@/sdk/markets/utils";
 import { Button, InputNumeric, Text } from "components";
 import { EmojiPill } from "components/EmojiPill";
 import { FormattedNumber } from "components/FormattedNumber";
@@ -25,6 +22,10 @@ import { useLiquidityTransactionBuilder } from "lib/hooks/transaction-builders/u
 import { toActualCoinDecimals } from "lib/utils/decimals";
 import { useSearchParams } from "next/navigation";
 import React, { type PropsWithChildren, useEffect, useMemo, useState } from "react";
+
+import { Column, Flex, FlexGap } from "@/containers";
+import { useMatchBreakpoints } from "@/hooks/index";
+import { toCoinTypes } from "@/sdk/markets/utils";
 
 import type { PoolsData } from "../../ClientPoolsPage";
 import { StyledAddLiquidityWrapper } from "./styled";

--- a/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-header/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-header/index.tsx
@@ -1,4 +1,3 @@
-import { Flex, FlexGap } from "@/containers";
 import Info from "components/info";
 import { Arrows } from "components/svg";
 import Text from "components/text";
@@ -6,6 +5,8 @@ import { translationFunction } from "context/language-context";
 import { useMatchBreakpoints } from "hooks";
 import React from "react";
 import { useScramble } from "use-scramble";
+
+import { Flex, FlexGap } from "@/containers";
 
 import type { TableHeaderProps } from "./types";
 

--- a/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-header/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-header/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, FlexGap } from "@containers";
+import { Flex, FlexGap } from "@/containers";
 import Info from "components/info";
 import { Arrows } from "components/svg";
 import Text from "components/text";

--- a/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-row-desktop/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-row-desktop/index.tsx
@@ -1,4 +1,3 @@
-import { Flex } from "@/containers";
 import { Td, Text, Tr } from "components";
 import { FormattedNumber } from "components/FormattedNumber";
 import Popup from "components/popup";
@@ -9,6 +8,8 @@ import React, { useMemo } from "react";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
 import { emojiNamesToPath } from "utils/pathname-helpers";
+
+import { Flex } from "@/containers";
 
 import type { TableRowDesktopProps } from "./types";
 import { XprPopup } from "./XprPopup";

--- a/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-row-desktop/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/pools-table/components/table-row-desktop/index.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@containers";
+import { Flex } from "@/containers";
 import { Td, Text, Tr } from "components";
 import { FormattedNumber } from "components/FormattedNumber";
 import Popup from "components/popup";

--- a/src/typescript/frontend/src/components/pages/pools/components/pools-table/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/pools-table/index.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import useElementDimensions from "@/hooks/use-element-dimensions";
-import type { OrderByStrings } from "@/sdk/indexer-v2/const";
 import { EmptyTr, HeaderTr, Table, TBody, Th, ThInner } from "components";
 import { useMatchBreakpoints } from "hooks";
 import type { SortByPageQueryParams } from "lib/queries/sorting/types";
 import React, { useRef, useState } from "react";
 import { getEmptyListTr } from "utils";
+
+import useElementDimensions from "@/hooks/use-element-dimensions";
+import type { OrderByStrings } from "@/sdk/indexer-v2/const";
 
 import type { PoolsData } from "../../ClientPoolsPage";
 import { TableHeader, TableRowDesktop } from "./components";

--- a/src/typescript/frontend/src/components/pages/pools/components/pools-table/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/pools-table/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import useElementDimensions from "@hooks/use-element-dimensions";
-import type { OrderByStrings } from "@sdk/indexer-v2/const";
+import useElementDimensions from "@/hooks/use-element-dimensions";
+import type { OrderByStrings } from "@/sdk/indexer-v2/const";
 import { EmptyTr, HeaderTr, Table, TBody, Th, ThInner } from "components";
 import { useMatchBreakpoints } from "hooks";
 import type { SortByPageQueryParams } from "lib/queries/sorting/types";

--- a/src/typescript/frontend/src/components/pages/pools/components/table-header-switcher/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/table-header-switcher/index.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Flex, FlexGap } from "@/containers";
 import Text from "components/text";
 import { translationFunction } from "context/language-context";
 import React, { useEffect, useState } from "react";
 import { useScramble } from "use-scramble";
+
+import { Flex, FlexGap } from "@/containers";
 
 import type { TableHeaderSwitcherProps } from "./types";
 

--- a/src/typescript/frontend/src/components/pages/pools/components/table-header-switcher/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/table-header-switcher/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Flex, FlexGap } from "@containers";
+import { Flex, FlexGap } from "@/containers";
 import Text from "components/text";
 import { translationFunction } from "context/language-context";
 import React, { useEffect, useState } from "react";

--- a/src/typescript/frontend/src/components/pages/pools/styled.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/styled.tsx
@@ -1,5 +1,6 @@
-import { Flex } from "@/containers";
 import styled from "styled-components";
+
+import { Flex } from "@/containers";
 
 export const StyledPoolsPage = styled.div`
   display: flex;

--- a/src/typescript/frontend/src/components/pages/pools/styled.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/styled.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@containers";
+import { Flex } from "@/containers";
 import styled from "styled-components";
 
 export const StyledPoolsPage = styled.div`

--- a/src/typescript/frontend/src/components/pages/test-utils/SetNewMeleeDuration.tsx
+++ b/src/typescript/frontend/src/components/pages/test-utils/SetNewMeleeDuration.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Network } from "@aptos-labs/ts-sdk";
-import { isNumberInConstruction } from "@sdk/utils";
+import { isNumberInConstruction } from "@/sdk/utils";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { cn } from "lib/utils/class-name";
 import { useState } from "react";

--- a/src/typescript/frontend/src/components/pages/test-utils/SetNewMeleeDuration.tsx
+++ b/src/typescript/frontend/src/components/pages/test-utils/SetNewMeleeDuration.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Network } from "@aptos-labs/ts-sdk";
-import { isNumberInConstruction } from "@/sdk/utils";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { cn } from "lib/utils/class-name";
 import { useState } from "react";
@@ -12,6 +11,7 @@ import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
 import { successfulTransactionToast } from "@/components/wallet/toasts";
 import { EmojicoinArena } from "@/contract-apis";
+import { isNumberInConstruction } from "@/sdk/utils";
 
 import { getLocalPublisher } from "./local-publisher";
 

--- a/src/typescript/frontend/src/components/pages/test-utils/local-publisher.ts
+++ b/src/typescript/frontend/src/components/pages/test-utils/local-publisher.ts
@@ -1,5 +1,5 @@
 import { Account, Ed25519PrivateKey, Hex, Network } from "@aptos-labs/ts-sdk";
-import { APTOS_NETWORK } from "@sdk/const";
+import { APTOS_NETWORK } from "@/sdk/const";
 
 /**
  * Expose the local publisher account for local development.

--- a/src/typescript/frontend/src/components/pages/test-utils/local-publisher.ts
+++ b/src/typescript/frontend/src/components/pages/test-utils/local-publisher.ts
@@ -1,4 +1,5 @@
 import { Account, Ed25519PrivateKey, Hex, Network } from "@aptos-labs/ts-sdk";
+
 import { APTOS_NETWORK } from "@/sdk/const";
 
 /**

--- a/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/MarketAddressConversion.tsx
+++ b/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/MarketAddressConversion.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { SymbolEmoji } from "@sdk/emoji_data";
-import { getMarketAddress } from "@sdk/emojicoin_dot_fun";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
+import { getMarketAddress } from "@/sdk/emojicoin_dot_fun";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { cn } from "lib/utils/class-name";
 import { useCallback, useMemo, useState } from "react";

--- a/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/MarketAddressConversion.tsx
+++ b/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/MarketAddressConversion.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import type { SymbolEmoji } from "@/sdk/emoji_data";
-import { getMarketAddress } from "@/sdk/emojicoin_dot_fun";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { cn } from "lib/utils/class-name";
 import { useCallback, useMemo, useState } from "react";
@@ -12,6 +10,8 @@ import { Emoji } from "utils/emoji";
 import EmojiPickerWithInput from "@/components/emoji-picker/EmojiPickerWithInput";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
+import { getMarketAddress } from "@/sdk/emojicoin_dot_fun";
 
 import { useFetchSymbol } from "./use-market-address-view";
 

--- a/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/use-market-address-view.ts
+++ b/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/use-market-address-view.ts
@@ -1,6 +1,6 @@
 import type { Aptos } from "@aptos-labs/ts-sdk";
-import { symbolBytesToEmojis } from "@sdk/emoji_data";
-import { REGISTRY_ADDRESS } from "@sdk/emojicoin_dot_fun";
+import { symbolBytesToEmojis } from "@/sdk/emoji_data";
+import { REGISTRY_ADDRESS } from "@/sdk/emojicoin_dot_fun";
 import { useQuery } from "@tanstack/react-query";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { withResponseError } from "lib/hooks/queries/client";

--- a/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/use-market-address-view.ts
+++ b/src/typescript/frontend/src/components/pages/test-utils/market-address-conversion/use-market-address-view.ts
@@ -1,12 +1,12 @@
 import type { Aptos } from "@aptos-labs/ts-sdk";
-import { symbolBytesToEmojis } from "@/sdk/emoji_data";
-import { REGISTRY_ADDRESS } from "@/sdk/emojicoin_dot_fun";
 import { useQuery } from "@tanstack/react-query";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { withResponseError } from "lib/hooks/queries/client";
 import { useMemo } from "react";
 
 import { MarketMetadataByMarketAddress } from "@/contract-apis";
+import { symbolBytesToEmojis } from "@/sdk/emoji_data";
+import { REGISTRY_ADDRESS } from "@/sdk/emojicoin_dot_fun";
 
 const fetchSymbol = async (args: { aptos: Aptos; marketAddress: string }) =>
   await withResponseError(

--- a/src/typescript/frontend/src/components/pages/verify-status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify-status/VerifyStatusPage.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
-import { standardizeAddress, truncateAddress } from "@sdk/utils";
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
+import { standardizeAddress, truncateAddress } from "@/sdk/utils";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { motion } from "framer-motion";

--- a/src/typescript/frontend/src/components/pages/verify-status/VerifyStatusPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify-status/VerifyStatusPage.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
-import { standardizeAddress, truncateAddress } from "@/sdk/utils";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { motion } from "framer-motion";
@@ -10,6 +8,9 @@ import { cn } from "lib/utils/class-name";
 import { useEffect, useState } from "react";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
+
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
+import { standardizeAddress, truncateAddress } from "@/sdk/utils";
 
 import { getIsOnCustomAllowlist } from "./get-verification-status";
 

--- a/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { type AccountInfo, useWallet } from "@aptos-labs/wallet-adapter-react";
-import { Flex } from "@containers";
-import type { AccountAddressString } from "@sdk/emojicoin_dot_fun";
+import { Flex } from "@/containers";
+import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import Text from "components/text";
 import { useAptos } from "context/wallet-context/AptosContextProvider";

--- a/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
+++ b/src/typescript/frontend/src/components/pages/verify/VerifyPage.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { type AccountInfo, useWallet } from "@aptos-labs/wallet-adapter-react";
-import { Flex } from "@/containers";
-import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 import ButtonWithConnectWalletFallback from "components/header/wallet-button/ConnectWalletButton";
 import Text from "components/text";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
@@ -12,6 +10,9 @@ import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { ROUTES } from "router/routes";
 import { useScramble } from "use-scramble";
+
+import { Flex } from "@/containers";
+import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 
 import { createSession } from "./session";
 

--- a/src/typescript/frontend/src/components/pages/verify/session.ts
+++ b/src/typescript/frontend/src/components/pages/verify/session.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import type { AccountAddressString } from "@sdk/emojicoin_dot_fun";
+import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 import { isAllowListed } from "lib/utils/allowlist";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";

--- a/src/typescript/frontend/src/components/pages/verify/session.ts
+++ b/src/typescript/frontend/src/components/pages/verify/session.ts
@@ -1,10 +1,11 @@
 "use server";
 
-import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 import { isAllowListed } from "lib/utils/allowlist";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { ROUTES } from "router/routes";
+
+import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 
 import {
   COOKIE_FOR_ACCOUNT_ADDRESS,

--- a/src/typescript/frontend/src/components/pages/verify/verify.ts
+++ b/src/typescript/frontend/src/components/pages/verify/verify.ts
@@ -1,6 +1,6 @@
 "use server";
 import { sha3_256 } from "@noble/hashes/sha3";
-import { normalizeHex } from "@sdk/utils/hex";
+import { normalizeHex } from "@/sdk/utils/hex";
 
 export const hashAddress = async (address: string) => {
   // Ensure the HASH_SEED is valid, since we don't import it.

--- a/src/typescript/frontend/src/components/pages/verify/verify.ts
+++ b/src/typescript/frontend/src/components/pages/verify/verify.ts
@@ -1,5 +1,6 @@
 "use server";
 import { sha3_256 } from "@noble/hashes/sha3";
+
 import { normalizeHex } from "@/sdk/utils/hex";
 
 export const hashAddress = async (address: string) => {

--- a/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import AptosIconBlack from "@icons/AptosBlack";
-import type { SymbolEmoji } from "@sdk/emoji_data";
-import { formatDisplayName, type ValidAptosName } from "@sdk/utils";
+import AptosIconBlack from "@/icons/AptosBlack";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
+import { formatDisplayName, type ValidAptosName } from "@/sdk/utils";
 import { ExplorerLink } from "components/explorer-link/ExplorerLink";
 import { FormattedNumber } from "components/FormattedNumber";
 import SearchBar from "components/inputs/search-bar";

--- a/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import AptosIconBlack from "@/icons/AptosBlack";
-import type { SymbolEmoji } from "@/sdk/emoji_data";
-import { formatDisplayName, type ValidAptosName } from "@/sdk/utils";
 import { ExplorerLink } from "components/explorer-link/ExplorerLink";
 import { FormattedNumber } from "components/FormattedNumber";
 import SearchBar from "components/inputs/search-bar";
@@ -13,6 +10,10 @@ import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import { useEffectOnce } from "react-use";
 import { ROUTES } from "router/routes";
+
+import AptosIconBlack from "@/icons/AptosBlack";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
+import { formatDisplayName, type ValidAptosName } from "@/sdk/utils";
 
 import { WalletPortfolioTable } from "./WalletPortfolioTable";
 import { WalletTransactionTable } from "./WalletTransactionTable";

--- a/src/typescript/frontend/src/components/pages/wallet/WalletTransactionTable.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletTransactionTable.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { type AnyEmoji, encodeEmojis, type SymbolEmoji } from "@sdk/emoji_data";
-import type { OrderByStrings } from "@sdk/indexer-v2/const";
-import { toNominal } from "@sdk/utils";
+import { type AnyEmoji, encodeEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
+import type { OrderByStrings } from "@/sdk/indexer-v2/const";
+import { toNominal } from "@/sdk/utils";
 import { FormattedNumber } from "components/FormattedNumber";
 import { ColoredPriceDisplay } from "components/misc/ColoredPriceDisplay";
 import { EcTable, type EcTableColumn } from "components/ui/table/ecTable";

--- a/src/typescript/frontend/src/components/pages/wallet/WalletTransactionTable.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletTransactionTable.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { type AnyEmoji, encodeEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
-import type { OrderByStrings } from "@/sdk/indexer-v2/const";
-import { toNominal } from "@/sdk/utils";
 import { FormattedNumber } from "components/FormattedNumber";
 import { ColoredPriceDisplay } from "components/misc/ColoredPriceDisplay";
 import { EcTable, type EcTableColumn } from "components/ui/table/ecTable";
@@ -14,6 +11,10 @@ import { useState } from "react";
 import { ROUTES } from "router/routes";
 import { Emoji } from "utils/emoji";
 import { emojiNamesToPath } from "utils/pathname-helpers";
+
+import { type AnyEmoji, encodeEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
+import type { OrderByStrings } from "@/sdk/indexer-v2/const";
+import { toNominal } from "@/sdk/utils";
 
 import { type SwapEvent, useSwapEventsQuery } from "./useSwapEventsQuery";
 

--- a/src/typescript/frontend/src/components/pages/wallet/fetch-specific-markets-action.ts
+++ b/src/typescript/frontend/src/components/pages/wallet/fetch-specific-markets-action.ts
@@ -1,9 +1,9 @@
 "use server";
 
-import type { SymbolEmoji } from "@sdk/emoji_data";
-import { fetchSpecificMarkets } from "@sdk/indexer-v2/queries";
-import { calculateCurvePrice } from "@sdk/markets";
-import { toNominal } from "@sdk/utils";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
+import { fetchSpecificMarkets } from "@/sdk/indexer-v2/queries";
+import { calculateCurvePrice } from "@/sdk/markets";
+import { toNominal } from "@/sdk/utils";
 
 /**
  * Wrapper to make `fetchSpecificMarkets` into a single server action. Only return the data required

--- a/src/typescript/frontend/src/components/pages/wallet/useSwapEventsQuery.ts
+++ b/src/typescript/frontend/src/components/pages/wallet/useSwapEventsQuery.ts
@@ -1,4 +1,4 @@
-import { LIMIT } from "@sdk/indexer-v2/const";
+import { LIMIT } from "@/sdk/indexer-v2/const";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import type { GetTradesSchema } from "app/api/trades/schema";
 import { ROUTES } from "router/routes";

--- a/src/typescript/frontend/src/components/pages/wallet/useSwapEventsQuery.ts
+++ b/src/typescript/frontend/src/components/pages/wallet/useSwapEventsQuery.ts
@@ -1,4 +1,3 @@
-import { LIMIT } from "@/sdk/indexer-v2/const";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import type { GetTradesSchema } from "app/api/trades/schema";
 import { ROUTES } from "router/routes";
@@ -7,6 +6,7 @@ import { addSearchParams } from "utils/url-utils";
 import type { z } from "zod";
 
 import type { fetchSwapEvents } from "@/queries/market";
+import { LIMIT } from "@/sdk/indexer-v2/const";
 
 export type SwapEvent = Awaited<ReturnType<typeof fetchSwapEvents>>[number];
 

--- a/src/typescript/frontend/src/components/price-feed/index.tsx
+++ b/src/typescript/frontend/src/components/price-feed/index.tsx
@@ -1,4 +1,4 @@
-import type { DatabaseModels } from "@sdk/indexer-v2/types";
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
 
 import { PriceFeedInner } from "./inner";
 

--- a/src/typescript/frontend/src/components/price-feed/inner.tsx
+++ b/src/typescript/frontend/src/components/price-feed/inner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { DatabaseModels } from "@sdk/indexer-v2/types";
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
 import Carousel from "components/carousel";
 import { FormattedNumber } from "components/FormattedNumber";
 import { PriceColors } from "components/misc/ColoredPriceDisplay";

--- a/src/typescript/frontend/src/components/price-feed/inner.tsx
+++ b/src/typescript/frontend/src/components/price-feed/inner.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { DatabaseModels } from "@/sdk/indexer-v2/types";
 import Carousel from "components/carousel";
 import { FormattedNumber } from "components/FormattedNumber";
 import { PriceColors } from "components/misc/ColoredPriceDisplay";
@@ -10,6 +9,8 @@ import Link from "next/link";
 import { useMemo } from "react";
 import useEffectOnce from "react-use/lib/useEffectOnce";
 import { Emoji } from "utils/emoji";
+
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
 
 export const PriceDelta = ({ delta, className = "" }: { delta: number; className?: string }) => {
   const { prefix, suffix } = useMemo(

--- a/src/typescript/frontend/src/components/selects/dropdown-menu/styled.tsx
+++ b/src/typescript/frontend/src/components/selects/dropdown-menu/styled.tsx
@@ -1,5 +1,6 @@
-import { Box } from "@/containers";
 import styled from "styled-components";
+
+import { Box } from "@/containers";
 
 export const DropdownMenuWrapper = styled(Box)`
   max-height: 300px;

--- a/src/typescript/frontend/src/components/selects/dropdown-menu/styled.tsx
+++ b/src/typescript/frontend/src/components/selects/dropdown-menu/styled.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@containers";
+import { Box } from "@/containers";
 import styled from "styled-components";
 
 export const DropdownMenuWrapper = styled(Box)`

--- a/src/typescript/frontend/src/components/selects/select/index.tsx
+++ b/src/typescript/frontend/src/components/selects/select/index.tsx
@@ -1,8 +1,9 @@
-import { FlexGap } from "@/containers";
 import Text from "components/text";
 import { translationFunction } from "context/language-context";
 import React from "react";
 import { useScramble } from "use-scramble";
+
+import { FlexGap } from "@/containers";
 
 import type { SelectProps } from "../types";
 import { DropdownSelectWrapper } from "./styled";

--- a/src/typescript/frontend/src/components/selects/select/index.tsx
+++ b/src/typescript/frontend/src/components/selects/select/index.tsx
@@ -1,4 +1,4 @@
-import { FlexGap } from "@containers";
+import { FlexGap } from "@/containers";
 import Text from "components/text";
 import { translationFunction } from "context/language-context";
 import React from "react";

--- a/src/typescript/frontend/src/components/selects/select/styled.tsx
+++ b/src/typescript/frontend/src/components/selects/select/styled.tsx
@@ -1,5 +1,6 @@
-import { Box } from "@/containers";
 import styled from "styled-components";
+
+import { Box } from "@/containers";
 
 export const DropdownSelectWrapper = styled(Box)`
   cursor: pointer;

--- a/src/typescript/frontend/src/components/selects/select/styled.tsx
+++ b/src/typescript/frontend/src/components/selects/select/styled.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@containers";
+import { Box } from "@/containers";
 import styled from "styled-components";
 
 export const DropdownSelectWrapper = styled(Box)`

--- a/src/typescript/frontend/src/components/table/index.tsx
+++ b/src/typescript/frontend/src/components/table/index.tsx
@@ -1,4 +1,3 @@
-import { Flex } from "@/containers";
 import styled, { css } from "styled-components";
 import {
   layout,
@@ -8,6 +7,8 @@ import {
   typography,
   type TypographyProps,
 } from "styled-system";
+
+import { Flex } from "@/containers";
 
 interface TdProps extends TypographyProps, SpaceProps, LayoutProps {}
 

--- a/src/typescript/frontend/src/components/table/index.tsx
+++ b/src/typescript/frontend/src/components/table/index.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@containers";
+import { Flex } from "@/containers";
 import styled, { css } from "styled-components";
 import {
   layout,

--- a/src/typescript/frontend/src/components/text-carousel/TextCarousel.tsx
+++ b/src/typescript/frontend/src/components/text-carousel/TextCarousel.tsx
@@ -1,5 +1,6 @@
-import Planet from "@/icons/Planet";
 import Carousel from "components/carousel";
+
+import Planet from "@/icons/Planet";
 
 const Item = ({ children }: { children: React.ReactNode }) => {
   return (

--- a/src/typescript/frontend/src/components/text-carousel/TextCarousel.tsx
+++ b/src/typescript/frontend/src/components/text-carousel/TextCarousel.tsx
@@ -1,4 +1,4 @@
-import Planet from "@icons/Planet";
+import Planet from "@/icons/Planet";
 import Carousel from "components/carousel";
 
 const Item = ({ children }: { children: React.ReactNode }) => {

--- a/src/typescript/frontend/src/components/ui/table-cells/apt-cell.tsx
+++ b/src/typescript/frontend/src/components/ui/table-cells/apt-cell.tsx
@@ -1,4 +1,4 @@
-import AptosIconBlack from "@icons/AptosBlack";
+import AptosIconBlack from "@/icons/AptosBlack";
 import { FormattedNumber } from "components/FormattedNumber";
 import type { FormatNumberStringProps } from "lib/utils/format-number-string";
 

--- a/src/typescript/frontend/src/components/ui/table-cells/apt-cell.tsx
+++ b/src/typescript/frontend/src/components/ui/table-cells/apt-cell.tsx
@@ -1,6 +1,7 @@
-import AptosIconBlack from "@/icons/AptosBlack";
 import { FormattedNumber } from "components/FormattedNumber";
 import type { FormatNumberStringProps } from "lib/utils/format-number-string";
+
+import AptosIconBlack from "@/icons/AptosBlack";
 
 export const AptCell = (props: FormatNumberStringProps & { scramble?: boolean }) => {
   return (

--- a/src/typescript/frontend/src/components/ui/table-cells/wallet-address-cell.tsx
+++ b/src/typescript/frontend/src/components/ui/table-cells/wallet-address-cell.tsx
@@ -1,5 +1,5 @@
-import { useNameResolver } from "@hooks/use-name-resolver";
-import { formatDisplayName } from "@sdk/utils";
+import { useNameResolver } from "@/hooks/use-name-resolver";
+import { formatDisplayName } from "@/sdk/utils";
 import { cn } from "lib/utils/class-name";
 import { useMemo } from "react";
 import { ROUTES } from "router/routes";

--- a/src/typescript/frontend/src/components/ui/table-cells/wallet-address-cell.tsx
+++ b/src/typescript/frontend/src/components/ui/table-cells/wallet-address-cell.tsx
@@ -1,8 +1,9 @@
-import { useNameResolver } from "@/hooks/use-name-resolver";
-import { formatDisplayName } from "@/sdk/utils";
 import { cn } from "lib/utils/class-name";
 import { useMemo } from "react";
 import { ROUTES } from "router/routes";
+
+import { useNameResolver } from "@/hooks/use-name-resolver";
+import { formatDisplayName } from "@/sdk/utils";
 
 export const WalletAddressCell = ({
   address,

--- a/src/typescript/frontend/src/components/ui/table/ecTable.tsx
+++ b/src/typescript/frontend/src/components/ui/table/ecTable.tsx
@@ -1,4 +1,4 @@
-import type { OrderByStrings } from "@sdk/indexer-v2/const";
+import type { OrderByStrings } from "@/sdk/indexer-v2/const";
 import AnimatedLoadingBoxes from "components/pages/launch-emojicoin/animated-loading-boxes";
 import { cn } from "lib/utils/class-name";
 import _ from "lodash";

--- a/src/typescript/frontend/src/components/ui/table/ecTable.tsx
+++ b/src/typescript/frontend/src/components/ui/table/ecTable.tsx
@@ -1,8 +1,9 @@
-import type { OrderByStrings } from "@/sdk/indexer-v2/const";
 import AnimatedLoadingBoxes from "components/pages/launch-emojicoin/animated-loading-boxes";
 import { cn } from "lib/utils/class-name";
 import _ from "lodash";
 import { type ReactNode, useCallback, useMemo, useState } from "react";
+
+import type { OrderByStrings } from "@/sdk/indexer-v2/const";
 
 import { EcTableBody } from "./ecTableBody";
 import { EcTableHead } from "./ecTableHead";

--- a/src/typescript/frontend/src/components/ui/table/ecTableHead.tsx
+++ b/src/typescript/frontend/src/components/ui/table/ecTableHead.tsx
@@ -1,4 +1,4 @@
-import SortArrow from "@icons/SortArrow";
+import SortArrow from "@/icons/SortArrow";
 import { Arrows } from "components/svg";
 import { TableHead } from "components/ui/table/table";
 import { cn } from "lib/utils/class-name";

--- a/src/typescript/frontend/src/components/ui/table/ecTableHead.tsx
+++ b/src/typescript/frontend/src/components/ui/table/ecTableHead.tsx
@@ -1,8 +1,9 @@
-import SortArrow from "@/icons/SortArrow";
 import { Arrows } from "components/svg";
 import { TableHead } from "components/ui/table/table";
 import { cn } from "lib/utils/class-name";
 import type { FC } from "react";
+
+import SortArrow from "@/icons/SortArrow";
 
 interface SortableHeadProps {
   text: string | React.ReactNode;

--- a/src/typescript/frontend/src/components/wallet/WalletDropdownMenu.tsx
+++ b/src/typescript/frontend/src/components/wallet/WalletDropdownMenu.tsx
@@ -3,7 +3,6 @@ import {
   isAptosConnectWallet,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
-import { formatDisplayName } from "@/sdk/utils/misc";
 import {
   DropdownArrow,
   DropdownContent,
@@ -20,6 +19,8 @@ import { ROUTES } from "router/routes";
 import { useScramble } from "use-scramble";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
+
+import { formatDisplayName } from "@/sdk/utils/misc";
 
 import { WalletDropdownItem } from "./WalletDropdownItem";
 

--- a/src/typescript/frontend/src/components/wallet/WalletDropdownMenu.tsx
+++ b/src/typescript/frontend/src/components/wallet/WalletDropdownMenu.tsx
@@ -3,7 +3,7 @@ import {
   isAptosConnectWallet,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
-import { formatDisplayName } from "@sdk/utils/misc";
+import { formatDisplayName } from "@/sdk/utils/misc";
 import {
   DropdownArrow,
   DropdownContent,

--- a/src/typescript/frontend/src/components/wallet/WalletModal.tsx
+++ b/src/typescript/frontend/src/components/wallet/WalletModal.tsx
@@ -4,7 +4,7 @@ import {
   partitionWallets,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
-import EmojicoinLogo from "@icons/EmojicoinLogo";
+import EmojicoinLogo from "@/icons/EmojicoinLogo";
 import { BaseModal } from "components/modal/BaseModal";
 import { Arrow } from "components/svg";
 import { DEFAULT_TOAST_CONFIG } from "const";

--- a/src/typescript/frontend/src/components/wallet/WalletModal.tsx
+++ b/src/typescript/frontend/src/components/wallet/WalletModal.tsx
@@ -4,7 +4,6 @@ import {
   partitionWallets,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
-import EmojicoinLogo from "@/icons/EmojicoinLogo";
 import { BaseModal } from "components/modal/BaseModal";
 import { Arrow } from "components/svg";
 import { DEFAULT_TOAST_CONFIG } from "const";
@@ -12,6 +11,8 @@ import { isSupportedWallet, WalletItem, walletSort } from "context/wallet-contex
 import { motion, type MotionProps, type PanInfo } from "framer-motion";
 import { type Dispatch, type SetStateAction, useState } from "react";
 import { toast } from "react-toastify";
+
+import EmojicoinLogo from "@/icons/EmojicoinLogo";
 
 import { AptosConnectWalletRow } from "./AptosConnectWalletRow";
 import LearnMoreSlideshow, { SLIDE_INDICES } from "./LearnMoreSlideshow";

--- a/src/typescript/frontend/src/components/wallet/toasts.tsx
+++ b/src/typescript/frontend/src/components/wallet/toasts.tsx
@@ -6,8 +6,8 @@ import {
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import type { NetworkInfo } from "@aptos-labs/wallet-adapter-react";
-import { PeriodDuration } from "@sdk/const";
-import { getPeriodStartTimeFromTime, truncateAddress } from "@sdk/utils/misc";
+import { PeriodDuration } from "@/sdk/const";
+import { getPeriodStartTimeFromTime, truncateAddress } from "@/sdk/utils/misc";
 import { ExplorerLink } from "components/explorer-link/ExplorerLink";
 import { DEFAULT_TOAST_CONFIG } from "const";
 import { APTOS_NETWORK } from "lib/env";

--- a/src/typescript/frontend/src/components/wallet/toasts.tsx
+++ b/src/typescript/frontend/src/components/wallet/toasts.tsx
@@ -6,12 +6,13 @@ import {
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import type { NetworkInfo } from "@aptos-labs/wallet-adapter-react";
-import { PeriodDuration } from "@/sdk/const";
-import { getPeriodStartTimeFromTime, truncateAddress } from "@/sdk/utils/misc";
 import { ExplorerLink } from "components/explorer-link/ExplorerLink";
 import { DEFAULT_TOAST_CONFIG } from "const";
 import { APTOS_NETWORK } from "lib/env";
 import { toast } from "react-toastify";
+
+import { PeriodDuration } from "@/sdk/const";
+import { getPeriodStartTimeFromTime, truncateAddress } from "@/sdk/utils/misc";
 
 const debouncedToastKey = (s: string, debouncePeriod: PeriodDuration) => {
   const periodBoundary = getPeriodStartTimeFromTime(

--- a/src/typescript/frontend/src/context/providers.tsx
+++ b/src/typescript/frontend/src/context/providers.tsx
@@ -8,7 +8,6 @@ import { MartianWallet } from "@martianwallet/aptos-wallet-adapter";
 import { OKXWallet } from "@okwallet/aptos-wallet-adapter";
 import { PontemWallet } from "@pontem/wallet-adapter-plugin";
 import { RiseWallet } from "@rise-wallet/wallet-adapter";
-import { getAptosApiKey } from "@/sdk/const";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Footer from "components/footer";
 import { GeoblockedBanner } from "components/geoblocking";
@@ -26,6 +25,8 @@ import { ThemeProvider } from "styled-components";
 import { GlobalStyle } from "styles";
 import StyledToaster from "styles/StyledToaster";
 import { completePickerData } from "utils/picker-data/complete-picker-data";
+
+import { getAptosApiKey } from "@/sdk/const";
 
 import { ConnectToWebSockets } from "./ConnectToWebSockets";
 import ContentWrapper from "./ContentWrapper";

--- a/src/typescript/frontend/src/context/providers.tsx
+++ b/src/typescript/frontend/src/context/providers.tsx
@@ -8,7 +8,7 @@ import { MartianWallet } from "@martianwallet/aptos-wallet-adapter";
 import { OKXWallet } from "@okwallet/aptos-wallet-adapter";
 import { PontemWallet } from "@pontem/wallet-adapter-plugin";
 import { RiseWallet } from "@rise-wallet/wallet-adapter";
-import { getAptosApiKey } from "@sdk/const";
+import { getAptosApiKey } from "@/sdk/const";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Footer from "components/footer";
 import { GeoblockedBanner } from "components/geoblocking";

--- a/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
+++ b/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
@@ -7,15 +7,6 @@ import {
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
-import { useNameResolver } from "@/hooks/use-name-resolver";
-import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
-import type {
-  EntryFunctionTransactionBuilder,
-  WalletInputTransactionData,
-} from "@/sdk/emojicoin_dot_fun/payload-builders";
-import { sleep } from "@/sdk/utils";
-import { getAptosClient } from "@/sdk/utils/aptos-client";
 import {
   checkNetworkAndToast,
   parseAPIErrorAndToast,
@@ -34,6 +25,16 @@ import {
   useState,
 } from "react";
 import { toast } from "react-toastify";
+
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
+import { useNameResolver } from "@/hooks/use-name-resolver";
+import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
+import type {
+  EntryFunctionTransactionBuilder,
+  WalletInputTransactionData,
+} from "@/sdk/emojicoin_dot_fun/payload-builders";
+import { sleep } from "@/sdk/utils";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 
 import {
   copyAddressHelper,

--- a/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
+++ b/src/typescript/frontend/src/context/wallet-context/AptosContextProvider.tsx
@@ -7,15 +7,15 @@ import {
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import useIsUserGeoblocked from "@hooks/use-is-user-geoblocked";
-import { useNameResolver } from "@hooks/use-name-resolver";
-import type { TypeTagInput } from "@sdk/emojicoin_dot_fun";
+import useIsUserGeoblocked from "@/hooks/use-is-user-geoblocked";
+import { useNameResolver } from "@/hooks/use-name-resolver";
+import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
 import type {
   EntryFunctionTransactionBuilder,
   WalletInputTransactionData,
-} from "@sdk/emojicoin_dot_fun/payload-builders";
-import { sleep } from "@sdk/utils";
-import { getAptosClient } from "@sdk/utils/aptos-client";
+} from "@/sdk/emojicoin_dot_fun/payload-builders";
+import { sleep } from "@/sdk/utils";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 import {
   checkNetworkAndToast,
   parseAPIErrorAndToast,

--- a/src/typescript/frontend/src/context/wallet-context/WalletItem.tsx
+++ b/src/typescript/frontend/src/context/wallet-context/WalletItem.tsx
@@ -6,6 +6,12 @@ import {
   type Wallet,
   WalletReadyState,
 } from "@aptos-labs/wallet-adapter-react";
+import { Arrow } from "components/svg";
+import { type MouseEventHandler, type ReactElement, useCallback, useEffect, useState } from "react";
+import { useScramble } from "use-scramble";
+import { emoji } from "utils";
+import { Emoji } from "utils/emoji";
+
 import BitgetIcon from "@/icons/BitgetIcon";
 import MartianIcon from "@/icons/MartianIcon";
 import NightlyIcon from "@/icons/NightlyIcon";
@@ -13,11 +19,6 @@ import OKXIcon from "@/icons/OKXIcon";
 import PetraIcon from "@/icons/PetraIcon";
 import PontemIcon from "@/icons/PontemIcon";
 import RiseIcon from "@/icons/RiseIcon";
-import { Arrow } from "components/svg";
-import { type MouseEventHandler, type ReactElement, useCallback, useEffect, useState } from "react";
-import { useScramble } from "use-scramble";
-import { emoji } from "utils";
-import { Emoji } from "utils/emoji";
 
 const IconProps = {
   width: 28,

--- a/src/typescript/frontend/src/context/wallet-context/WalletItem.tsx
+++ b/src/typescript/frontend/src/context/wallet-context/WalletItem.tsx
@@ -6,13 +6,13 @@ import {
   type Wallet,
   WalletReadyState,
 } from "@aptos-labs/wallet-adapter-react";
-import BitgetIcon from "@icons/BitgetIcon";
-import MartianIcon from "@icons/MartianIcon";
-import NightlyIcon from "@icons/NightlyIcon";
-import OKXIcon from "@icons/OKXIcon";
-import PetraIcon from "@icons/PetraIcon";
-import PontemIcon from "@icons/PontemIcon";
-import RiseIcon from "@icons/RiseIcon";
+import BitgetIcon from "@/icons/BitgetIcon";
+import MartianIcon from "@/icons/MartianIcon";
+import NightlyIcon from "@/icons/NightlyIcon";
+import OKXIcon from "@/icons/OKXIcon";
+import PetraIcon from "@/icons/PetraIcon";
+import PontemIcon from "@/icons/PontemIcon";
+import RiseIcon from "@/icons/RiseIcon";
 import { Arrow } from "components/svg";
 import { type MouseEventHandler, type ReactElement, useCallback, useEffect, useState } from "react";
 import { useScramble } from "use-scramble";

--- a/src/typescript/frontend/src/context/wallet-context/utils.ts
+++ b/src/typescript/frontend/src/context/wallet-context/utils.ts
@@ -5,9 +5,9 @@ import {
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
-import type { TypeTagInput } from "@sdk/emojicoin_dot_fun";
-import { getEventsAsProcessorModelsFromResponse } from "@sdk/indexer-v2/mini-processor";
-import { getAptBalanceFromChanges, getCoinBalanceFromChanges } from "@sdk/utils";
+import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
+import { getEventsAsProcessorModelsFromResponse } from "@/sdk/indexer-v2/mini-processor";
+import { getAptBalanceFromChanges, getCoinBalanceFromChanges } from "@/sdk/utils";
 import type { Dispatch, SetStateAction } from "react";
 import { toast } from "react-toastify";
 import { emoji } from "utils";

--- a/src/typescript/frontend/src/context/wallet-context/utils.ts
+++ b/src/typescript/frontend/src/context/wallet-context/utils.ts
@@ -5,12 +5,13 @@ import {
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
-import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
-import { getEventsAsProcessorModelsFromResponse } from "@/sdk/indexer-v2/mini-processor";
-import { getAptBalanceFromChanges, getCoinBalanceFromChanges } from "@/sdk/utils";
 import type { Dispatch, SetStateAction } from "react";
 import { toast } from "react-toastify";
 import { emoji } from "utils";
+
+import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
+import { getEventsAsProcessorModelsFromResponse } from "@/sdk/indexer-v2/mini-processor";
+import { getAptBalanceFromChanges, getCoinBalanceFromChanges } from "@/sdk/utils";
 
 export const setBalancesFromWriteset = ({
   response,

--- a/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
+++ b/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
@@ -1,5 +1,6 @@
-import { toNominal } from "@/sdk/utils";
 import { useAptPrice } from "context/AptPrice";
+
+import { toNominal } from "@/sdk/utils";
 
 /**
  * Returns the market cap in USD.

--- a/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
+++ b/src/typescript/frontend/src/hooks/use-usd-market-cap.ts
@@ -1,4 +1,4 @@
-import { toNominal } from "@sdk/utils";
+import { toNominal } from "@/sdk/utils";
 import { useAptPrice } from "context/AptPrice";
 
 /**

--- a/src/typescript/frontend/src/lib/api/schemas/api-pagination.ts
+++ b/src/typescript/frontend/src/lib/api/schemas/api-pagination.ts
@@ -1,4 +1,4 @@
-import { toOrderBy } from "@sdk/indexer-v2";
+import { toOrderBy } from "@/sdk/indexer-v2";
 import { z } from "zod";
 
 export const PaginationSchema = z.object({

--- a/src/typescript/frontend/src/lib/api/schemas/api-pagination.ts
+++ b/src/typescript/frontend/src/lib/api/schemas/api-pagination.ts
@@ -1,5 +1,6 @@
-import { toOrderBy } from "@/sdk/indexer-v2";
 import { z } from "zod";
+
+import { toOrderBy } from "@/sdk/indexer-v2";
 
 export const PaginationSchema = z.object({
   orderBy: z

--- a/src/typescript/frontend/src/lib/chart-utils/index.ts
+++ b/src/typescript/frontend/src/lib/chart-utils/index.ts
@@ -1,10 +1,10 @@
 // cspell:word Kolkata
 // cspell:word Fakaofo
 
-import { isValidMarketSymbol } from "@sdk/emoji_data";
+import { isValidMarketSymbol } from "@/sdk/emoji_data";
 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
 // @ts-ignore Expect an error when the library isn't installed. Since it's a type, it's fine.
-import type { Bar } from "@static/charting_library/datafeed-api";
+import type { Bar } from "@/static/charting_library/datafeed-api";
 
 /**
  * Retrieves the client's timezone based on the current system time offset.

--- a/src/typescript/frontend/src/lib/env.ts
+++ b/src/typescript/frontend/src/lib/env.ts
@@ -1,5 +1,5 @@
 import type { Network } from "@aptos-labs/ts-sdk";
-import type { AccountAddressString } from "@sdk/emojicoin_dot_fun";
+import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 import { parse } from "semver";
 
 import packageInfo from "../../package.json";

--- a/src/typescript/frontend/src/lib/env.ts
+++ b/src/typescript/frontend/src/lib/env.ts
@@ -1,6 +1,7 @@
 import type { Network } from "@aptos-labs/ts-sdk";
-import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 import { parse } from "semver";
+
+import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 
 import packageInfo from "../../package.json";
 

--- a/src/typescript/frontend/src/lib/hooks/queries/use-fetch-owner-emojicoin-balances.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-fetch-owner-emojicoin-balances.ts
@@ -1,12 +1,13 @@
 import { AccountAddress, type AccountAddressInput } from "@aptos-labs/ts-sdk";
-import { getSymbolEmojisInString, toMarketEmojiData } from "@/sdk/emoji_data/utils";
-import { sum, toAccountAddressString, toNominal } from "@/sdk/utils";
 import { useQuery } from "@tanstack/react-query";
 import { fetchSpecificMarketsAction } from "components/pages/wallet/fetch-specific-markets-action";
 import type { AssetBalance } from "lib/queries/aptos-indexer/fetch-emojicoin-balances";
 import { fetchOwnerEmojicoinBalances } from "lib/queries/aptos-indexer/fetch-owner-emojicoin-balances";
 import { useMemo } from "react";
 import { emojiNamesToPath } from "utils/pathname-helpers";
+
+import { getSymbolEmojisInString, toMarketEmojiData } from "@/sdk/emoji_data/utils";
+import { sum, toAccountAddressString, toNominal } from "@/sdk/utils";
 
 import { withResponseError } from "./client";
 

--- a/src/typescript/frontend/src/lib/hooks/queries/use-fetch-owner-emojicoin-balances.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-fetch-owner-emojicoin-balances.ts
@@ -1,6 +1,6 @@
 import { AccountAddress, type AccountAddressInput } from "@aptos-labs/ts-sdk";
-import { getSymbolEmojisInString, toMarketEmojiData } from "@sdk/emoji_data/utils";
-import { sum, toAccountAddressString, toNominal } from "@sdk/utils";
+import { getSymbolEmojisInString, toMarketEmojiData } from "@/sdk/emoji_data/utils";
+import { sum, toAccountAddressString, toNominal } from "@/sdk/utils";
 import { useQuery } from "@tanstack/react-query";
 import { fetchSpecificMarketsAction } from "components/pages/wallet/fetch-specific-markets-action";
 import type { AssetBalance } from "lib/queries/aptos-indexer/fetch-emojicoin-balances";

--- a/src/typescript/frontend/src/lib/hooks/queries/use-get-swap-gas.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-get-swap-gas.ts
@@ -1,7 +1,7 @@
 import type { Aptos, TypeTag } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
-import type { AccountAddressString, AnyNumber, TypeTagInput } from "@sdk/emojicoin_dot_fun";
-import { toCoinTypes } from "@sdk/markets/utils";
+import type { AccountAddressString, AnyNumber, TypeTagInput } from "@/sdk/emojicoin_dot_fun";
+import { toCoinTypes } from "@/sdk/markets/utils";
 import { useQuery } from "@tanstack/react-query";
 import Big from "big.js";
 import { useAptos } from "context/wallet-context/AptosContextProvider";

--- a/src/typescript/frontend/src/lib/hooks/queries/use-get-swap-gas.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-get-swap-gas.ts
@@ -1,7 +1,5 @@
 import type { Aptos, TypeTag } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
-import type { AccountAddressString, AnyNumber, TypeTagInput } from "@/sdk/emojicoin_dot_fun";
-import { toCoinTypes } from "@/sdk/markets/utils";
 import { useQuery } from "@tanstack/react-query";
 import Big from "big.js";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
@@ -10,6 +8,8 @@ import { useMemo } from "react";
 
 import { tryEd25519PublicKey } from "@/components/pages/launch-emojicoin/hooks/use-register-market";
 import { Swap } from "@/contract-apis/emojicoin-dot-fun";
+import type { AccountAddressString, AnyNumber, TypeTagInput } from "@/sdk/emojicoin_dot_fun";
+import { toCoinTypes } from "@/sdk/markets/utils";
 
 type Args = {
   aptos: Aptos;

--- a/src/typescript/frontend/src/lib/hooks/queries/use-grace-period.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-grace-period.ts
@@ -1,9 +1,10 @@
-import { getRegistrationGracePeriodFlag } from "@/sdk/markets/utils";
-import { standardizeAddress } from "@/sdk/utils/account-address";
 import { useQuery } from "@tanstack/react-query";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useEffect, useMemo, useState } from "react";
+
+import { getRegistrationGracePeriodFlag } from "@/sdk/markets/utils";
+import { standardizeAddress } from "@/sdk/utils/account-address";
 
 // -------------------------------------------------------------------------------------------------
 //                        Utilities for calculating the number of seconds left.

--- a/src/typescript/frontend/src/lib/hooks/queries/use-grace-period.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-grace-period.ts
@@ -1,5 +1,5 @@
-import { getRegistrationGracePeriodFlag } from "@sdk/markets/utils";
-import { standardizeAddress } from "@sdk/utils/account-address";
+import { getRegistrationGracePeriodFlag } from "@/sdk/markets/utils";
+import { standardizeAddress } from "@/sdk/utils/account-address";
 import { useQuery } from "@tanstack/react-query";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";

--- a/src/typescript/frontend/src/lib/hooks/queries/use-num-markets.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-num-markets.ts
@@ -1,8 +1,8 @@
-import { getAptosClient } from "@/sdk/utils/aptos-client";
 import { useQuery } from "@tanstack/react-query";
 import { useEventStore } from "context/event-store-context";
 
 import { RegistryView } from "@/contract-apis/emojicoin-dot-fun";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 
 async function getNumMarkets(): Promise<number> {
   const aptos = getAptosClient();

--- a/src/typescript/frontend/src/lib/hooks/queries/use-num-markets.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-num-markets.ts
@@ -1,4 +1,4 @@
-import { getAptosClient } from "@sdk/utils/aptos-client";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
 import { useQuery } from "@tanstack/react-query";
 import { useEventStore } from "context/event-store-context";
 

--- a/src/typescript/frontend/src/lib/hooks/queries/use-simulate-provide-liquidity.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-simulate-provide-liquidity.ts
@@ -1,5 +1,5 @@
 import type { Aptos } from "@aptos-labs/ts-sdk";
-import type { AccountAddressString, AnyNumber, TypeTagInput } from "@sdk/emojicoin_dot_fun";
+import type { AccountAddressString, AnyNumber, TypeTagInput } from "@/sdk/emojicoin_dot_fun";
 import { useQuery } from "@tanstack/react-query";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { withResponseError } from "lib/hooks/queries/client";

--- a/src/typescript/frontend/src/lib/hooks/queries/use-simulate-provide-liquidity.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-simulate-provide-liquidity.ts
@@ -1,5 +1,4 @@
 import type { Aptos } from "@aptos-labs/ts-sdk";
-import type { AccountAddressString, AnyNumber, TypeTagInput } from "@/sdk/emojicoin_dot_fun";
 import { useQuery } from "@tanstack/react-query";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { withResponseError } from "lib/hooks/queries/client";
@@ -8,6 +7,7 @@ import {
   SimulateProvideLiquidity,
   SimulateRemoveLiquidity,
 } from "@/contract-apis/emojicoin-dot-fun";
+import type { AccountAddressString, AnyNumber, TypeTagInput } from "@/sdk/emojicoin_dot_fun";
 
 const simulateProvideLiquidity = async (args: {
   aptos: Aptos;

--- a/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
@@ -1,6 +1,6 @@
 import type { Aptos } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
-import type { TypeTagInput } from "@sdk/emojicoin_dot_fun";
+import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 

--- a/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
@@ -1,10 +1,10 @@
 import type { Aptos } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
-import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { Balance } from "@/contract-apis";
+import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
 
 import { withResponseError } from "./client";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-arena-swap-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-arena-swap-builder.ts
@@ -1,9 +1,9 @@
 import type { TypeTag } from "@aptos-labs/ts-sdk";
-import { toCoinTypes } from "@/sdk/markets";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { Swap } from "@/contract-apis/emojicoin-arena";
+import { toCoinTypes } from "@/sdk/markets";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-arena-swap-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-arena-swap-builder.ts
@@ -1,5 +1,5 @@
 import type { TypeTag } from "@aptos-labs/ts-sdk";
-import { toCoinTypes } from "@sdk/markets";
+import { toCoinTypes } from "@/sdk/markets";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-chat-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-chat-builder.ts
@@ -1,6 +1,6 @@
-import { MAX_NUM_CHAT_EMOJIS } from "@sdk/const";
-import { toChatMessageEntryFunctionArgs } from "@sdk/emoji_data/chat-message";
-import { toCoinTypesForEntry } from "@sdk/markets";
+import { MAX_NUM_CHAT_EMOJIS } from "@/sdk/const";
+import { toChatMessageEntryFunctionArgs } from "@/sdk/emoji_data/chat-message";
+import { toCoinTypesForEntry } from "@/sdk/markets";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-chat-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-chat-builder.ts
@@ -1,11 +1,11 @@
-import { MAX_NUM_CHAT_EMOJIS } from "@/sdk/const";
-import { toChatMessageEntryFunctionArgs } from "@/sdk/emoji_data/chat-message";
-import { toCoinTypesForEntry } from "@/sdk/markets";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { Chat } from "@/contract-apis/emojicoin-dot-fun";
+import { MAX_NUM_CHAT_EMOJIS } from "@/sdk/const";
+import { toChatMessageEntryFunctionArgs } from "@/sdk/emoji_data/chat-message";
+import { toCoinTypesForEntry } from "@/sdk/markets";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-enter-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-enter-builder.ts
@@ -1,10 +1,10 @@
 import type { TypeTag } from "@aptos-labs/ts-sdk";
-import { toCoinTypes } from "@/sdk/markets";
-import type { AnyNumberString } from "@/sdk-types";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { Enter } from "@/contract-apis/emojicoin-arena";
+import { toCoinTypes } from "@/sdk/markets";
+import type { AnyNumberString } from "@/sdk-types";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-enter-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-enter-builder.ts
@@ -1,6 +1,6 @@
 import type { TypeTag } from "@aptos-labs/ts-sdk";
-import { toCoinTypes } from "@sdk/markets";
-import type { AnyNumberString } from "@sdk-types";
+import { toCoinTypes } from "@/sdk/markets";
+import type { AnyNumberString } from "@/sdk-types";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-exit-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-exit-builder.ts
@@ -1,5 +1,5 @@
 import type { TypeTag } from "@aptos-labs/ts-sdk";
-import { toCoinTypes } from "@sdk/markets";
+import { toCoinTypes } from "@/sdk/markets";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-exit-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-exit-builder.ts
@@ -1,9 +1,9 @@
 import type { TypeTag } from "@aptos-labs/ts-sdk";
-import { toCoinTypes } from "@/sdk/markets";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { Exit } from "@/contract-apis/emojicoin-arena";
+import { toCoinTypes } from "@/sdk/markets";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-liquidity-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-liquidity-builder.ts
@@ -1,8 +1,8 @@
-import { toCoinTypesForEntry } from "@/sdk/markets";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { ProvideLiquidity, RemoveLiquidity } from "@/contract-apis";
+import { toCoinTypesForEntry } from "@/sdk/markets";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-liquidity-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-liquidity-builder.ts
@@ -1,4 +1,4 @@
-import { toCoinTypesForEntry } from "@sdk/markets";
+import { toCoinTypesForEntry } from "@/sdk/markets";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-market-register-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-market-register-builder.ts
@@ -1,10 +1,10 @@
-import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data/emoji-data";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { INTEGRATOR_ADDRESS } from "lib/env";
 import { useMemo } from "react";
 
 import { RegisterMarket } from "@/contract-apis/emojicoin-dot-fun";
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data/emoji-data";
 
 import { useTransactionBuilderWithOptions } from "./use-transaction-builder";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-market-register-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-market-register-builder.ts
@@ -1,4 +1,4 @@
-import { SYMBOL_EMOJI_DATA } from "@sdk/emoji_data/emoji-data";
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data/emoji-data";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { INTEGRATOR_ADDRESS } from "lib/env";

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-swap-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-swap-builder.ts
@@ -1,5 +1,5 @@
-import { toCoinTypesForEntry } from "@sdk/markets";
-import type { AnyNumberString } from "@sdk-types";
+import { toCoinTypesForEntry } from "@/sdk/markets";
+import type { AnyNumberString } from "@/sdk-types";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS } from "lib/env";
 import { useMemo } from "react";

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-swap-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-swap-builder.ts
@@ -1,10 +1,10 @@
-import { toCoinTypesForEntry } from "@/sdk/markets";
-import type { AnyNumberString } from "@/sdk-types";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS } from "lib/env";
 import { useMemo } from "react";
 
 import { Swap } from "@/contract-apis";
+import { toCoinTypesForEntry } from "@/sdk/markets";
+import type { AnyNumberString } from "@/sdk-types";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-transaction-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-transaction-builder.ts
@@ -3,7 +3,7 @@ import type { InputGenerateTransactionOptions } from "@aptos-labs/wallet-adapter
 import type {
   EntryFunctionTransactionBuilder,
   WalletInputTransactionData,
-} from "@sdk/emojicoin_dot_fun/payload-builders";
+} from "@/sdk/emojicoin_dot_fun/payload-builders";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useEffect, useState } from "react";
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-transaction-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-transaction-builder.ts
@@ -1,11 +1,12 @@
 import type { AccountAddressInput, AptosConfig } from "@aptos-labs/ts-sdk";
 import type { InputGenerateTransactionOptions } from "@aptos-labs/wallet-adapter-core";
+import { useAptos } from "context/wallet-context/AptosContextProvider";
+import { useEffect, useState } from "react";
+
 import type {
   EntryFunctionTransactionBuilder,
   WalletInputTransactionData,
 } from "@/sdk/emojicoin_dot_fun/payload-builders";
-import { useAptos } from "context/wallet-context/AptosContextProvider";
-import { useEffect, useState } from "react";
 
 type BuilderConfig = {
   aptosConfig: AptosConfig;

--- a/src/typescript/frontend/src/lib/hooks/use-account-sequence-number.ts
+++ b/src/typescript/frontend/src/lib/hooks/use-account-sequence-number.ts
@@ -1,6 +1,6 @@
 import type { AccountAddressInput, Aptos } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
-import { getAptosClient } from "@sdk/utils";
+import { getAptosClient } from "@/sdk/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 

--- a/src/typescript/frontend/src/lib/hooks/use-account-sequence-number.ts
+++ b/src/typescript/frontend/src/lib/hooks/use-account-sequence-number.ts
@@ -1,8 +1,9 @@
 import type { AccountAddressInput, Aptos } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
-import { getAptosClient } from "@/sdk/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
+
+import { getAptosClient } from "@/sdk/utils";
 
 import { withResponseError } from "./queries/client";
 

--- a/src/typescript/frontend/src/lib/hooks/use-calculate-swap-price.ts
+++ b/src/typescript/frontend/src/lib/hooks/use-calculate-swap-price.ts
@@ -1,11 +1,11 @@
-import { INITIAL_REAL_RESERVES, INITIAL_VIRTUAL_RESERVES } from "@sdk/const";
+import { INITIAL_REAL_RESERVES, INITIAL_VIRTUAL_RESERVES } from "@/sdk/const";
 import {
   calculateSwapNetProceeds,
   type SwapNetProceedsArgs,
   SwapNotEnoughBaseError,
-} from "@sdk/emojicoin_dot_fun/calculate-swap-price";
-import type { DatabaseModels } from "@sdk/indexer-v2/types";
-import type { AnyNumberString } from "@sdk/types/types";
+} from "@/sdk/emojicoin_dot_fun/calculate-swap-price";
+import type { DatabaseModels } from "@/sdk/indexer-v2/types";
+import type { AnyNumberString } from "@/sdk/types/types";
 
 /**
  * This hook calls the client-side calculation of the swap net proceeds amount.

--- a/src/typescript/frontend/src/lib/local-development/inner.tsx
+++ b/src/typescript/frontend/src/lib/local-development/inner.tsx
@@ -3,11 +3,6 @@
 
 import { Network } from "@aptos-labs/ts-sdk";
 import { type AccountInfo, useWallet, type WalletName } from "@aptos-labs/wallet-adapter-react";
-import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS, ONE_APT } from "@/sdk/const";
-import { encodeEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
-import { getEvents, getMarketAddress } from "@/sdk/emojicoin_dot_fun";
-import { fetchAllCurrentMeleeData, toArenaCoinTypes, toCoinTypesForEntry } from "@/sdk/markets";
-import { getAptosClient } from "@/sdk/utils";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { APTOS_NETWORK } from "lib/env";
@@ -27,6 +22,11 @@ import {
   RegisterMarket,
   Swap,
 } from "@/contract-apis";
+import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS, ONE_APT } from "@/sdk/const";
+import { encodeEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
+import { getEvents, getMarketAddress } from "@/sdk/emojicoin_dot_fun";
+import { fetchAllCurrentMeleeData, toArenaCoinTypes, toCoinTypesForEntry } from "@/sdk/markets";
+import { getAptosClient } from "@/sdk/utils";
 
 const iconClassName = "p-2 !text-white cursor-pointer !h-[40px] !w-[40px]";
 const debugButtonClassName =

--- a/src/typescript/frontend/src/lib/local-development/inner.tsx
+++ b/src/typescript/frontend/src/lib/local-development/inner.tsx
@@ -3,11 +3,11 @@
 
 import { Network } from "@aptos-labs/ts-sdk";
 import { type AccountInfo, useWallet, type WalletName } from "@aptos-labs/wallet-adapter-react";
-import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS, ONE_APT } from "@sdk/const";
-import { encodeEmojis, type SymbolEmoji } from "@sdk/emoji_data";
-import { getEvents, getMarketAddress } from "@sdk/emojicoin_dot_fun";
-import { fetchAllCurrentMeleeData, toArenaCoinTypes, toCoinTypesForEntry } from "@sdk/markets";
-import { getAptosClient } from "@sdk/utils";
+import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS, ONE_APT } from "@/sdk/const";
+import { encodeEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
+import { getEvents, getMarketAddress } from "@/sdk/emojicoin_dot_fun";
+import { fetchAllCurrentMeleeData, toArenaCoinTypes, toCoinTypesForEntry } from "@/sdk/markets";
+import { getAptosClient } from "@/sdk/utils";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { APTOS_NETWORK } from "lib/env";

--- a/src/typescript/frontend/src/lib/queries/aptos-client/market-view.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-client/market-view.ts
@@ -1,11 +1,11 @@
 "use server";
 
-import { getAptosClient } from "@/sdk/utils/aptos-client";
-import { toMarketView } from "@/sdk-types";
 import { unstable_cache } from "next/cache";
 import { parseJSON, stringifyJSON } from "utils";
 
 import { MarketView } from "@/contract-apis/emojicoin-dot-fun";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
+import { toMarketView } from "@/sdk-types";
 
 const fetchContractMarketView = async (marketAddress: `0x${string}`) => {
   const aptos = getAptosClient();

--- a/src/typescript/frontend/src/lib/queries/aptos-client/market-view.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-client/market-view.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import { getAptosClient } from "@sdk/utils/aptos-client";
-import { toMarketView } from "@sdk-types";
+import { getAptosClient } from "@/sdk/utils/aptos-client";
+import { toMarketView } from "@/sdk-types";
 import { unstable_cache } from "next/cache";
 import { parseJSON, stringifyJSON } from "utils";
 

--- a/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-emojicoin-balances.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-emojicoin-balances.ts
@@ -1,6 +1,6 @@
 // cspell:word ilike
 import { AccountAddress } from "@aptos-labs/ts-sdk";
-import { getAptosClient, removeLeadingZerosFromStructString } from "@sdk/utils";
+import { getAptosClient, removeLeadingZerosFromStructString } from "@/sdk/utils";
 
 export type AssetBalance = {
   amount: string;

--- a/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-emojicoin-balances.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-emojicoin-balances.ts
@@ -1,5 +1,6 @@
 // cspell:word ilike
 import { AccountAddress } from "@aptos-labs/ts-sdk";
+
 import { getAptosClient, removeLeadingZerosFromStructString } from "@/sdk/utils";
 
 export type AssetBalance = {

--- a/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-owner-emojicoin-balances.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-owner-emojicoin-balances.ts
@@ -1,4 +1,5 @@
 import { parseTypeTag } from "@aptos-labs/ts-sdk";
+
 import { encodeEmojis, getSymbolEmojisInString } from "@/sdk/emoji_data";
 import { getEmojicoinMarketAddressAndTypeTags } from "@/sdk/markets";
 

--- a/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-owner-emojicoin-balances.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-owner-emojicoin-balances.ts
@@ -1,6 +1,6 @@
 import { parseTypeTag } from "@aptos-labs/ts-sdk";
-import { encodeEmojis, getSymbolEmojisInString } from "@sdk/emoji_data";
-import { getEmojicoinMarketAddressAndTypeTags } from "@sdk/markets";
+import { encodeEmojis, getSymbolEmojisInString } from "@/sdk/emoji_data";
+import { getEmojicoinMarketAddressAndTypeTags } from "@/sdk/markets";
 
 import {
   type AssetBalance,

--- a/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
@@ -1,8 +1,9 @@
 "use server";
 
 import { AccountAddress } from "@aptos-labs/ts-sdk";
-import { toCoinTypes } from "@/sdk/markets";
 import { unstable_cache } from "next/cache";
+
+import { toCoinTypes } from "@/sdk/markets";
 
 import { fetchEmojicoinBalances } from "./fetch-emojicoin-balances";
 

--- a/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { AccountAddress } from "@aptos-labs/ts-sdk";
-import { toCoinTypes } from "@sdk/markets";
+import { toCoinTypes } from "@/sdk/markets";
 import { unstable_cache } from "next/cache";
 
 import { fetchEmojicoinBalances } from "./fetch-emojicoin-balances";

--- a/src/typescript/frontend/src/lib/queries/price-feed.ts
+++ b/src/typescript/frontend/src/lib/queries/price-feed.ts
@@ -1,8 +1,8 @@
-import { ORDER_BY } from "@/sdk/indexer-v2/const";
-import { SortMarketsBy } from "@/sdk/indexer-v2/types";
 import { unstable_cache } from "next/cache";
 
 import { fetchPriceFeedWithMarketState } from "@/queries/home";
+import { ORDER_BY } from "@/sdk/indexer-v2/const";
+import { SortMarketsBy } from "@/sdk/indexer-v2/types";
 
 export const NUM_MARKETS_ON_PRICE_FEED = 25;
 

--- a/src/typescript/frontend/src/lib/queries/price-feed.ts
+++ b/src/typescript/frontend/src/lib/queries/price-feed.ts
@@ -1,5 +1,5 @@
-import { ORDER_BY } from "@sdk/indexer-v2/const";
-import { SortMarketsBy } from "@sdk/indexer-v2/types";
+import { ORDER_BY } from "@/sdk/indexer-v2/const";
+import { SortMarketsBy } from "@/sdk/indexer-v2/types";
 import { unstable_cache } from "next/cache";
 
 import { fetchPriceFeedWithMarketState } from "@/queries/home";

--- a/src/typescript/frontend/src/lib/queries/sorting/query-params.ts
+++ b/src/typescript/frontend/src/lib/queries/sorting/query-params.ts
@@ -1,6 +1,7 @@
+import { safeParsePageWithDefault } from "lib/routes/home-page-params";
+
 import type { OrderByStrings } from "@/sdk/indexer-v2/const";
 import { DEFAULT_SORT_BY, type SortMarketsBy } from "@/sdk/indexer-v2/types/common";
-import { safeParsePageWithDefault } from "lib/routes/home-page-params";
 
 import { type SortByPageQueryParams, toMarketDataSortByHomePage } from "./types";
 

--- a/src/typescript/frontend/src/lib/queries/sorting/query-params.ts
+++ b/src/typescript/frontend/src/lib/queries/sorting/query-params.ts
@@ -1,5 +1,5 @@
-import type { OrderByStrings } from "@sdk/indexer-v2/const";
-import { DEFAULT_SORT_BY, type SortMarketsBy } from "@sdk/indexer-v2/types/common";
+import type { OrderByStrings } from "@/sdk/indexer-v2/const";
+import { DEFAULT_SORT_BY, type SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 import { safeParsePageWithDefault } from "lib/routes/home-page-params";
 
 import { type SortByPageQueryParams, toMarketDataSortByHomePage } from "./types";

--- a/src/typescript/frontend/src/lib/queries/sorting/types.ts
+++ b/src/typescript/frontend/src/lib/queries/sorting/types.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SORT_BY, SortMarketsBy } from "@sdk/indexer-v2/types/common";
+import { DEFAULT_SORT_BY, SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 
 export type MarketDataSortByHomePage =
   | SortMarketsBy.MarketCap

--- a/src/typescript/frontend/src/lib/routes/home-page-params.ts
+++ b/src/typescript/frontend/src/lib/routes/home-page-params.ts
@@ -1,5 +1,5 @@
-import { toOrderBy } from "@sdk/indexer-v2/const";
-import { Schemas } from "@sdk/utils";
+import { toOrderBy } from "@/sdk/indexer-v2/const";
+import { Schemas } from "@/sdk/utils";
 import type { HomePageSearchParams } from "lib/queries/sorting/query-params";
 import { toMarketDataSortByHomePage } from "lib/queries/sorting/types";
 

--- a/src/typescript/frontend/src/lib/routes/home-page-params.ts
+++ b/src/typescript/frontend/src/lib/routes/home-page-params.ts
@@ -1,7 +1,8 @@
-import { toOrderBy } from "@/sdk/indexer-v2/const";
-import { Schemas } from "@/sdk/utils";
 import type { HomePageSearchParams } from "lib/queries/sorting/query-params";
 import { toMarketDataSortByHomePage } from "lib/queries/sorting/types";
+
+import { toOrderBy } from "@/sdk/indexer-v2/const";
+import { Schemas } from "@/sdk/utils";
 
 export interface HomePageParams {
   params?: {};

--- a/src/typescript/frontend/src/lib/server-env.ts
+++ b/src/typescript/frontend/src/lib/server-env.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { EMOJICOIN_INDEXER_URL } from "@sdk/server/env";
+import { EMOJICOIN_INDEXER_URL } from "@/sdk/server/env";
 
 import { APTOS_NETWORK, IS_ALLOWLIST_ENABLED } from "./env";
 

--- a/src/typescript/frontend/src/lib/store/arena/store.ts
+++ b/src/typescript/frontend/src/lib/store/arena/store.ts
@@ -1,11 +1,11 @@
-import { ArenaPeriod, Period } from "@sdk/const";
+import { ArenaPeriod, Period } from "@/sdk/const";
 import type {
   ArenaEnterModel,
   ArenaExitModel,
   ArenaInfoModel,
   ArenaMeleeModel,
   ArenaSwapModel,
-} from "@sdk/indexer-v2";
+} from "@/sdk/indexer-v2";
 import type { WritableDraft } from "immer";
 import type { ArenaChartSymbol } from "lib/chart-utils";
 

--- a/src/typescript/frontend/src/lib/store/arena/store.ts
+++ b/src/typescript/frontend/src/lib/store/arena/store.ts
@@ -1,3 +1,6 @@
+import type { WritableDraft } from "immer";
+import type { ArenaChartSymbol } from "lib/chart-utils";
+
 import { ArenaPeriod, Period } from "@/sdk/const";
 import type {
   ArenaEnterModel,
@@ -6,8 +9,6 @@ import type {
   ArenaMeleeModel,
   ArenaSwapModel,
 } from "@/sdk/indexer-v2";
-import type { WritableDraft } from "immer";
-import type { ArenaChartSymbol } from "lib/chart-utils";
 
 import type { CandlestickData } from "../event/types";
 import { createInitialCandlestickData } from "../utils";

--- a/src/typescript/frontend/src/lib/store/arena/utils.ts
+++ b/src/typescript/frontend/src/lib/store/arena/utils.ts
@@ -1,12 +1,12 @@
-import type { ArenaCandlestickModel, ArenaModelWithMeleeID } from "@sdk/indexer-v2";
+import type { ArenaCandlestickModel, ArenaModelWithMeleeID } from "@/sdk/indexer-v2";
 import {
   isArenaCandlestickModel,
   isArenaEnterModel,
   isArenaExitModel,
   isArenaMeleeModel,
   isArenaSwapModel,
-} from "@sdk/types/arena-types";
-import { toNominal } from "@sdk/utils";
+} from "@/sdk/types/arena-types";
+import { toNominal } from "@/sdk/utils";
 import type { WritableDraft } from "immer";
 
 import { toBar } from "../event/candlestick-bars";

--- a/src/typescript/frontend/src/lib/store/arena/utils.ts
+++ b/src/typescript/frontend/src/lib/store/arena/utils.ts
@@ -1,3 +1,5 @@
+import type { WritableDraft } from "immer";
+
 import type { ArenaCandlestickModel, ArenaModelWithMeleeID } from "@/sdk/indexer-v2";
 import {
   isArenaCandlestickModel,
@@ -7,7 +9,6 @@ import {
   isArenaSwapModel,
 } from "@/sdk/types/arena-types";
 import { toNominal } from "@/sdk/utils";
-import type { WritableDraft } from "immer";
 
 import { toBar } from "../event/candlestick-bars";
 import { callbackClonedLatestBarIfSubscribed } from "../utils";

--- a/src/typescript/frontend/src/lib/store/emoji-picker-store.ts
+++ b/src/typescript/frontend/src/lib/store/emoji-picker-store.ts
@@ -1,5 +1,6 @@
-import type { AnyEmoji, SymbolEmojiData } from "@/sdk/emoji_data";
 import { createStore } from "zustand";
+
+import type { AnyEmoji, SymbolEmojiData } from "@/sdk/emoji_data";
 
 import { insertEmojiTextInputHelper, removeEmojiTextInputHelper } from "./emoji-picker-utils";
 

--- a/src/typescript/frontend/src/lib/store/emoji-picker-store.ts
+++ b/src/typescript/frontend/src/lib/store/emoji-picker-store.ts
@@ -1,4 +1,4 @@
-import type { AnyEmoji, SymbolEmojiData } from "@sdk/emoji_data";
+import type { AnyEmoji, SymbolEmojiData } from "@/sdk/emoji_data";
 import { createStore } from "zustand";
 
 import { insertEmojiTextInputHelper, removeEmojiTextInputHelper } from "./emoji-picker-utils";

--- a/src/typescript/frontend/src/lib/store/emoji-picker-utils.ts
+++ b/src/typescript/frontend/src/lib/store/emoji-picker-utils.ts
@@ -1,4 +1,4 @@
-import { getEmojisInString, isSymbolEmoji, isValidChatMessageEmoji } from "@sdk/emoji_data";
+import { getEmojisInString, isSymbolEmoji, isValidChatMessageEmoji } from "@/sdk/emoji_data";
 
 import type { EmojiPickerStore } from "./emoji-picker-store";
 

--- a/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
+++ b/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
@@ -1,3 +1,5 @@
+import Big from "big.js";
+
 import { type AnyPeriod, type Period, periodEnumToRawDuration, rawPeriodToEnum } from "@/sdk/const";
 import {
   type ArenaCandlestickModel,
@@ -8,7 +10,6 @@ import {
 import { getPeriodStartTimeFromTime, toNominal } from "@/sdk/utils";
 import { q64ToBig } from "@/sdk/utils/nominal-price";
 import type { Types } from "@/sdk-types";
-import Big from "big.js";
 
 type Bar = {
   time: number;

--- a/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
+++ b/src/typescript/frontend/src/lib/store/event/candlestick-bars.ts
@@ -1,13 +1,13 @@
-import { type AnyPeriod, type Period, periodEnumToRawDuration, rawPeriodToEnum } from "@sdk/const";
+import { type AnyPeriod, type Period, periodEnumToRawDuration, rawPeriodToEnum } from "@/sdk/const";
 import {
   type ArenaCandlestickModel,
   isPeriodicStateEventModel,
   type PeriodicStateEventModel,
   type SwapEventModel,
-} from "@sdk/indexer-v2/types";
-import { getPeriodStartTimeFromTime, toNominal } from "@sdk/utils";
-import { q64ToBig } from "@sdk/utils/nominal-price";
-import type { Types } from "@sdk-types";
+} from "@/sdk/indexer-v2/types";
+import { getPeriodStartTimeFromTime, toNominal } from "@/sdk/utils";
+import { q64ToBig } from "@/sdk/utils/nominal-price";
+import type { Types } from "@/sdk-types";
 import Big from "big.js";
 
 type Bar = {

--- a/src/typescript/frontend/src/lib/store/event/event-store.ts
+++ b/src/typescript/frontend/src/lib/store/event/event-store.ts
@@ -1,3 +1,8 @@
+import { encodeSymbolsForChart, isArenaChartSymbol } from "lib/chart-utils";
+import { immer } from "zustand/middleware/immer";
+import { createStore } from "zustand/vanilla";
+
+import { periodToPeriodTypeFromBroker } from "@/broker/index";
 import {
   type BrokerEventModels,
   isChatEventModel,
@@ -18,11 +23,6 @@ import {
   isArenaSwapModel,
 } from "@/sdk/types/arena-types";
 import { DEBUG_ASSERT, extractFilter } from "@/sdk/utils";
-import { encodeSymbolsForChart, isArenaChartSymbol } from "lib/chart-utils";
-import { immer } from "zustand/middleware/immer";
-import { createStore } from "zustand/vanilla";
-
-import { periodToPeriodTypeFromBroker } from "@/broker/index";
 
 import { ensureMeleeInStore, initializeArenaStore } from "../arena/store";
 import {

--- a/src/typescript/frontend/src/lib/store/event/event-store.ts
+++ b/src/typescript/frontend/src/lib/store/event/event-store.ts
@@ -8,7 +8,7 @@ import {
   isMarketRegistrationEventModel,
   isPeriodicStateEventModel,
   isSwapEventModel,
-} from "@sdk/indexer-v2/types";
+} from "@/sdk/indexer-v2/types";
 import {
   isArenaCandlestickModel,
   isArenaEnterModel,
@@ -16,8 +16,8 @@ import {
   isArenaMeleeModel,
   isArenaModelWithMeleeID,
   isArenaSwapModel,
-} from "@sdk/types/arena-types";
-import { DEBUG_ASSERT, extractFilter } from "@sdk/utils";
+} from "@/sdk/types/arena-types";
+import { DEBUG_ASSERT, extractFilter } from "@/sdk/utils";
 import { encodeSymbolsForChart, isArenaChartSymbol } from "lib/chart-utils";
 import { immer } from "zustand/middleware/immer";
 import { createStore } from "zustand/vanilla";

--- a/src/typescript/frontend/src/lib/store/event/local-storage.ts
+++ b/src/typescript/frontend/src/lib/store/event/local-storage.ts
@@ -1,4 +1,4 @@
-import type { EventModelWithMarket } from "@sdk/indexer-v2";
+import type { EventModelWithMarket } from "@/sdk/indexer-v2";
 import { parseJSON, stringifyJSON } from "utils";
 
 const LOCAL_STORAGE_EXPIRATION_TIME = 1000 * 60; // 10 minutes.

--- a/src/typescript/frontend/src/lib/store/event/local-storage.ts
+++ b/src/typescript/frontend/src/lib/store/event/local-storage.ts
@@ -1,5 +1,6 @@
-import type { EventModelWithMarket } from "@/sdk/indexer-v2";
 import { parseJSON, stringifyJSON } from "utils";
+
+import type { EventModelWithMarket } from "@/sdk/indexer-v2";
 
 const LOCAL_STORAGE_EXPIRATION_TIME = 1000 * 60; // 10 minutes.
 

--- a/src/typescript/frontend/src/lib/store/event/types.ts
+++ b/src/typescript/frontend/src/lib/store/event/types.ts
@@ -1,10 +1,15 @@
-import type { AnyPeriod, Period } from "@/sdk/const";
-import type { SymbolEmoji } from "@/sdk/emoji_data";
-import type { BrokerEventModels, DatabaseModels, MarketMetadataModel } from "@/sdk/indexer-v2/types";
-import type { Flatten } from "@/sdk-types";
-import type { SubscribeBarsCallback } from "@/static/charting_library/datafeed-api";
 import type { WritableDraft } from "immer";
 import type { ArenaChartSymbol } from "lib/chart-utils";
+
+import type { AnyPeriod, Period } from "@/sdk/const";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
+import type {
+  BrokerEventModels,
+  DatabaseModels,
+  MarketMetadataModel,
+} from "@/sdk/indexer-v2/types";
+import type { Flatten } from "@/sdk-types";
+import type { SubscribeBarsCallback } from "@/static/charting_library/datafeed-api";
 
 import type { ArenaActions, ArenaState } from "../arena/store";
 import type { ClientActions, ClientState } from "../websocket/store";

--- a/src/typescript/frontend/src/lib/store/event/types.ts
+++ b/src/typescript/frontend/src/lib/store/event/types.ts
@@ -1,8 +1,8 @@
-import type { AnyPeriod, Period } from "@sdk/const";
-import type { SymbolEmoji } from "@sdk/emoji_data";
-import type { BrokerEventModels, DatabaseModels, MarketMetadataModel } from "@sdk/indexer-v2/types";
-import type { Flatten } from "@sdk-types";
-import type { SubscribeBarsCallback } from "@static/charting_library/datafeed-api";
+import type { AnyPeriod, Period } from "@/sdk/const";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
+import type { BrokerEventModels, DatabaseModels, MarketMetadataModel } from "@/sdk/indexer-v2/types";
+import type { Flatten } from "@/sdk-types";
+import type { SubscribeBarsCallback } from "@/static/charting_library/datafeed-api";
 import type { WritableDraft } from "immer";
 import type { ArenaChartSymbol } from "lib/chart-utils";
 

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -1,3 +1,5 @@
+import type { WritableDraft } from "immer";
+
 import { NON_ARENA_PERIODS, Period, periodEnumToRawDuration } from "@/sdk/const";
 import type {
   EventModelWithMarket,
@@ -6,7 +8,6 @@ import type {
 } from "@/sdk/indexer-v2/types";
 import { getPeriodStartTimeFromTime } from "@/sdk/utils";
 import { q64ToBig, toNominal } from "@/sdk/utils/nominal-price";
-import type { WritableDraft } from "immer";
 
 import { callbackClonedLatestBarIfSubscribed, createInitialCandlestickData } from "../utils";
 import { createBarFromPeriodicState, createBarFromSwap } from "./candlestick-bars";

--- a/src/typescript/frontend/src/lib/store/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/event/utils.ts
@@ -1,11 +1,11 @@
-import { NON_ARENA_PERIODS, Period, periodEnumToRawDuration } from "@sdk/const";
+import { NON_ARENA_PERIODS, Period, periodEnumToRawDuration } from "@/sdk/const";
 import type {
   EventModelWithMarket,
   PeriodicStateEventModel,
   SwapEventModel,
-} from "@sdk/indexer-v2/types";
-import { getPeriodStartTimeFromTime } from "@sdk/utils";
-import { q64ToBig, toNominal } from "@sdk/utils/nominal-price";
+} from "@/sdk/indexer-v2/types";
+import { getPeriodStartTimeFromTime } from "@/sdk/utils";
+import { q64ToBig, toNominal } from "@/sdk/utils/nominal-price";
 import type { WritableDraft } from "immer";
 
 import { callbackClonedLatestBarIfSubscribed, createInitialCandlestickData } from "../utils";

--- a/src/typescript/frontend/src/lib/store/utils.ts
+++ b/src/typescript/frontend/src/lib/store/utils.ts
@@ -1,5 +1,6 @@
-import type { SubscribeBarsCallback } from "@/static/charting_library";
 import type { WritableDraft } from "immer";
+
+import type { SubscribeBarsCallback } from "@/static/charting_library";
 
 import type { LatestBar } from "./event/candlestick-bars";
 import type { CandlestickData } from "./event/types";

--- a/src/typescript/frontend/src/lib/store/utils.ts
+++ b/src/typescript/frontend/src/lib/store/utils.ts
@@ -1,4 +1,4 @@
-import type { SubscribeBarsCallback } from "@static/charting_library";
+import type { SubscribeBarsCallback } from "@/static/charting_library";
 import type { WritableDraft } from "immer";
 
 import type { LatestBar } from "./event/candlestick-bars";

--- a/src/typescript/frontend/src/lib/store/websocket/store.ts
+++ b/src/typescript/frontend/src/lib/store/websocket/store.ts
@@ -1,7 +1,7 @@
 // cspell:word immerable
 "use client";
 
-import type { PeriodTypeFromBroker } from "@sdk/indexer-v2/types/json-types";
+import type { PeriodTypeFromBroker } from "@/sdk/indexer-v2/types/json-types";
 import { immerable } from "immer";
 import { BROKER_URL } from "lib/env";
 

--- a/src/typescript/frontend/src/lib/store/websocket/store.ts
+++ b/src/typescript/frontend/src/lib/store/websocket/store.ts
@@ -1,12 +1,12 @@
 // cspell:word immerable
 "use client";
 
-import type { PeriodTypeFromBroker } from "@/sdk/indexer-v2/types/json-types";
 import { immerable } from "immer";
 import { BROKER_URL } from "lib/env";
 
 import { WebSocketClient, type WebSocketClientArgs } from "@/broker/client";
 import type { SubscribableBrokerEvents } from "@/broker/types";
+import type { PeriodTypeFromBroker } from "@/sdk/indexer-v2/types/json-types";
 import type { ImmerGetEventAndClientStore, ImmerSetEventAndClientStore } from "@/store/event/types";
 
 export type ClientState = {

--- a/src/typescript/frontend/src/lib/utils/decimals.ts
+++ b/src/typescript/frontend/src/lib/utils/decimals.ts
@@ -1,6 +1,7 @@
+import Big from "big.js";
+
 import { DECIMALS } from "@/sdk/const";
 import type { AnyNumberString } from "@/sdk-types";
-import Big from "big.js";
 
 // Converts a number to its representation in coin decimals.
 // Both APT and emojicoins use a fixed number of decimals: 8.

--- a/src/typescript/frontend/src/lib/utils/decimals.ts
+++ b/src/typescript/frontend/src/lib/utils/decimals.ts
@@ -1,5 +1,5 @@
-import { DECIMALS } from "@sdk/const";
-import type { AnyNumberString } from "@sdk-types";
+import { DECIMALS } from "@/sdk/const";
+import type { AnyNumberString } from "@/sdk-types";
 import Big from "big.js";
 
 // Converts a number to its representation in coin decimals.

--- a/src/typescript/frontend/src/lib/utils/emojis-to-name-or-symbol.ts
+++ b/src/typescript/frontend/src/lib/utils/emojis-to-name-or-symbol.ts
@@ -1,4 +1,4 @@
-import type { SymbolEmojiData } from "@sdk/emoji_data";
+import type { SymbolEmojiData } from "@/sdk/emoji_data";
 
 /**
  * Converts an array of SymbolEmojiData to a string of names.

--- a/src/typescript/frontend/src/lib/utils/explorer-link.ts
+++ b/src/typescript/frontend/src/lib/utils/explorer-link.ts
@@ -1,5 +1,6 @@
-import type { AnyNumberString } from "@/sdk-types";
 import { APTOS_NETWORK } from "lib/env";
+
+import type { AnyNumberString } from "@/sdk-types";
 
 const linkTypes = {
   coin: "coin",

--- a/src/typescript/frontend/src/lib/utils/explorer-link.ts
+++ b/src/typescript/frontend/src/lib/utils/explorer-link.ts
@@ -1,4 +1,4 @@
-import type { AnyNumberString } from "@sdk-types";
+import type { AnyNumberString } from "@/sdk-types";
 import { APTOS_NETWORK } from "lib/env";
 
 const linkTypes = {

--- a/src/typescript/frontend/src/lib/utils/format-number-string.ts
+++ b/src/typescript/frontend/src/lib/utils/format-number-string.ts
@@ -1,5 +1,5 @@
-import { toNominal } from "@sdk/utils";
-import type { AnyNumberString, Flatten } from "@sdk-types";
+import { toNominal } from "@/sdk/utils";
+import type { AnyNumberString, Flatten } from "@/sdk-types";
 
 /**
  * Sliding precision will show `decimals` decimals when Math.abs(number) is

--- a/src/typescript/frontend/src/lib/utils/get-user-rank.ts
+++ b/src/typescript/frontend/src/lib/utils/get-user-rank.ts
@@ -1,5 +1,5 @@
-import type { ChatEventModel, SwapEventModel } from "@sdk/indexer-v2/types";
-import { q64ToBig } from "@sdk/utils/nominal-price";
+import type { ChatEventModel, SwapEventModel } from "@/sdk/indexer-v2/types";
+import { q64ToBig } from "@/sdk/utils/nominal-price";
 
 enum RankIcon {
   based = "🐳",

--- a/src/typescript/frontend/src/utils/emoji.tsx
+++ b/src/typescript/frontend/src/utils/emoji.tsx
@@ -1,7 +1,8 @@
-import { type AnyEmojiData, getEmojisInString } from "@/sdk/index";
 import { useEmojiFontConfig } from "lib/hooks/use-emoji-font-family";
 import { type DetailedHTMLProps, type HTMLAttributes, useMemo } from "react";
 import type { CSSProperties } from "styled-components";
+
+import { type AnyEmojiData, getEmojisInString } from "@/sdk/index";
 
 /**
  * Displays emoji as a simple span element containing text representing one or more emojis.

--- a/src/typescript/frontend/src/utils/emoji.tsx
+++ b/src/typescript/frontend/src/utils/emoji.tsx
@@ -1,4 +1,4 @@
-import { type AnyEmojiData, getEmojisInString } from "@sdk/index";
+import { type AnyEmojiData, getEmojisInString } from "@/sdk/index";
 import { useEmojiFontConfig } from "lib/hooks/use-emoji-font-family";
 import { type DetailedHTMLProps, type HTMLAttributes, useMemo } from "react";
 import type { CSSProperties } from "styled-components";

--- a/src/typescript/frontend/src/utils/index.ts
+++ b/src/typescript/frontend/src/utils/index.ts
@@ -1,5 +1,5 @@
-import { type AnyEmojiName, CHAT_EMOJI_DATA, SYMBOL_EMOJI_DATA } from "@sdk/emoji_data";
-import { sleep } from "@sdk/utils";
+import { type AnyEmojiName, CHAT_EMOJI_DATA, SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data";
+import { sleep } from "@/sdk/utils";
 
 export { isDisallowedEventKey } from "./check-is-disallowed-event-key";
 export { checkIsEllipsis } from "./check-is-ellipsis";

--- a/src/typescript/frontend/src/utils/pathname-helpers.ts
+++ b/src/typescript/frontend/src/utils/pathname-helpers.ts
@@ -1,4 +1,4 @@
-import { SYMBOL_EMOJI_DATA } from "@sdk/emoji_data/emoji-data";
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data/emoji-data";
 import { ROUTES } from "router/routes";
 
 /**

--- a/src/typescript/frontend/src/utils/pathname-helpers.ts
+++ b/src/typescript/frontend/src/utils/pathname-helpers.ts
@@ -1,5 +1,6 @@
-import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data/emoji-data";
 import { ROUTES } from "router/routes";
+
+import { SYMBOL_EMOJI_DATA } from "@/sdk/emoji_data/emoji-data";
 
 /**
  * The delimiter for multiple emoji names; i.e.,

--- a/src/typescript/frontend/tests/mocks/charting_library.d.ts
+++ b/src/typescript/frontend/tests/mocks/charting_library.d.ts
@@ -5,7 +5,7 @@
  * Stub for TradingView charting library to silence `tsc` errors without having to
  * clone the private submodule in CI.
  */
-declare module "@static/charting_library" {
+declare module "@/static/charting_library" {
   export type Timezone = string;
   export type ThemeName = "Dark" | "Light";
   export type ResolutionString = string;

--- a/src/typescript/frontend/tests/mocks/datafeed-api.d.ts
+++ b/src/typescript/frontend/tests/mocks/datafeed-api.d.ts
@@ -3,6 +3,6 @@
  * Stub for TradingView charting library to silence `tsc` errors without having to
  * clone the private submodule in CI.
  */
-declare module "@static/charting_library/datafeed-api" {
+declare module "@/static/charting_library/datafeed-api" {
   export type SubscribeBarsCallback = (...args: any[]) => void;
 }

--- a/src/typescript/frontend/tests/unit/chart-symbol-encoding.test.ts
+++ b/src/typescript/frontend/tests/unit/chart-symbol-encoding.test.ts
@@ -1,5 +1,5 @@
-import type { SymbolEmoji } from "@sdk/emoji_data/types";
-import { isValidMarketSymbol } from "@sdk/emoji_data/valid-market-symbol";
+import type { SymbolEmoji } from "@/sdk/emoji_data/types";
+import { isValidMarketSymbol } from "@/sdk/emoji_data/valid-market-symbol";
 
 import {
   ARENA_CHART_SYMBOL_DELIMITER,

--- a/src/typescript/frontend/tsconfig.json
+++ b/src/typescript/frontend/tsconfig.json
@@ -40,22 +40,22 @@
       "@/store/*": [
         "lib/store/*"
       ],
-      "@containers": [
+      "@/containers": [
         "components/layout/components/index.ts"
       ],
-      "@hooks/*": [
+      "@/hooks/*": [
         "hooks/*"
       ],
-      "@icons/*": [
+      "@/icons/*": [
         "components/svg/icons/*"
       ],
-      "@sdk-types": [
+      "@/sdk-types": [
         "../../sdk/src/types/index.ts"
       ],
-      "@sdk/*": [
+      "@/sdk/*": [
         "../../sdk/src/*"
       ],
-      "@static/*": [
+      "@/static/*": [
         "../public/static/*"
       ]
     },

--- a/src/typescript/frontend/tsconfig.json
+++ b/src/typescript/frontend/tsconfig.json
@@ -28,26 +28,23 @@
       "@/components/*": [
         "components/*"
       ],
+      "@/containers": [
+        "components/layout/components/index.ts"
+      ],
       "@/contract-apis": [
         "../../sdk/src/emojicoin_dot_fun/contract-apis"
       ],
       "@/contract-apis/*": [
         "../../sdk/src/emojicoin_dot_fun/contract-apis/*"
       ],
-      "@/queries/*": [
-        "../../sdk/src/indexer-v2/queries/app/*"
-      ],
-      "@/store/*": [
-        "lib/store/*"
-      ],
-      "@/containers": [
-        "components/layout/components/index.ts"
-      ],
       "@/hooks/*": [
         "hooks/*"
       ],
       "@/icons/*": [
         "components/svg/icons/*"
+      ],
+      "@/queries/*": [
+        "../../sdk/src/indexer-v2/queries/app/*"
       ],
       "@/sdk-types": [
         "../../sdk/src/types/index.ts"
@@ -57,6 +54,9 @@
       ],
       "@/static/*": [
         "../public/static/*"
+      ],
+      "@/store/*": [
+        "lib/store/*"
       ]
     },
     "plugins": [


### PR DESCRIPTION
# Description

This also lets `simple-import-sort` sort imports more intelligently

The only changes are in the `frontend`, since `sdk` already was using `@/contract-apis`.

The changes made were a simple find and replace on:

- `@containers`   =>   `@/containers`
- `@hooks`        =>   `@/hooks`
- `@icons`        =>   `@/icons`
- `@sdk-types`    =>   `@/sdk-types`
- `@sdk`          =>   `@/sdk`
- `@static`       =>   `@/static`

And then I ran `pnpm run lint:fix` to auto sort imports

EDIT: Just to double check, I also made sure all usages were of the import form with regex. For example for `@containers` I checked that `@containers` appeared the same exact amount of times as `"@containers.*";`, for all replacements above.