### PR TITLE
feat(ECO-3123): Implement rewards remaining tracking

### DIFF
--- a/src/typescript/frontend/src/app/arena/page.tsx
+++ b/src/typescript/frontend/src/app/arena/page.tsx
@@ -15,9 +15,16 @@ export const metadata: Metadata = {
 export default async function Arena() {
   if (!FEATURE_FLAGS.Arena) redirect(ROUTES.home);
 
-  const { arenaInfo, market0, market1 } = await fetchCachedMeleeData();
+  const { arenaInfo, market0, market1, rewardsRemaining } = await fetchCachedMeleeData();
 
-  if (!arenaInfo || !market0 || !market1) redirect(ROUTES.home);
+  if (!arenaInfo || !market0 || !market1 || rewardsRemaining === null) redirect(ROUTES.home);
 
-  return <ArenaClient arenaInfo={arenaInfo} market0={market0} market1={market1} />;
+  return (
+    <ArenaClient
+      arenaInfo={arenaInfo}
+      market0={market0}
+      market1={market1}
+      vaultBalance={rewardsRemaining}
+    />
+  );
 }

--- a/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
@@ -2,7 +2,6 @@
 
 import type { ClassValue } from "clsx";
 import { Countdown } from "components/Countdown";
-import { FormattedNumber } from "components/FormattedNumber";
 import { useEventStore } from "context/event-store-context/hooks";
 import React, { useEffect } from "react";
 import { createPortal } from "react-dom";
@@ -11,26 +10,10 @@ import ChartContainer from "@/components/charts/ChartContainer";
 import { useMatchBreakpoints } from "@/hooks/index";
 import { useCurrentMeleeInfo } from "@/hooks/use-current-melee-info";
 
+import RewardsRemainingBox from "./RewardsRemainingBox";
 import { MobileNavigation, TabContainer } from "./tabs";
-import { type ArenaProps, Box, EmojiTitle } from "./utils";
-
-const RewardsRemainingBox = ({ rewardsRemaining }: { rewardsRemaining: bigint }) => {
-  const { isMobile } = useMatchBreakpoints();
-  return (
-    <Box className="grid grid-rows-[auto_1fr] place-items-center p-[1em]">
-      <div
-        className={`uppercase ${isMobile ? "text-2xl" : "text-3xl"} text-light-gray tracking-widest text-center`}
-      >
-        {"Rewards remaining"}
-      </div>
-      <div
-        className={`uppercase font-forma ${isMobile ? "text-4xl" : "text-6xl lg:text-7xl xl:text-8xl"} text-white`}
-      >
-        <FormattedNumber value={rewardsRemaining} nominalize />
-      </div>
-    </Box>
-  );
-};
+import type { ArenaProps, ArenaPropsWithVaultBalance } from "./utils";
+import { Box, EmojiTitle } from "./utils";
 
 const chartBoxClassName: ClassValue = "relative w-full h-full col-start-1 col-end-3";
 
@@ -50,7 +33,7 @@ const Desktop = React.memo((props: ArenaProps) => {
       <Box className="col-start-2 col-end-4 text-5xl lg:text-6xl xl:text-7xl grid place-items-center">
         <Countdown startTime={arenaInfo.startTime} duration={arenaInfo.duration / 1000n / 1000n} />
       </Box>
-      <RewardsRemainingBox rewardsRemaining={arenaInfo.rewardsRemaining} />
+      <RewardsRemainingBox />
       <Box className={chartBoxClassName}>
         <ChartContainer
           symbol={market0.market.symbolData.symbol}
@@ -81,7 +64,7 @@ const Mobile = React.memo((props: ArenaProps) => {
             />
           </div>
         </Box>
-        <RewardsRemainingBox rewardsRemaining={arenaInfo.rewardsRemaining} />
+        <RewardsRemainingBox />
         <Box className="h-[500px]">
           <Box className={chartBoxClassName}>
             <ChartContainer
@@ -99,17 +82,19 @@ const Mobile = React.memo((props: ArenaProps) => {
 // Necessary to add a display name because of the React.memo wrapper.
 Mobile.displayName = "Mobile";
 
-export const ArenaClient = (props: ArenaProps) => {
+export const ArenaClient = (props: ArenaPropsWithVaultBalance) => {
   const { isMobile } = useMatchBreakpoints();
   const loadArenaInfoFromServer = useEventStore((s) => s.loadArenaInfoFromServer);
   const loadMarketStateFromServer = useEventStore((s) => s.loadMarketStateFromServer);
+  const loadVaultBalanceFromServer = useEventStore((s) => s.loadVaultBalanceFromServer);
   const { meleeInfo: arenaInfo, market0, market1 } = useCurrentMeleeInfo();
 
   useEffect(() => {
     loadArenaInfoFromServer(props.arenaInfo);
     loadMarketStateFromServer([props.market0]);
     loadMarketStateFromServer([props.market1]);
-  }, [loadArenaInfoFromServer, loadMarketStateFromServer, props]);
+    loadVaultBalanceFromServer(props.vaultBalance);
+  }, [loadArenaInfoFromServer, loadMarketStateFromServer, loadVaultBalanceFromServer, props]);
 
   return isMobile ? (
     <Mobile

--- a/src/typescript/frontend/src/components/pages/arena/RewardsRemainingBox.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/RewardsRemainingBox.tsx
@@ -7,7 +7,7 @@ import { Box } from "./utils";
 export default function RewardsRemainingBox() {
   const rewardsRemaining = useRewardsRemaining();
   const { isMobile } = useMatchBreakpoints();
-  
+
   return (
     <Box className="grid grid-rows-[auto_1fr] place-items-center p-[1em]">
       <div

--- a/src/typescript/frontend/src/components/pages/arena/RewardsRemainingBox.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/RewardsRemainingBox.tsx
@@ -1,0 +1,25 @@
+import { FormattedNumber } from "@/components/FormattedNumber";
+import { useMatchBreakpoints } from "@/hooks/index";
+import useRewardsRemaining from "@/hooks/use-rewards-remaining";
+
+import { Box } from "./utils";
+
+export default function RewardsRemainingBox() {
+  const rewardsRemaining = useRewardsRemaining();
+  const { isMobile } = useMatchBreakpoints();
+  
+  return (
+    <Box className="grid grid-rows-[auto_1fr] place-items-center p-[1em]">
+      <div
+        className={`uppercase ${isMobile ? "text-2xl" : "text-3xl"} text-light-gray tracking-widest text-center`}
+      >
+        {"Rewards remaining"}
+      </div>
+      <div
+        className={`uppercase font-forma ${isMobile ? "text-4xl" : "text-6xl lg:text-7xl xl:text-8xl"} text-white`}
+      >
+        <FormattedNumber value={rewardsRemaining} nominalize scramble />
+      </div>
+    </Box>
+  );
+}

--- a/src/typescript/frontend/src/components/pages/arena/utils.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/utils.tsx
@@ -14,6 +14,8 @@ export type ArenaProps = {
   market1: MarketStateModel;
 };
 
+export type ArenaPropsWithVaultBalance = ArenaProps & { vaultBalance: bigint };
+
 export const Box = ({
   className,
   children,

--- a/src/typescript/frontend/src/hooks/use-rewards-remaining.ts
+++ b/src/typescript/frontend/src/hooks/use-rewards-remaining.ts
@@ -1,0 +1,15 @@
+import { useEventStore } from "context/event-store-context/hooks";
+import { useMemo } from "react";
+
+import { minBigInt } from "@/sdk/index";
+
+export default function useRewardsRemaining() {
+  const arenaInfo = useEventStore((s) => s.arenaInfoFromServer);
+  const vaultBalance = useEventStore((s) => s.vaultBalance);
+
+  return useMemo(() => {
+    if (!arenaInfo) return 0n;
+    if (!vaultBalance) return arenaInfo.rewardsRemaining;
+    return minBigInt(arenaInfo.rewardsRemaining, vaultBalance);
+  }, [arenaInfo, vaultBalance]);
+}

--- a/src/typescript/frontend/src/lib/store/event/event-store.ts
+++ b/src/typescript/frontend/src/lib/store/event/event-store.ts
@@ -24,7 +24,11 @@ import {
 } from "@/sdk/types/arena-types";
 import { compareBigInt, DEBUG_ASSERT, extractFilter } from "@/sdk/utils";
 
-import { ensureMeleeInStore, initializeArenaStore } from "../arena/event/store";
+import {
+  ensureMeleeInStore,
+  initializeArenaStore,
+  updateRewardsRemainingAndVaultBalance,
+} from "../arena/event/store";
 import {
   getMeleeIDFromArenaModel,
   handleLatestBarForArenaCandlestick,
@@ -83,6 +87,11 @@ export const createEventStore = () => {
           );
           ensureMeleeInStore(state, info.meleeID);
           state.meleeMap.set(arenaSymbol, info.meleeID);
+        });
+      },
+      loadVaultBalanceFromServer: (vaultBalance) => {
+        set((state) => {
+          state.vaultBalance = vaultBalance;
         });
       },
       loadMarketStateFromServer: (states) => {
@@ -213,6 +222,7 @@ export const createEventStore = () => {
                   }
                 }
               }
+              updateRewardsRemainingAndVaultBalance(state, event);
             }
           });
         });

--- a/src/typescript/sdk/src/indexer-v2/queries/app/arena.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/app/arena.ts
@@ -11,6 +11,7 @@ import {
   toArenaInfoModel,
   toArenaMeleeModel,
   toArenaPositionModel,
+  toArenaVaultBalanceUpdateModel,
   toMarketStateModel,
 } from "../../types";
 import { TableName } from "../../types/json-types";
@@ -40,6 +41,15 @@ const selectArenaInfo = () =>
     .order("melee_id", ORDER_BY.DESC)
     .limit(1)
     .single<DatabaseJsonType["arena_info"]>();
+
+const selectVaultBalance = () =>
+  postgrest
+    .from(TableName.ArenaVaultBalanceUpdateEvents)
+    .select("*")
+    .order("transaction_version", ORDER_BY.DESC)
+    .order("event_index", ORDER_BY.DESC)
+    .limit(1)
+    .maybeSingle();
 
 const selectPosition = ({ user, meleeID }: { user: AccountAddressInput; meleeID: bigint }) =>
   postgrest
@@ -103,6 +113,10 @@ export const fetchArenaInfo = queryHelperSingle(selectArenaInfo, toArenaInfoMode
 export const fetchArenaInfoByMeleeID = queryHelperSingle(
   selectArenaInfoByMeleeID,
   toArenaInfoModel
+);
+export const fetchVaultBalance = queryHelperSingle(
+  selectVaultBalance,
+  toArenaVaultBalanceUpdateModel
 );
 export const fetchPosition = queryHelperSingle(selectPosition, toArenaPositionModel);
 export const fetchMarketStateByAddress = queryHelperSingle(


### PR DESCRIPTION
# Description

- Take into account vault balance.
- Take into account distributed rewards since last querying of remaining
  rewards
- Take into account collected tap out fees since last querying of
  remaining rewards
- Take into account a new melee

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
