### PR TITLE
chore(ECO-3137): Fix account address parsing inputs and unit tests for account addresses with ts-sdk 1.37.1 requirements

### DIFF
--- a/src/typescript/sdk/jest.config.js
+++ b/src/typescript/sdk/jest.config.js
@@ -16,11 +16,15 @@ module.exports = {
   coveragePathIgnorePatterns: [],
   testPathIgnorePatterns: ["dist/*", "tests/utils/*"],
   collectCoverage: false,
-  globals: {
-    "ts-jest": {
-      tsconfig: "<rootDir>/tests/tsconfig.json",
-    }
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        tsconfig: "tests/tsconfig.json",
+      },
+    ],
   },
+  transformIgnorePatterns: ["node_modules"],
   coverageThreshold: {
     global: {
       branches: 50,

--- a/src/typescript/sdk/src/utils/account-address.ts
+++ b/src/typescript/sdk/src/utils/account-address.ts
@@ -6,18 +6,27 @@ import {
   type SingleKeyAccount,
 } from "@aptos-labs/ts-sdk";
 
+export const padAddressInput = <T>(s: T) =>
+  typeof s === "string"
+    ? s.startsWith("0x")
+      ? `0x${s.substring(2).padStart(64, "0")}`
+      : `0x${s.padStart(64, "0")}`
+    : s;
+
 export const standardizeAddress = (address: AccountAddressInput) =>
-  AccountAddress.from(address).toString();
+  AccountAddress.from(padAddressInput(address)).toString();
 
 type AnyAccount = Ed25519Account | SingleKeyAccount | SingleKeyAccount | Account;
 
 export const toAccountAddress = (input: AnyAccount | AccountAddressInput) =>
   AccountAddress.from(
-    typeof input === "object" && "accountAddress" in input ? input.accountAddress : input
+    typeof input === "object" && "accountAddress" in input
+      ? input.accountAddress
+      : padAddressInput(input)
   );
 
 export const toAccountAddressString = (input: AnyAccount | AccountAddressInput) =>
-  toAccountAddress(input).toString();
+  toAccountAddress(padAddressInput(input)).toString();
 
 /**
  * Remove the leading zeros from a hex string that starts with `0x`.

--- a/src/typescript/sdk/tests/unit/serialize-entry-args-to-json.test.ts
+++ b/src/typescript/sdk/tests/unit/serialize-entry-args-to-json.test.ts
@@ -13,7 +13,12 @@ import {
   U256,
 } from "@aptos-labs/ts-sdk";
 
-import { type AnyPrimitive, serializeEntryArgsToJsonArray, toAccountAddress } from "../../src";
+import {
+  type AnyPrimitive,
+  padAddressInput,
+  serializeEntryArgsToJsonArray,
+  toAccountAddress,
+} from "../../src";
 
 const MAX_U8 = 2 ** 8 - 1;
 const MAX_U16 = 2 ** 16 - 1;
@@ -44,8 +49,8 @@ describe("ensures all BCS-serializable values can be serialized to JSON-serializ
     u256_b: new U256(MAX_U256),
     string_a: new MoveString("string_a"),
     string_b: new MoveString("string_b"),
-    address_a: AccountAddress.from("0x0123456789abcdef"),
-    address_b: AccountAddress.from("0xfedcba9876543210"),
+    address_a: AccountAddress.from(padAddressInput("0x0123456789abcdef")),
+    address_b: AccountAddress.from(padAddressInput("0xfedcba9876543210")),
   };
 
   const bcsArrayArgs = {


### PR DESCRIPTION
# Description

The new TS SDK 1.37.1 (upgrading from 1.27.0, so it might be some version in between) added a requirement to `AccountAddress` conversions that the number of input hex characters must be at least 60. This wasn't previously there, so we must pad all of our addresses with as many 0s as possible before converting to an AccountAddress.

We could technically pass `AccountAddress.from(input, { maxMissingChars: 63 })` to each invocation of the function, but that might be more complicated, and this is generally an error that won't occur often, since there are rarely addresses that start with more than 4 zeros.

The main reason it's failing now is because we test those addresses specifically. 