### PR TITLE
fix(ECO-3127): Only regenerate background emojis on a step interval to avoid excessive re-renders

### DIFF
--- a/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
+++ b/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
@@ -5,7 +5,7 @@ import { Emoji } from "utils/emoji";
 
 import { getRandomSymbolEmoji } from "@/sdk/emoji_data";
 
-import { useRoughWindowSize } from "./use-window-size-with-step";
+import { useWindowSizeWithStep } from "./use-window-size-with-step";
 
 const MemoizedRandomEmoji = React.memo(OneRandomEmoji);
 
@@ -47,8 +47,7 @@ export function BackgroundEmojis() {
     return () => doc?.removeEventListener("scroll", handleScroll);
   }, []);
 
-  // Window dimensions with less granularity to avoid excessive re-renders on resize.
-  const { width, height } = useRoughWindowSize(300);
+  const { width, height } = useWindowSizeWithStep();
 
   const { rows, cols, emojis } = useMemo(() => {
     // 1x the width, 3x the height, based on the element dimensions. (h-300% w-100%)

--- a/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
+++ b/src/typescript/frontend/src/components/misc/background-emojis/BackgroundEmojis.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { useWindowSize } from "react-use";
 import { Emoji } from "utils/emoji";
 
 import { getRandomSymbolEmoji } from "@/sdk/emoji_data";
+
+import { useRoughWindowSize } from "./use-window-size-with-step";
 
 const MemoizedRandomEmoji = React.memo(OneRandomEmoji);
 
@@ -34,7 +35,6 @@ const maybeRandomEmoji = () => (Math.random() < CHANCE ? getRandomSymbolEmoji().
 const PARALLAX_STRENGTH = 0.15;
 
 export function BackgroundEmojis() {
-  const { width, height } = useWindowSize();
   const [scrollY, setScrollY] = useState(0);
 
   useEffect(() => {
@@ -46,6 +46,9 @@ export function BackgroundEmojis() {
     doc?.addEventListener("scroll", handleScroll);
     return () => doc?.removeEventListener("scroll", handleScroll);
   }, []);
+
+  // Window dimensions with less granularity to avoid excessive re-renders on resize.
+  const { width, height } = useRoughWindowSize(300);
 
   const { rows, cols, emojis } = useMemo(() => {
     // 1x the width, 3x the height, based on the element dimensions. (h-300% w-100%)

--- a/src/typescript/frontend/src/components/misc/background-emojis/use-window-size-with-step.ts
+++ b/src/typescript/frontend/src/components/misc/background-emojis/use-window-size-with-step.ts
@@ -1,52 +1,23 @@
 import { useMemo } from "react";
 import useWindowSize from "react-use/lib/useWindowSize";
 
-/**
- * Rounds a numeric value down to the nearest multiple of the specified step size.
- * @param value - The numeric value to quantize
- * @param step - The step size to quantize to
- * @returns The value rounded down to the nearest step
- */
-const stepFn = (value: number, step: number) => Math.floor(value / step) * step;
+const STEP_SIZE = 100;
 
-/** Default pixel threshold before dimensions update */
-const DEFAULT_STEP_SIZE = 100;
+// Round the input value down to the nearest multiple of STEP_SIZE.
+const stepFn = (value: number) => Math.floor(value / STEP_SIZE) * STEP_SIZE;
 
 /**
  * Returns window dimensions that only update when crossing step boundaries.
- *
- * This hook prevents excessive re-renders during window resizing by "quantizing"
- * dimensions to specific step increments. The returned width and height
- * only change when the actual window dimensions cross these step thresholds.
- *
- * @param stepSize - Optional step size in pixels. Controls how much the window must resize before
- *                   triggering an update. Defaults to {@link DEFAULT_STEP_SIZE}
- *
- * @example
- * ```tsx
- * // Basic usage with default step size
- * function ResponsiveGrid() {
- *   const { width, height } = useSteppedWindowSize();
- *   return <Grid columns={Math.ceil(width / 200)} rows={Math.ceil(height / 150)} />;
- * }
- *
- * // Custom step size of 50px for finer control
- * function PreciseLayout() {
- *   const { width, height } = useSteppedWindowSize(50);
- *   return <Layout width={width} height={height} />;
- * }
- * ```
- *
- * @returns Object containing stepped width and height values
+ * Prevents excessive re-renders during window resizing.
  */
-export const useRoughWindowSize = (stepSize: number = DEFAULT_STEP_SIZE) => {
+export const useWindowSizeWithStep = () => {
   const { width, height } = useWindowSize();
 
   return useMemo(
     () => ({
-      width: stepFn(width, stepSize),
-      height: stepFn(height, stepSize),
+      width: stepFn(width),
+      height: stepFn(height),
     }),
-    [width, height, stepSize]
+    [width, height]
   );
 };

--- a/src/typescript/frontend/src/components/misc/background-emojis/use-window-size-with-step.ts
+++ b/src/typescript/frontend/src/components/misc/background-emojis/use-window-size-with-step.ts
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import useWindowSize from "react-use/lib/useWindowSize";
+
+/**
+ * Rounds a numeric value down to the nearest multiple of the specified step size.
+ * @param value - The numeric value to quantize
+ * @param step - The step size to quantize to
+ * @returns The value rounded down to the nearest step
+ */
+const stepFn = (value: number, step: number) => Math.floor(value / step) * step;
+
+/** Default pixel threshold before dimensions update */
+const DEFAULT_STEP_SIZE = 100;
+
+/**
+ * Returns window dimensions that only update when crossing step boundaries.
+ *
+ * This hook prevents excessive re-renders during window resizing by "quantizing"
+ * dimensions to specific step increments. The returned width and height
+ * only change when the actual window dimensions cross these step thresholds.
+ *
+ * @param stepSize - Optional step size in pixels. Controls how much the window must resize before
+ *                   triggering an update. Defaults to {@link DEFAULT_STEP_SIZE}
+ *
+ * @example
+ * ```tsx
+ * // Basic usage with default step size
+ * function ResponsiveGrid() {
+ *   const { width, height } = useSteppedWindowSize();
+ *   return <Grid columns={Math.ceil(width / 200)} rows={Math.ceil(height / 150)} />;
+ * }
+ *
+ * // Custom step size of 50px for finer control
+ * function PreciseLayout() {
+ *   const { width, height } = useSteppedWindowSize(50);
+ *   return <Layout width={width} height={height} />;
+ * }
+ * ```
+ *
+ * @returns Object containing stepped width and height values
+ */
+export const useRoughWindowSize = (stepSize: number = DEFAULT_STEP_SIZE) => {
+  const { width, height } = useWindowSize();
+
+  return useMemo(
+    () => ({
+      width: stepFn(width, stepSize),
+      height: stepFn(height, stepSize),
+    }),
+    [width, height, stepSize]
+  );
+};

--- a/src/typescript/frontend/src/components/misc/background-emojis/use-window-size-with-step.ts
+++ b/src/typescript/frontend/src/components/misc/background-emojis/use-window-size-with-step.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import useWindowSize from "react-use/lib/useWindowSize";
 
-const STEP_SIZE = 100;
+const STEP_SIZE = 222;
 
 // Round the input value down to the nearest multiple of STEP_SIZE.
 const stepFn = (value: number) => Math.floor(value / STEP_SIZE) * STEP_SIZE;


### PR DESCRIPTION
# Description

See the videos attached below for the difference and explanation (it's fairly obvious):

https://github.com/user-attachments/assets/7babe320-6350-43d5-b51f-3a02e57f9bb3

## Fix video below in comments
