### PR TITLE
refactor(ECO-3140): Use `Nominal` `CoinTypeString` and update arena field names to be accurate

### DIFF
--- a/src/typescript/frontend/src/app/api/coingecko/tickers/route.ts
+++ b/src/typescript/frontend/src/app/api/coingecko/tickers/route.ts
@@ -2,7 +2,7 @@ import { getAptPrice } from "lib/queries/get-apt-price";
 import type { NextRequest } from "next/server";
 import { stringifyJSON } from "utils";
 
-import { APTOS_COIN_TYPE_TAG } from "@/sdk/const";
+import { APTOS_COIN_TYPE_STRING } from "@/sdk/const";
 import { postgrest } from "@/sdk/indexer-v2/queries/client";
 import { TableName } from "@/sdk/indexer-v2/types";
 import { toNominal, toNominalPrice } from "@/sdk/utils";
@@ -52,14 +52,12 @@ export async function GET(request: NextRequest) {
     .order("market_id")
     .range(skip, skip + limit - 1);
 
-  const APTOS_COIN = APTOS_COIN_TYPE_TAG.toString();
-
   const aptPrice = await getAptPrice();
 
   const data = markets.data?.map((e) => ({
-    ticker_id: `${e.market_address}::coin_factory::Emojicoin_${APTOS_COIN}`,
+    ticker_id: `${e.market_address}::coin_factory::Emojicoin_${APTOS_COIN_TYPE_STRING}`,
     base_currency: `${e.market_address}::coin_factory::Emojicoin`,
-    target_currency: APTOS_COIN,
+    target_currency: APTOS_COIN_TYPE_STRING,
     pool_id: e.symbol_emojis.join(""),
     last_price: toNominalPrice(e.last_swap_avg_execution_price_q64).toString(),
     base_volume: toNominal(BigInt(e.daily_base_volume)).toString(),

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-emojicoin/SwapComponent.tsx
@@ -23,7 +23,7 @@ import { getMaxSlippageSettings } from "utils/slippage";
 
 import { Flex, FlexGap } from "@/containers";
 import { useTooltip } from "@/hooks/index";
-import { toCoinTypes } from "@/sdk/markets/utils";
+import { toEmojicoinTypes } from "@/sdk/markets/utils";
 
 import FlipInputsArrow from "./FlipInputsArrow";
 import { AptosInputLabel, EmojiInputLabel } from "./InputLabels";
@@ -104,7 +104,7 @@ export default function SwapComponent({
   });
 
   useEffect(() => {
-    const emojicoinType = toCoinTypes(marketAddress).emojicoin.toString();
+    const emojicoinType = toEmojicoinTypes(marketAddress).emojicoin.toString();
     setEmojicoinType(emojicoinType);
   }, [marketAddress, setEmojicoinType]);
 

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { TypeTag } from "@aptos-labs/ts-sdk";
 import { Button, InputNumeric, Text } from "components";
 import { EmojiPill } from "components/EmojiPill";
 import { FormattedNumber } from "components/FormattedNumber";
@@ -130,7 +129,7 @@ const Liquidity = ({ market }: LiquidityProps) => {
       : true;
 
   useEffect(() => {
-    if (emojicoin instanceof TypeTag) {
+    if (emojicoin) {
       setEmojicoinType(emojicoin);
     }
   }, [emojicoin, setEmojicoinType]);

--- a/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/components/liquidity/index.tsx
@@ -24,7 +24,7 @@ import React, { type PropsWithChildren, useEffect, useMemo, useState } from "rea
 
 import { Column, Flex, FlexGap } from "@/containers";
 import { useMatchBreakpoints } from "@/hooks/index";
-import { toCoinTypes } from "@/sdk/markets/utils";
+import { toEmojicoinTypes } from "@/sdk/markets/utils";
 
 import type { PoolsData } from "../../ClientPoolsPage";
 import { StyledAddLiquidityWrapper } from "./styled";
@@ -108,7 +108,7 @@ const Liquidity = ({ market }: LiquidityProps) => {
     quoteAmount: liquidity ?? 0n,
   });
 
-  const { emojicoin } = marketAddress ? toCoinTypes(marketAddress) : { emojicoin: "" };
+  const { emojicoin } = marketAddress ? toEmojicoinTypes(marketAddress) : { emojicoin: "" };
 
   const removeLiquidityResult = useSimulateRemoveLiquidity({
     marketAddress,

--- a/src/typescript/frontend/src/context/wallet-context/utils.ts
+++ b/src/typescript/frontend/src/context/wallet-context/utils.ts
@@ -1,9 +1,4 @@
-import {
-  AccountAddress,
-  parseTypeTag,
-  TypeTag,
-  type UserTransactionResponse,
-} from "@aptos-labs/ts-sdk";
+import { AccountAddress, TypeTag, type UserTransactionResponse } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
 import type { Dispatch, SetStateAction } from "react";
 import { toast } from "react-toastify";
@@ -11,7 +6,7 @@ import { emoji } from "utils";
 
 import type { TypeTagInput } from "@/sdk/emojicoin_dot_fun";
 import { getEventsAsProcessorModelsFromResponse } from "@/sdk/indexer-v2/mini-processor";
-import { getAptBalanceFromChanges, getCoinBalanceFromChanges } from "@/sdk/utils";
+import { getAptBalanceFromChanges, getCoinBalanceFromChanges, toCoinTypeString } from "@/sdk/utils";
 
 export const setBalancesFromWriteset = ({
   response,
@@ -36,10 +31,10 @@ export const setBalancesFromWriteset = ({
 
   const newAptBalance = getAptBalanceFromChanges(response, userAddress);
   const newEmojicoinBalance = emojicoin
-    ? getCoinBalanceFromChanges({ response, userAddress, coinType: parseTypeTag(emojicoin) })
+    ? getCoinBalanceFromChanges({ response, userAddress, coinType: toCoinTypeString(emojicoin) })
     : undefined;
   const newEmojicoinLPBalance = emojicoinLP
-    ? getCoinBalanceFromChanges({ response, userAddress, coinType: parseTypeTag(emojicoinLP) })
+    ? getCoinBalanceFromChanges({ response, userAddress, coinType: toCoinTypeString(emojicoinLP) })
     : undefined;
   // Update the user's balance if the coins are present in the write set changes.
   if (typeof newAptBalance !== "undefined") setAptBalance(newAptBalance);

--- a/src/typescript/frontend/src/lib/hooks/queries/use-get-swap-gas.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-get-swap-gas.ts
@@ -1,4 +1,4 @@
-import type { Aptos, TypeTag } from "@aptos-labs/ts-sdk";
+import type { Aptos } from "@aptos-labs/ts-sdk";
 import type { AccountInfo } from "@aptos-labs/wallet-adapter-core";
 import { useQuery } from "@tanstack/react-query";
 import Big from "big.js";
@@ -9,7 +9,7 @@ import { useMemo } from "react";
 import { tryEd25519PublicKey } from "@/components/pages/launch-emojicoin/hooks/use-register-market";
 import { Swap } from "@/move-modules/emojicoin-dot-fun";
 import type { AccountAddressString, AnyNumber, TypeTagInput } from "@/sdk/emojicoin_dot_fun";
-import { toCoinTypes } from "@/sdk/markets/utils";
+import { toCoinTypesForEntry } from "@/sdk/markets/utils";
 
 type Args = {
   aptos: Aptos;
@@ -67,10 +67,7 @@ export const useGetGasWithDefault = (args: {
   isSell: boolean;
   numSwaps: number;
 }) => {
-  const { marketAddress } = args;
-  const { emojicoin, emojicoinLP } = toCoinTypes(marketAddress);
   const { aptos, account } = useAptos();
-  const typeTags = [emojicoin, emojicoinLP] as [TypeTag, TypeTag];
   const { inputAmount, swapper, minOutputAmount } = useMemo(() => {
     const bigInput = Big(args.inputAmount.toString());
     const inputAmount = BigInt(bigInput.toString());
@@ -89,7 +86,7 @@ export const useGetGasWithDefault = (args: {
     swapper,
     inputAmount,
     minOutputAmount,
-    typeTags,
+    typeTags: toCoinTypesForEntry(args.marketAddress),
   });
 
   // Neither of these values will ever be zero if a meaningful value is returned,

--- a/src/typescript/frontend/src/lib/hooks/queries/use-get-swap-gas.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-get-swap-gas.ts
@@ -9,7 +9,7 @@ import { useMemo } from "react";
 import { tryEd25519PublicKey } from "@/components/pages/launch-emojicoin/hooks/use-register-market";
 import { Swap } from "@/move-modules/emojicoin-dot-fun";
 import type { AccountAddressString, AnyNumber, TypeTagInput } from "@/sdk/emojicoin_dot_fun";
-import { toCoinTypesForEntry } from "@/sdk/markets/utils";
+import { toEmojicoinTypesForEntry } from "@/sdk/markets/utils";
 
 type Args = {
   aptos: Aptos;
@@ -86,7 +86,7 @@ export const useGetGasWithDefault = (args: {
     swapper,
     inputAmount,
     minOutputAmount,
-    typeTags: toCoinTypesForEntry(args.marketAddress),
+    typeTags: toEmojicoinTypesForEntry(args.marketAddress),
   });
 
   // Neither of these values will ever be zero if a meaningful value is returned,

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-arena-swap-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-arena-swap-builder.ts
@@ -1,9 +1,8 @@
-import type { TypeTag } from "@aptos-labs/ts-sdk";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { Swap } from "@/move-modules/emojicoin-arena";
-import { toCoinTypes } from "@/sdk/markets";
+import { toArenaCoinTypes } from "@/sdk/markets";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 
@@ -21,16 +20,9 @@ export const useArenaSwapTransactionBuilder = (
     if (!accountAddress) {
       return null;
     }
-    const { emojicoin: emojicoin0, emojicoinLP: emojicoinLP0 } = toCoinTypes(market0Address);
-    const { emojicoin: emojicoin1, emojicoinLP: emojicoinLP1 } = toCoinTypes(market1Address);
     return {
       swapper: accountAddress,
-      typeTags: [emojicoin0, emojicoinLP0, emojicoin1, emojicoinLP1] as [
-        TypeTag,
-        TypeTag,
-        TypeTag,
-        TypeTag,
-      ],
+      typeTags: toArenaCoinTypes({ market0Address, market1Address }),
     };
   }, [accountAddress, market0Address, market1Address]);
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-chat-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-chat-builder.ts
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import { Chat } from "@/move-modules/emojicoin-dot-fun";
 import { MAX_NUM_CHAT_EMOJIS } from "@/sdk/const";
 import { toChatMessageEntryFunctionArgs } from "@/sdk/emoji_data/chat-message";
-import { toCoinTypesForEntry } from "@/sdk/markets";
+import { toEmojicoinTypesForEntry } from "@/sdk/markets";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 
@@ -23,7 +23,7 @@ export const useChatTransactionBuilder = (marketAddress: `0x${string}`) => {
     }
     const emojiText = emojis.join("");
     const { emojiBytes, emojiIndicesSequence } = toChatMessageEntryFunctionArgs(emojiText);
-    const typeTags = toCoinTypesForEntry(marketAddress);
+    const typeTags = toEmojicoinTypesForEntry(marketAddress);
     return {
       user: account.address,
       marketAddress,

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-enter-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-enter-builder.ts
@@ -1,9 +1,9 @@
+import type { TypeTag } from "@aptos-labs/ts-sdk";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { Enter } from "@/move-modules/emojicoin-arena";
 import { toArenaCoinTypes } from "@/sdk/markets";
-import type { CoinTypeString } from "@/sdk/utils";
 import type { AnyNumberString } from "@/sdk-types";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
@@ -39,7 +39,7 @@ export const useEnterTransactionBuilder = (
         emojicoin1,
         emojicoinLP1,
         targetMarketAddress === market0Address ? emojicoin0 : emojicoin1,
-      ] as [CoinTypeString, CoinTypeString, CoinTypeString, CoinTypeString, CoinTypeString],
+      ] as [TypeTag, TypeTag, TypeTag, TypeTag, TypeTag],
     };
   }, [accountAddress, inputAmount, lockIn, market0Address, market1Address, targetMarketAddress]);
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-enter-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-enter-builder.ts
@@ -1,9 +1,9 @@
-import type { TypeTag } from "@aptos-labs/ts-sdk";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { Enter } from "@/move-modules/emojicoin-arena";
-import { toCoinTypes } from "@/sdk/markets";
+import { toArenaCoinTypes } from "@/sdk/markets";
+import type { CoinTypeString } from "@/sdk/utils";
 import type { AnyNumberString } from "@/sdk-types";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
@@ -25,8 +25,10 @@ export const useEnterTransactionBuilder = (
     if (!accountAddress) {
       return null;
     }
-    const { emojicoin: emojicoin0, emojicoinLP: emojicoinLP0 } = toCoinTypes(market0Address);
-    const { emojicoin: emojicoin1, emojicoinLP: emojicoinLP1 } = toCoinTypes(market1Address);
+    const [emojicoin0, emojicoinLP0, emojicoin1, emojicoinLP1] = toArenaCoinTypes({
+      market0Address,
+      market1Address,
+    });
     return {
       entrant: accountAddress,
       inputAmount: BigInt(inputAmount),
@@ -37,7 +39,7 @@ export const useEnterTransactionBuilder = (
         emojicoin1,
         emojicoinLP1,
         targetMarketAddress === market0Address ? emojicoin0 : emojicoin1,
-      ] as [TypeTag, TypeTag, TypeTag, TypeTag, TypeTag],
+      ] as [CoinTypeString, CoinTypeString, CoinTypeString, CoinTypeString, CoinTypeString],
     };
   }, [accountAddress, inputAmount, lockIn, market0Address, market1Address, targetMarketAddress]);
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-exit-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-exit-builder.ts
@@ -1,9 +1,8 @@
-import type { TypeTag } from "@aptos-labs/ts-sdk";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { Exit } from "@/move-modules/emojicoin-arena";
-import { toCoinTypes } from "@/sdk/markets";
+import { toArenaCoinTypes } from "@/sdk/markets";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 
@@ -21,16 +20,9 @@ export const useExitTransactionBuilder = (
     if (!accountAddress) {
       return null;
     }
-    const { emojicoin: emojicoin0, emojicoinLP: emojicoinLP0 } = toCoinTypes(market0Address);
-    const { emojicoin: emojicoin1, emojicoinLP: emojicoinLP1 } = toCoinTypes(market1Address);
     return {
       participant: accountAddress,
-      typeTags: [emojicoin0, emojicoinLP0, emojicoin1, emojicoinLP1] as [
-        TypeTag,
-        TypeTag,
-        TypeTag,
-        TypeTag,
-      ],
+      typeTags: toArenaCoinTypes({ market0Address, market1Address }),
     };
   }, [accountAddress, market0Address, market1Address]);
 

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-liquidity-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-liquidity-builder.ts
@@ -2,7 +2,7 @@ import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo } from "react";
 
 import { ProvideLiquidity, RemoveLiquidity } from "@/move-modules";
-import { toCoinTypesForEntry } from "@/sdk/markets";
+import { toEmojicoinTypesForEntry } from "@/sdk/markets";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
 
@@ -32,7 +32,7 @@ export const useLiquidityTransactionBuilder = (
     const sharedArgs = {
       provider: accountAddress,
       marketAddress,
-      typeTags: toCoinTypesForEntry(marketAddress),
+      typeTags: toEmojicoinTypesForEntry(marketAddress),
     };
     const otherArgs =
       direction === "add"

--- a/src/typescript/frontend/src/lib/hooks/transaction-builders/use-swap-builder.ts
+++ b/src/typescript/frontend/src/lib/hooks/transaction-builders/use-swap-builder.ts
@@ -3,7 +3,7 @@ import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS } from "lib/env";
 import { useMemo } from "react";
 
 import { Swap } from "@/move-modules";
-import { toCoinTypesForEntry } from "@/sdk/markets";
+import { toEmojicoinTypesForEntry } from "@/sdk/markets";
 import type { AnyNumberString } from "@/sdk-types";
 
 import { useTransactionBuilder } from "./use-transaction-builder";
@@ -31,7 +31,7 @@ export const useSwapTransactionBuilder = (
       isSell,
       integrator: INTEGRATOR_ADDRESS,
       integratorFeeRateBPs: INTEGRATOR_FEE_RATE_BPS,
-      typeTags: toCoinTypesForEntry(marketAddress),
+      typeTags: toEmojicoinTypesForEntry(marketAddress),
       minOutputAmount: BigInt(minOutputAmount),
     };
   }, [accountAddress, marketAddress, inputAmount, isSell, minOutputAmount]);

--- a/src/typescript/frontend/src/lib/local-development/inner.tsx
+++ b/src/typescript/frontend/src/lib/local-development/inner.tsx
@@ -25,7 +25,7 @@ import {
 import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS, ONE_APT } from "@/sdk/const";
 import { encodeEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
 import { getEvents, getMarketAddress } from "@/sdk/emojicoin_dot_fun";
-import { fetchAllCurrentMeleeData, toArenaCoinTypes, toCoinTypesForEntry } from "@/sdk/markets";
+import { fetchAllCurrentMeleeData, toArenaCoinTypes, toEmojicoinTypesForEntry } from "@/sdk/markets";
 import { getAptosClient } from "@/sdk/utils";
 
 const iconClassName = "p-2 !text-white cursor-pointer !h-[40px] !w-[40px]";
@@ -103,7 +103,7 @@ const InnerDisplayDebugData = () => {
               integrator: INTEGRATOR_ADDRESS,
               integratorFeeRateBPs: INTEGRATOR_FEE_RATE_BPS,
               minOutputAmount: 0n,
-              typeTags: toCoinTypesForEntry(
+              typeTags: toEmojicoinTypesForEntry(
                 models.marketRegistrationEvents[0].marketMetadata.marketAddress
               ),
             })

--- a/src/typescript/frontend/src/lib/local-development/inner.tsx
+++ b/src/typescript/frontend/src/lib/local-development/inner.tsx
@@ -25,7 +25,11 @@ import {
 import { INTEGRATOR_ADDRESS, INTEGRATOR_FEE_RATE_BPS, ONE_APT } from "@/sdk/const";
 import { encodeEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
 import { getEvents, getMarketAddress } from "@/sdk/emojicoin_dot_fun";
-import { fetchAllCurrentMeleeData, toArenaCoinTypes, toEmojicoinTypesForEntry } from "@/sdk/markets";
+import {
+  fetchAllCurrentMeleeData,
+  toArenaCoinTypes,
+  toEmojicoinTypesForEntry,
+} from "@/sdk/markets";
 import { getAptosClient } from "@/sdk/utils";
 
 const iconClassName = "p-2 !text-white cursor-pointer !h-[40px] !w-[40px]";

--- a/src/typescript/frontend/src/lib/local-development/inner.tsx
+++ b/src/typescript/frontend/src/lib/local-development/inner.tsx
@@ -40,9 +40,9 @@ const InnerDisplayDebugData = () => {
   const handleCrank = async (definedAccount: AccountInfo) =>
     // Use fire and water if on the local network, otherwise get the actual melee data.
     fetchAllCurrentMeleeData()
-      .then(({ market1, market2 }) => [market1.symbolEmojis, market2.symbolEmojis])
-      .then(([symbol1, symbol2]) => {
-        const [c0, lp0, c1, lp1] = toArenaCoinTypes({ symbol1, symbol2 });
+      .then(({ market0, market1 }) => [market0.symbolEmojis, market1.symbolEmojis])
+      .then(([symbol0, symbol1]) => {
+        const [c0, lp0, c1, lp1] = toArenaCoinTypes({ symbol0, symbol1 });
         EmojicoinArena.Enter.builder({
           aptosConfig: aptos.config,
           entrant: definedAccount.address,

--- a/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
@@ -3,12 +3,12 @@
 import { AccountAddress } from "@aptos-labs/ts-sdk";
 import { unstable_cache } from "next/cache";
 
-import { toCoinTypes } from "@/sdk/markets";
+import { toEmojicoinTypes } from "@/sdk/markets";
 
 import { fetchEmojicoinBalances } from "./fetch-emojicoin-balances";
 
 async function fetchTopHoldersInternal(marketAddress: `0x${string}`) {
-  const { emojicoin } = toCoinTypes(marketAddress);
+  const { emojicoin } = toEmojicoinTypes(marketAddress);
   const holders = await fetchEmojicoinBalances({ assetType: emojicoin });
 
   // Exclude the emojicoin market address from the holders list.

--- a/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
@@ -4,12 +4,14 @@ import { AccountAddress } from "@aptos-labs/ts-sdk";
 import { unstable_cache } from "next/cache";
 
 import { toEmojicoinTypes } from "@/sdk/markets";
+import type { CoinTypeString } from "@/sdk/utils";
 
 import { fetchEmojicoinBalances } from "./fetch-emojicoin-balances";
 
 async function fetchTopHoldersInternal(marketAddress: `0x${string}`) {
   const { emojicoin } = toEmojicoinTypes(marketAddress);
-  const holders = await fetchEmojicoinBalances({ assetType: emojicoin });
+  const assetType = emojicoin.toString() as CoinTypeString;
+  const holders = await fetchEmojicoinBalances({ assetType });
 
   // Exclude the emojicoin market address from the holders list.
   const market = AccountAddress.from(marketAddress);

--- a/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
+++ b/src/typescript/frontend/src/lib/queries/aptos-indexer/fetch-top-holders.ts
@@ -9,12 +9,7 @@ import { fetchEmojicoinBalances } from "./fetch-emojicoin-balances";
 
 async function fetchTopHoldersInternal(marketAddress: `0x${string}`) {
   const { emojicoin } = toCoinTypes(marketAddress);
-  if (!emojicoin.isStruct()) {
-    console.error(`Invalid market address passed to \`fetchHoldersInternal\`: ${marketAddress}`);
-    return [];
-  }
-  const assetType = emojicoin.toString();
-  const holders = await fetchEmojicoinBalances({ assetType });
+  const holders = await fetchEmojicoinBalances({ assetType: emojicoin });
 
   // Exclude the emojicoin market address from the holders list.
   const market = AccountAddress.from(marketAddress);

--- a/src/typescript/sdk/README.md
+++ b/src/typescript/sdk/README.md
@@ -99,10 +99,10 @@ console.log(registerEvents.marketRegistrationEvents[0]);
 
 ```typescript
 // Using variables from above...
-import { getMarketAddress, toCoinTypesForEntry } from "@econia-labs/emojicoin-sdk";
+import { getMarketAddress, toEmojicoinTypesForEntry } from "@econia-labs/emojicoin-sdk";
 
 const marketAddress = getMarketAddress(emojis);
-const typeTags = toCoinTypesForEntry(marketAddress);
+const typeTags = toEmojicoinTypesForEntry(marketAddress);
 
 await SwapWithRewards.submit({
   aptosConfig: aptos.config,

--- a/src/typescript/sdk/src/client/emojicoin-client.ts
+++ b/src/typescript/sdk/src/client/emojicoin-client.ts
@@ -594,11 +594,11 @@ export class EmojicoinClient {
     lockIn: boolean,
     symbol0: SymbolEmoji[],
     symbol1: SymbolEmoji[],
-    escrowCoin: "symbol1" | "symbol2",
+    escrowCoin: "symbol0" | "symbol1",
     options?: Options
   ) {
     const typeTags = toArenaCoinTypes({ symbol0, symbol1 });
-    const escrowType = escrowCoin === "symbol1" ? typeTags[0] : typeTags[2];
+    const escrowType = escrowCoin === "symbol0" ? typeTags[0] : typeTags[2];
     const response = await EmojicoinArena.Enter.submit({
       aptosConfig: this.aptos.config,
       entrant,

--- a/src/typescript/sdk/src/client/emojicoin-client.ts
+++ b/src/typescript/sdk/src/client/emojicoin-client.ts
@@ -6,7 +6,6 @@ import {
   AptosConfig,
   type InputGenerateTransactionOptions,
   type LedgerVersionArg,
-  type TypeTag,
   type UserTransactionResponse,
   type WaitForTransactionOptions,
 } from "@aptos-labs/ts-sdk";
@@ -36,7 +35,7 @@ import { TableName } from "../indexer-v2/types/json-types";
 import { getEmojicoinMarketAddressAndTypeTags } from "../markets";
 import { toArenaCoinTypes } from "../markets/arena-utils";
 import { type AnyNumberString, toMarketView, toRegistryView, toSwapEvent } from "../types";
-import { waitFor } from "../utils";
+import { type CoinTypeString, waitFor } from "../utils";
 import { APTOS_CONFIG, getAptosClient } from "../utils/aptos-client";
 import customExpect from "./expect";
 
@@ -564,11 +563,11 @@ export class EmojicoinClient {
 
   private async arenaSwap(
     swapper: Account,
+    symbol0: SymbolEmoji[],
     symbol1: SymbolEmoji[],
-    symbol2: SymbolEmoji[],
     options?: Options
   ) {
-    const typeTags = toArenaCoinTypes({ symbol1, symbol2 });
+    const typeTags = toArenaCoinTypes({ symbol0, symbol1 });
     const response = await EmojicoinArena.Swap.submit({
       aptosConfig: this.aptos.config,
       swapper,
@@ -593,12 +592,12 @@ export class EmojicoinClient {
     entrant: Account,
     inputAmount: bigint,
     lockIn: boolean,
+    symbol0: SymbolEmoji[],
     symbol1: SymbolEmoji[],
-    symbol2: SymbolEmoji[],
     escrowCoin: "symbol1" | "symbol2",
     options?: Options
   ) {
-    const typeTags = toArenaCoinTypes({ symbol1, symbol2 });
+    const typeTags = toArenaCoinTypes({ symbol0, symbol1 });
     const escrowType = escrowCoin === "symbol1" ? typeTags[0] : typeTags[2];
     const response = await EmojicoinArena.Enter.submit({
       aptosConfig: this.aptos.config,
@@ -644,11 +643,11 @@ export class EmojicoinClient {
 
   private async arenaExit(
     participant: Account,
+    symbol0: SymbolEmoji[],
     symbol1: SymbolEmoji[],
-    symbol2: SymbolEmoji[],
     options?: Options
   ) {
-    const typeTags = toArenaCoinTypes({ symbol1, symbol2 });
+    const typeTags = toArenaCoinTypes({ symbol0, symbol1 });
     const response = await EmojicoinArena.Exit.submit({
       aptosConfig: this.aptos.config,
       participant,
@@ -688,7 +687,7 @@ export class EmojicoinClient {
 
   private getEmojicoinInfo(symbolEmojis: SymbolEmoji[]): {
     marketAddress: AccountAddress;
-    typeTags: [TypeTag, TypeTag];
+    typeTags: [CoinTypeString, CoinTypeString];
   } {
     const { marketAddress, emojicoin, emojicoinLP } = getEmojicoinMarketAddressAndTypeTags({
       symbolBytes: this.emojisToHexSymbol(symbolEmojis),

--- a/src/typescript/sdk/src/client/emojicoin-client.ts
+++ b/src/typescript/sdk/src/client/emojicoin-client.ts
@@ -1,14 +1,13 @@
-import {
-  type Account,
-  AccountAddress,
-  type AccountAddressInput,
-  Aptos,
-  AptosConfig,
-  type InputGenerateTransactionOptions,
-  type LedgerVersionArg,
-  type UserTransactionResponse,
-  type WaitForTransactionOptions,
+import type {
+  Account,
+  AccountAddressInput,
+  InputGenerateTransactionOptions,
+  LedgerVersionArg,
+  TypeTag,
+  UserTransactionResponse,
+  WaitForTransactionOptions,
 } from "@aptos-labs/ts-sdk";
+import { AccountAddress, Aptos, AptosConfig } from "@aptos-labs/ts-sdk";
 
 import {
   Chat,
@@ -35,7 +34,7 @@ import { TableName } from "../indexer-v2/types/json-types";
 import { getEmojicoinMarketAddressAndTypeTags } from "../markets";
 import { toArenaCoinTypes } from "../markets/arena-utils";
 import { type AnyNumberString, toMarketView, toRegistryView, toSwapEvent } from "../types";
-import { type CoinTypeString, waitFor } from "../utils";
+import { waitFor } from "../utils";
 import { APTOS_CONFIG, getAptosClient } from "../utils/aptos-client";
 import customExpect from "./expect";
 
@@ -687,7 +686,7 @@ export class EmojicoinClient {
 
   private getEmojicoinInfo(symbolEmojis: SymbolEmoji[]): {
     marketAddress: AccountAddress;
-    typeTags: [CoinTypeString, CoinTypeString];
+    typeTags: [TypeTag, TypeTag];
   } {
     const { marketAddress, emojicoin, emojicoinLP } = getEmojicoinMarketAddressAndTypeTags({
       symbolBytes: this.emojisToHexSymbol(symbolEmojis),

--- a/src/typescript/sdk/src/const.ts
+++ b/src/typescript/sdk/src/const.ts
@@ -9,6 +9,7 @@ import Big from "big.js";
 
 import type { DatabaseStructType } from "./indexer-v2/types/json-types";
 import type { Types } from "./types";
+import type { CoinTypeString } from "./utils";
 import type { ValueOf } from "./utils/utility-types";
 
 export const VERCEL = process.env.VERCEL === "1";
@@ -92,7 +93,7 @@ export const INTEGRATOR_ADDRESS = (() =>
 export const INTEGRATOR_FEE_RATE_BPS = Number(process.env.NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS);
 export const ONE_APT = 1 * 10 ** 8;
 export const ONE_APT_BIGINT = BigInt(ONE_APT);
-export const APTOS_COIN_TYPE_TAG = parseTypeTag(APTOS_COIN);
+export const APTOS_COIN_TYPE_STRING = parseTypeTag(APTOS_COIN).toString() as CoinTypeString;
 export const MAX_GAS_FOR_PUBLISH = 1500000;
 export const COIN_FACTORY_MODULE_NAME = "coin_factory";
 export const EMOJICOIN_DOT_FUN_MODULE_NAME = "emojicoin_dot_fun";

--- a/src/typescript/sdk/src/emojicoin_dot_fun/utils.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/utils.ts
@@ -12,7 +12,7 @@ import { EMOJICOIN_DOT_FUN_MODULE_NAME, MODULE_ADDRESS } from "../const";
 import { encodeEmojis, type SymbolEmoji } from "../emoji_data";
 import type { JsonTypes } from "../types/json-types";
 import { createNamedObjectAddress } from "../utils/aptos-utils";
-import { type StructTagString,typeTagInputToStructName } from "../utils/type-tags";
+import { type StructTagString, typeTagInputToStructName } from "../utils/type-tags";
 import {
   arenaConverter,
   type ArenaEvents,

--- a/src/typescript/sdk/src/emojicoin_dot_fun/utils.ts
+++ b/src/typescript/sdk/src/emojicoin_dot_fun/utils.ts
@@ -12,7 +12,7 @@ import { EMOJICOIN_DOT_FUN_MODULE_NAME, MODULE_ADDRESS } from "../const";
 import { encodeEmojis, type SymbolEmoji } from "../emoji_data";
 import type { JsonTypes } from "../types/json-types";
 import { createNamedObjectAddress } from "../utils/aptos-utils";
-import { typeTagInputToStructName } from "../utils/type-tags";
+import { type StructTagString,typeTagInputToStructName } from "../utils/type-tags";
 import {
   arenaConverter,
   type ArenaEvents,
@@ -105,7 +105,7 @@ function getEventsMaybeWithIndices(
   }
 
   response.events.forEach((event, eventIndex): void => {
-    const structName = typeTagInputToStructName(event.type);
+    const structName = typeTagInputToStructName(event.type as StructTagString);
     if (!structName || (!isAnEmojicoinStructName(structName) && !isAnArenaStructName(structName))) {
       return;
     }

--- a/src/typescript/sdk/src/markets/arena-utils.ts
+++ b/src/typescript/sdk/src/markets/arena-utils.ts
@@ -1,10 +1,10 @@
-import type { AccountAddressInput, LedgerVersionArg } from "@aptos-labs/ts-sdk";
+import type { AccountAddressInput, LedgerVersionArg, TypeTag } from "@aptos-labs/ts-sdk";
 
 import { type SymbolEmoji, toMarketEmojiData } from "../emoji_data";
 import { EmojicoinArena, getMarketAddress, MarketView } from "../emojicoin_dot_fun";
 import { toMarketView } from "../types";
 import { toArenaMeleeEvent, toArenaRegistry } from "../types/arena-types";
-import { type CoinTypeString, getAptosClient } from "../utils";
+import { getAptosClient } from "../utils";
 import type { StrictXOR } from "../utils/utility-types";
 import { toEmojicoinTypesForEntry } from "./utils";
 
@@ -28,10 +28,10 @@ export const toArenaCoinTypes = (args: StrictXOR<ArenaSymbols, ArenaMarketAddres
       : [getMarketAddress(args.symbol0), getMarketAddress(args.symbol1)];
 
   return [...toEmojicoinTypesForEntry(address0), ...toEmojicoinTypesForEntry(address1)] as [
-    CoinTypeString,
-    CoinTypeString,
-    CoinTypeString,
-    CoinTypeString,
+    TypeTag,
+    TypeTag,
+    TypeTag,
+    TypeTag,
   ];
 };
 

--- a/src/typescript/sdk/src/markets/arena-utils.ts
+++ b/src/typescript/sdk/src/markets/arena-utils.ts
@@ -6,7 +6,7 @@ import { toMarketView } from "../types";
 import { toArenaMeleeEvent, toArenaRegistry } from "../types/arena-types";
 import { type CoinTypeString, getAptosClient } from "../utils";
 import type { StrictXOR } from "../utils/utility-types";
-import { toCoinTypesForEntry } from "./utils";
+import { toEmojicoinTypesForEntry } from "./utils";
 
 type ArenaSymbols = { symbol0: SymbolEmoji[]; symbol1: SymbolEmoji[] };
 type ArenaMarketAddresses = {
@@ -27,7 +27,7 @@ export const toArenaCoinTypes = (args: StrictXOR<ArenaSymbols, ArenaMarketAddres
       ? [args.market0Address, args.market1Address]
       : [getMarketAddress(args.symbol0), getMarketAddress(args.symbol1)];
 
-  return [...toCoinTypesForEntry(address0), ...toCoinTypesForEntry(address1)] as [
+  return [...toEmojicoinTypesForEntry(address0), ...toEmojicoinTypesForEntry(address1)] as [
     CoinTypeString,
     CoinTypeString,
     CoinTypeString,

--- a/src/typescript/sdk/src/markets/arena-utils.ts
+++ b/src/typescript/sdk/src/markets/arena-utils.ts
@@ -1,35 +1,37 @@
-import type { LedgerVersionArg, TypeTag } from "@aptos-labs/ts-sdk";
+import type { AccountAddressInput, LedgerVersionArg } from "@aptos-labs/ts-sdk";
 
 import { type SymbolEmoji, toMarketEmojiData } from "../emoji_data";
 import { EmojicoinArena, getMarketAddress, MarketView } from "../emojicoin_dot_fun";
 import { toMarketView } from "../types";
 import { toArenaMeleeEvent, toArenaRegistry } from "../types/arena-types";
-import { getAptosClient } from "../utils";
+import { type CoinTypeString, getAptosClient } from "../utils";
+import type { StrictXOR } from "../utils/utility-types";
 import { toCoinTypesForEntry } from "./utils";
 
-/**
- * Converts two input symbols to the four coin TypeTags necessary for arena entry functions.
- *
- * @param symbols.a the first symbol as an array of symbol emojis
- * @param symbols.b the second symbol as an array of symbol emojis
- *
- * @returns [Coin0, LP0, Coin1, LP1] as [TypeTag, TypeTag, TypeTag, TypeTag]
- */
-export const toArenaCoinTypes = ({
-  symbol1,
-  symbol2,
-}: {
-  symbol1: SymbolEmoji[];
-  symbol2: SymbolEmoji[];
-}) => {
-  const addressA = getMarketAddress(symbol1);
-  const addressB = getMarketAddress(symbol2);
+type ArenaSymbols = { symbol0: SymbolEmoji[]; symbol1: SymbolEmoji[] };
+type ArenaMarketAddresses = {
+  market0Address: AccountAddressInput;
+  market1Address: AccountAddressInput;
+};
 
-  return [...toCoinTypesForEntry(addressA), ...toCoinTypesForEntry(addressB)] as [
-    TypeTag,
-    TypeTag,
-    TypeTag,
-    TypeTag,
+/**
+ * Converts two input symbols or addresses to the four coin type strings necessary for arena entry
+ * functions.
+ *
+ * @returns
+ * [Coin0, LP0, Coin1, LP1] as [CoinTypeString, CoinTypeString, CoinTypeString, CoinTypeString]
+ */
+export const toArenaCoinTypes = (args: StrictXOR<ArenaSymbols, ArenaMarketAddresses>) => {
+  const [address0, address1] =
+    "market0Address" in args
+      ? [args.market0Address, args.market1Address]
+      : [getMarketAddress(args.symbol0), getMarketAddress(args.symbol1)];
+
+  return [...toCoinTypesForEntry(address0), ...toCoinTypesForEntry(address1)] as [
+    CoinTypeString,
+    CoinTypeString,
+    CoinTypeString,
+    CoinTypeString,
   ];
 };
 
@@ -71,7 +73,7 @@ export const fetchArenaRegistryView = async (options?: LedgerVersionArg) =>
 export const fetchMeleeEmojiData = async (
   view: Awaited<ReturnType<typeof fetchArenaMeleeView>>
 ) => {
-  const [symbol1, symbol2] = await Promise.all(
+  const [symbol0, symbol1] = await Promise.all(
     [view.emojicoin0MarketAddress, view.emojicoin1MarketAddress].map((marketAddress) =>
       MarketView.view({
         aptos: getAptosClient(),
@@ -86,19 +88,19 @@ export const fetchMeleeEmojiData = async (
     )
   );
   const [coin0, lp0, coin1, lp1] = toArenaCoinTypes({
+    symbol0: symbol0.emojis.map(({ emoji }) => emoji),
     symbol1: symbol1.emojis.map(({ emoji }) => emoji),
-    symbol2: symbol2.emojis.map(({ emoji }) => emoji),
   });
 
   return {
     view,
+    market0: {
+      ...symbol0,
+      typeTags: [coin0, lp0] as const,
+    },
     market1: {
       ...symbol1,
-      typeTags: [coin0, lp0] as [TypeTag, TypeTag],
-    },
-    market2: {
-      ...symbol2,
-      typeTags: [coin1, lp1] as [TypeTag, TypeTag],
+      typeTags: [coin1, lp1] as const,
     },
   };
 };
@@ -111,11 +113,11 @@ export type MeleeEmojiData = Awaited<ReturnType<typeof fetchMeleeEmojiData>>;
 export const fetchAllCurrentMeleeData = async () => {
   const registry = await fetchArenaRegistryView();
   const melee = await fetchArenaMeleeView(registry.currentMeleeID);
-  const { market1, market2 } = await fetchMeleeEmojiData(melee);
+  const { market0, market1 } = await fetchMeleeEmojiData(melee);
   return {
     registry,
     melee,
+    market0,
     market1,
-    market2,
   };
 };

--- a/src/typescript/sdk/src/markets/utils.ts
+++ b/src/typescript/sdk/src/markets/utils.ts
@@ -59,7 +59,7 @@ import { toConfig } from "../utils/aptos-utils";
 import { isInBondingCurve } from "../utils/bonding-curve";
 import type { AtLeastOne } from "../utils/utility-types";
 
-export function toCoinTypes(inputAddress: AccountAddressInput): {
+export function toEmojicoinTypes(inputAddress: AccountAddressInput): {
   emojicoin: CoinTypeString;
   emojicoinLP: CoinTypeString;
 } {
@@ -79,10 +79,10 @@ export function toCoinTypes(inputAddress: AccountAddressInput): {
  * @param marketAddress the market address
  * @returns [emojicoin, emojicoinLP] as [TypeTag, TypeTag]
  */
-export function toCoinTypesForEntry(
+export function toEmojicoinTypesForEntry(
   marketAddress: AccountAddressInput
 ): [CoinTypeString, CoinTypeString] {
-  const { emojicoin, emojicoinLP } = toCoinTypes(marketAddress);
+  const { emojicoin, emojicoinLP } = toEmojicoinTypes(marketAddress);
   return [emojicoin, emojicoinLP] as [CoinTypeString, CoinTypeString];
 }
 
@@ -102,7 +102,7 @@ export function getEmojicoinMarketAddressAndTypeTags(args: {
   const emojis = symbolBytesToEmojis(symbolBytes.toUint8Array()).emojis.map((e) => e.emoji);
   const marketAddress = getMarketAddress(emojis, registryAddress);
 
-  const { emojicoin, emojicoinLP } = toCoinTypes(marketAddress);
+  const { emojicoin, emojicoinLP } = toEmojicoinTypes(marketAddress);
 
   return {
     marketAddress,

--- a/src/typescript/sdk/src/markets/utils.ts
+++ b/src/typescript/sdk/src/markets/utils.ts
@@ -9,6 +9,7 @@ import {
   type HexInput,
   type InputGenerateTransactionOptions,
   parseTypeTag,
+  type TypeTag,
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import Big from "big.js";
@@ -39,36 +40,29 @@ import {
 } from "../emojicoin_dot_fun";
 import type { Flatten } from "../types";
 import type { JsonTypes } from "../types/json-types";
+import type { AnyNumberString, Types } from "../types/types";
 import {
-  type AnyNumberString,
   toMarketResource,
   toMarketView,
   toRegistrantGracePeriodFlag,
   toRegistryResource,
-  type Types,
 } from "../types/types";
-import {
-  type CoinTypeString,
-  getResourceFromWriteSet,
-  STRUCT_STRINGS,
-  toCoinTypeString,
-  TYPE_TAGS,
-} from "../utils";
+import { getResourceFromWriteSet, STRUCT_STRINGS, TYPE_TAGS } from "../utils";
 import { getAptosClient } from "../utils/aptos-client";
 import { toConfig } from "../utils/aptos-utils";
 import { isInBondingCurve } from "../utils/bonding-curve";
 import type { AtLeastOne } from "../utils/utility-types";
 
 export function toEmojicoinTypes(inputAddress: AccountAddressInput): {
-  emojicoin: CoinTypeString;
-  emojicoinLP: CoinTypeString;
+  emojicoin: TypeTag;
+  emojicoinLP: TypeTag;
 } {
   const marketAddress = AccountAddress.from(inputAddress);
   const prefix = `${marketAddress.toString()}::${COIN_FACTORY_MODULE_NAME}`;
 
   return {
-    emojicoin: toCoinTypeString(`${prefix}::Emojicoin`),
-    emojicoinLP: toCoinTypeString(`${prefix}::EmojicoinLP`),
+    emojicoin: parseTypeTag(`${prefix}::Emojicoin`),
+    emojicoinLP: parseTypeTag(`${prefix}::EmojicoinLP`),
   };
 }
 
@@ -79,11 +73,9 @@ export function toEmojicoinTypes(inputAddress: AccountAddressInput): {
  * @param marketAddress the market address
  * @returns [emojicoin, emojicoinLP] as [TypeTag, TypeTag]
  */
-export function toEmojicoinTypesForEntry(
-  marketAddress: AccountAddressInput
-): [CoinTypeString, CoinTypeString] {
+export function toEmojicoinTypesForEntry(marketAddress: AccountAddressInput) {
   const { emojicoin, emojicoinLP } = toEmojicoinTypes(marketAddress);
-  return [emojicoin, emojicoinLP] as [CoinTypeString, CoinTypeString];
+  return [emojicoin, emojicoinLP] as [TypeTag, TypeTag];
 }
 
 /**

--- a/src/typescript/sdk/src/markets/utils.ts
+++ b/src/typescript/sdk/src/markets/utils.ts
@@ -9,7 +9,6 @@ import {
   type HexInput,
   type InputGenerateTransactionOptions,
   parseTypeTag,
-  type TypeTag,
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 import Big from "big.js";
@@ -48,23 +47,28 @@ import {
   toRegistryResource,
   type Types,
 } from "../types/types";
-import { getResourceFromWriteSet, STRUCT_STRINGS, TYPE_TAGS } from "../utils";
+import {
+  type CoinTypeString,
+  getResourceFromWriteSet,
+  STRUCT_STRINGS,
+  toCoinTypeString,
+  TYPE_TAGS,
+} from "../utils";
 import { getAptosClient } from "../utils/aptos-client";
 import { toConfig } from "../utils/aptos-utils";
 import { isInBondingCurve } from "../utils/bonding-curve";
 import type { AtLeastOne } from "../utils/utility-types";
 
 export function toCoinTypes(inputAddress: AccountAddressInput): {
-  emojicoin: TypeTag;
-  emojicoinLP: TypeTag;
+  emojicoin: CoinTypeString;
+  emojicoinLP: CoinTypeString;
 } {
   const marketAddress = AccountAddress.from(inputAddress);
+  const prefix = `${marketAddress.toString()}::${COIN_FACTORY_MODULE_NAME}`;
 
   return {
-    emojicoin: parseTypeTag(`${marketAddress.toString()}::${COIN_FACTORY_MODULE_NAME}::Emojicoin`),
-    emojicoinLP: parseTypeTag(
-      `${marketAddress.toString()}::${COIN_FACTORY_MODULE_NAME}::EmojicoinLP`
-    ),
+    emojicoin: toCoinTypeString(`${prefix}::Emojicoin`),
+    emojicoinLP: toCoinTypeString(`${prefix}::EmojicoinLP`),
   };
 }
 
@@ -75,9 +79,11 @@ export function toCoinTypes(inputAddress: AccountAddressInput): {
  * @param marketAddress the market address
  * @returns [emojicoin, emojicoinLP] as [TypeTag, TypeTag]
  */
-export function toCoinTypesForEntry(marketAddress: AccountAddressInput): [TypeTag, TypeTag] {
+export function toCoinTypesForEntry(
+  marketAddress: AccountAddressInput
+): [CoinTypeString, CoinTypeString] {
   const { emojicoin, emojicoinLP } = toCoinTypes(marketAddress);
-  return [emojicoin, emojicoinLP] as [TypeTag, TypeTag];
+  return [emojicoin, emojicoinLP] as [CoinTypeString, CoinTypeString];
 }
 
 /**

--- a/src/typescript/sdk/src/types/types.ts
+++ b/src/typescript/sdk/src/types/types.ts
@@ -1,4 +1,4 @@
-import type { AccountAddress } from "@aptos-labs/ts-sdk";
+import type { AccountAddress, TypeTag } from "@aptos-labs/ts-sdk";
 import { hexToBytes } from "@noble/hashes/utils";
 
 import {
@@ -9,7 +9,7 @@ import {
 } from "../const";
 import type { SymbolEmoji } from "../emoji_data";
 import type { AccountAddressString } from "../emojicoin_dot_fun/types";
-import type { CoinTypeString, STRUCT_STRINGS } from "../utils";
+import type { STRUCT_STRINGS } from "../utils";
 import { standardizeAddress } from "../utils/account-address";
 import type { Flatten } from ".";
 import type { ArenaTypes } from "./arena-types";
@@ -60,8 +60,8 @@ export type WithMarketID = {
 export type Types = ArenaTypes & {
   EmojicoinInfo: {
     marketAddress: AccountAddress;
-    emojicoin: CoinTypeString;
-    emojicoinLP: CoinTypeString;
+    emojicoin: TypeTag;
+    emojicoinLP: TypeTag;
   };
 
   TableHandle: {

--- a/src/typescript/sdk/src/types/types.ts
+++ b/src/typescript/sdk/src/types/types.ts
@@ -1,4 +1,4 @@
-import type { AccountAddress, TypeTag } from "@aptos-labs/ts-sdk";
+import type { AccountAddress } from "@aptos-labs/ts-sdk";
 import { hexToBytes } from "@noble/hashes/utils";
 
 import {
@@ -9,7 +9,7 @@ import {
 } from "../const";
 import type { SymbolEmoji } from "../emoji_data";
 import type { AccountAddressString } from "../emojicoin_dot_fun/types";
-import type { STRUCT_STRINGS } from "../utils";
+import type { CoinTypeString, STRUCT_STRINGS } from "../utils";
 import { standardizeAddress } from "../utils/account-address";
 import type { Flatten } from ".";
 import type { ArenaTypes } from "./arena-types";
@@ -60,8 +60,8 @@ export type WithMarketID = {
 export type Types = ArenaTypes & {
   EmojicoinInfo: {
     marketAddress: AccountAddress;
-    emojicoin: TypeTag;
-    emojicoinLP: TypeTag;
+    emojicoin: CoinTypeString;
+    emojicoinLP: CoinTypeString;
   };
 
   TableHandle: {

--- a/src/typescript/sdk/src/utils/parse-changes-for-balances.ts
+++ b/src/typescript/sdk/src/utils/parse-changes-for-balances.ts
@@ -2,14 +2,14 @@ import {
   AccountAddress,
   type AccountAddressInput,
   parseTypeTag,
-  type TypeTag,
   type UserTransactionResponse,
   type WriteSetChangeWriteResource,
 } from "@aptos-labs/ts-sdk";
 
-import { APTOS_COIN_TYPE_TAG } from "../const";
+import { APTOS_COIN_TYPE_STRING } from "../const";
 import type { TypeTagInput } from "../emojicoin_dot_fun/types";
 import { type JSONFeeStatement, toFeeStatement } from "../types/core";
+import type { CoinTypeString } from "./type-tags";
 
 /* eslint-disable-next-line import/no-unused-modules */
 export const getFeeStatement = (response: UserTransactionResponse) => {
@@ -30,7 +30,7 @@ export const getCoinBalanceFromChanges = ({
 }: {
   response: UserTransactionResponse;
   userAddress: AccountAddressInput;
-  coinType: TypeTag;
+  coinType: CoinTypeString;
 }) => {
   const { changes } = response;
   const coinBalanceChange = changes.find((change) => {
@@ -65,5 +65,5 @@ export const getAptBalanceFromChanges = (
   getCoinBalanceFromChanges({
     response,
     userAddress,
-    coinType: APTOS_COIN_TYPE_TAG,
+    coinType: APTOS_COIN_TYPE_STRING,
   });

--- a/src/typescript/sdk/src/utils/parse-changes-for-balances.ts
+++ b/src/typescript/sdk/src/utils/parse-changes-for-balances.ts
@@ -1,18 +1,15 @@
-import {
-  AccountAddress,
-  type AccountAddressInput,
-  parseTypeTag,
-  type UserTransactionResponse,
-  type WriteSetChangeWriteResource,
+import type {
+  AccountAddressInput,
+  TypeTag,
+  UserTransactionResponse,
+  WriteSetChangeWriteResource,
 } from "@aptos-labs/ts-sdk";
+import { AccountAddress, parseTypeTag } from "@aptos-labs/ts-sdk";
 
 import { APTOS_COIN_TYPE_STRING } from "../const";
 import type { TypeTagInput } from "../emojicoin_dot_fun/types";
-import {
-  isWriteSetChangeWriteResource,
-  type JSONFeeStatement,
-  toFeeStatement,
-} from "../types/core";
+import type { JSONFeeStatement } from "../types/core";
+import { isWriteSetChangeWriteResource, toFeeStatement } from "../types/core";
 import type { CoinStoreString, CoinTypeString } from "./type-tags";
 
 /* eslint-disable-next-line import/no-unused-modules */
@@ -36,7 +33,7 @@ export const getCoinBalanceFromChanges = ({
 }: {
   response: UserTransactionResponse;
   userAddress: AccountAddressInput;
-  coinType: CoinTypeString;
+  coinType: CoinTypeString | TypeTag;
 }) => {
   const { changes } = response;
   const coinBalanceChange = changes.find((change) => {

--- a/src/typescript/sdk/src/utils/parse-changes-for-balances.ts
+++ b/src/typescript/sdk/src/utils/parse-changes-for-balances.ts
@@ -27,7 +27,7 @@ export const toCoinTypeString = (type: TypeTagInput) =>
   parseTypeTag(type.toString()).toString() as CoinTypeString;
 
 export const toCoinStoreString = (type: TypeTagInput) =>
-  `0x0::coin::CoinStore<${toCoinTypeString(type)}>` as CoinStoreString;
+  `0x1::coin::CoinStore<${toCoinTypeString(type)}>` as CoinStoreString;
 
 export const getCoinBalanceFromChanges = ({
   response,

--- a/src/typescript/sdk/src/utils/type-tags.ts
+++ b/src/typescript/sdk/src/utils/type-tags.ts
@@ -16,6 +16,7 @@ import {
 } from "../const";
 import type { TypeTagInput } from "../emojicoin_dot_fun";
 import { removeLeadingZeros } from "./account-address";
+import type { Nominal } from "./utility-types";
 
 export function toTypeTag(
   addressInput: AccountAddressInput,
@@ -79,6 +80,11 @@ export type ArenaStructName =
   | "ArenaVaultBalanceUpdateEvent";
 
 export type StructTagString = `0x${string}::${string}::${string}`;
+export type CoinStoreString = Nominal<
+  `0x1::coin::CoinStore<${StructTagString}>`,
+  "CoinStoreString"
+>;
+export type CoinTypeString = Nominal<StructTagString, "CoinTypeString">;
 
 type AnyEmojicoinDotFunStructName = EmojicoinStructName | ArenaStructName;
 

--- a/src/typescript/sdk/src/utils/utility-types.ts
+++ b/src/typescript/sdk/src/utils/utility-types.ts
@@ -37,7 +37,32 @@ export type DeepWritable<T> = {
   -readonly [P in keyof T]: DeepWritable<T[P]>;
 };
 
+/**
+ * This doesn't work on objects with multiple keys. For that, use {@link StrictXOR}.
+ */
 // prettier-ignore
 export type XOR<T, U> =
   | (T & { [K in keyof U]?: never })
-  | (U & { [K in keyof T]?: never });
+  | (U & { [K in keyof T]?: never }) ;
+
+/**
+ * A less ergonomic, but functional exclusive OR utility type. This function requires a specific
+ * invocation to properly infer types. See the example below.
+ *
+ * @example
+ * type ABorCD = StrictXOR<{ a: number, b: number }, { c: number, d: number }>;
+ * function foo(value: ABorCD) {
+ *   // `value.` won't autocomplete- it will show as having no fields. However, you can do this:
+ *   if ("a" in value) {
+ *     // TypeScript can properly infer from here
+ *   } else {
+ *     // And here
+ *   }
+ * }
+ *
+ */
+export type StrictXOR<T, U> = Exclude<T, U> | Exclude<U, T>;
+
+declare const __brand: unique symbol;
+type Brand<B> = { [__brand]: B };
+export type Nominal<T, B> = T & Brand<B>;

--- a/src/typescript/sdk/tests/e2e/arena/candlesticks.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/candlesticks.test.ts
@@ -74,9 +74,9 @@ describe("ensures arena candlesticks work", () => {
       publisher,
       1n,
       false,
+      melee.market0.symbolEmojis,
       melee.market1.symbolEmojis,
-      melee.market2.symbolEmojis,
-      "symbol1"
+      "symbol0"
     );
     melee = await fetchArenaMeleeView(res.arena.event.meleeID).then(fetchMeleeEmojiData);
     await waitForProcessor(res);
@@ -94,12 +94,12 @@ describe("ensures arena candlesticks work", () => {
     const registrant0: string = await postgrest
       .from(TableName.MarketRegistrationEvents)
       .select("registrant")
-      .eq("market_id", melee.market1.marketID)
+      .eq("market_id", melee.market0.marketID)
       .then((r) => r.data![0].registrant.substring(2, 5));
     const registrant1: string = await postgrest
       .from(TableName.MarketRegistrationEvents)
       .select("registrant")
-      .eq("market_id", melee.market2.marketID)
+      .eq("market_id", melee.market1.marketID)
       .then((r) => r.data![0].registrant.substring(2, 5));
 
     let account1: Account;
@@ -136,14 +136,14 @@ describe("ensures arena candlesticks work", () => {
       state0 = await postgrest
         .from(TableName.MarketLatestStateEvent)
         .select("*")
-        .eq("market_id", melee.market1.marketID)
+        .eq("market_id", melee.market0.marketID)
         .single()
         .then((r) => r.data)
         .then((r) => toMarketLatestStateEventModel(r));
       state1 = await postgrest
         .from(TableName.MarketLatestStateEvent)
         .select("*")
-        .eq("market_id", melee.market2.marketID)
+        .eq("market_id", melee.market1.marketID)
         .single()
         .then((r) => r.data)
         .then((r) => toMarketLatestStateEventModel(r));
@@ -183,9 +183,9 @@ describe("ensures arena candlesticks work", () => {
         account1,
         ONE_APT_BIGINT,
         false,
+        melee.market0.symbolEmojis,
         melee.market1.symbolEmojis,
-        melee.market2.symbolEmojis,
-        "symbol1"
+        "symbol0"
       )
     );
 
@@ -210,7 +210,7 @@ describe("ensures arena candlesticks work", () => {
 
     // No swap is generated from the exit.
 
-    await emojicoin.arena.exit(account1, melee.market1.symbolEmojis, melee.market2.symbolEmojis);
+    await emojicoin.arena.exit(account1, melee.market0.symbolEmojis, melee.market1.symbolEmojis);
 
     // Here, we make a swap on the other market.
 
@@ -219,9 +219,9 @@ describe("ensures arena candlesticks work", () => {
         account2,
         ONE_APT_BIGINT,
         false,
+        melee.market0.symbolEmojis,
         melee.market1.symbolEmojis,
-        melee.market2.symbolEmojis,
-        "symbol2"
+        "symbol1"
       )
     );
 
@@ -248,7 +248,7 @@ describe("ensures arena candlesticks work", () => {
     // We swap for emojicoin 1 to emojicoin 0.
 
     await waitForProcessor(
-      await emojicoin.arena.swap(account2, melee.market1.symbolEmojis, melee.market2.symbolEmojis)
+      await emojicoin.arena.swap(account2, melee.market0.symbolEmojis, melee.market1.symbolEmojis)
     );
 
     await refreshCandlesticksData();
@@ -275,7 +275,7 @@ describe("ensures arena candlesticks work", () => {
     // This swap should happen in the next candlestick boundary, so it should generate a new one.
 
     await waitForProcessor(
-      await emojicoin.arena.swap(account2, melee.market1.symbolEmojis, melee.market2.symbolEmojis)
+      await emojicoin.arena.swap(account2, melee.market0.symbolEmojis, melee.market1.symbolEmojis)
     );
 
     const oldSwap1 = state1!;

--- a/src/typescript/sdk/tests/e2e/arena/utils.ts
+++ b/src/typescript/sdk/tests/e2e/arena/utils.ts
@@ -44,9 +44,9 @@ export const registerAndUnlockInitialMarketsForArenaTest = async () => {
   const { res3, res4 } = await fetchArenaRegistryView().then((res) =>
     fetchArenaMeleeView(res.currentMeleeID)
       .then(fetchMeleeEmojiData)
-      .then(async ({ market1, market2 }) => ({
-        res3: await emojicoin.buy(publisher, market1.symbolEmojis, 1n),
-        res4: await emojicoin.buy(publisher, market2.symbolEmojis, 1n),
+      .then(async ({ market0, market1 }) => ({
+        res3: await emojicoin.buy(publisher, market0.symbolEmojis, 1n),
+        res4: await emojicoin.buy(publisher, market1.symbolEmojis, 1n),
       }))
   );
 
@@ -85,22 +85,22 @@ export const setNextMeleeDurationAndEnsureCrank = async (
 ) => {
   const { currentMeleeID } = await fetchArenaRegistryView();
   const melee = await fetchArenaMeleeView(currentMeleeID).then(fetchMeleeEmojiData);
-  const [symbol1, symbol2] = [melee.market1.symbolEmojis, melee.market2.symbolEmojis];
+  const [symbol0, symbol1] = [melee.market0.symbolEmojis, melee.market1.symbolEmojis];
   const emojicoin = new EmojicoinClient();
   const publisher = getPublisher();
   // End the first melee by cranking with `enter` and set the next melee's duration.
   await emojicoin.arena.setNextMeleeDuration(publisher, nextDuration);
-  const crank = await emojicoin.arena.enter(publisher, 1n, false, symbol1, symbol2, "symbol1");
+  const crank = await emojicoin.arena.enter(publisher, 1n, false, symbol0, symbol1, "symbol0");
   const { currentMeleeID: newMeleeID } = await fetchArenaRegistryView();
   const newMelee = await fetchArenaMeleeView(newMeleeID).then(fetchMeleeEmojiData);
-  const [newSymbol1, newSymbol2] = [newMelee.market1.symbolEmojis, newMelee.market2.symbolEmojis];
+  const [newSymbol0, newSymbol1] = [newMelee.market0.symbolEmojis, newMelee.market1.symbolEmojis];
   expect(newMeleeID).toEqual(currentMeleeID + 1n);
   expect(newMelee.view.duration).toEqual(nextDuration);
   return {
     melee: newMelee,
     meleeID: newMeleeID,
+    symbol0: newSymbol0,
     symbol1: newSymbol1,
-    symbol2: newSymbol2,
     version: crank.response.version,
   };
 };

--- a/src/typescript/sdk/tests/e2e/broker/websockets.test.ts
+++ b/src/typescript/sdk/tests/e2e/broker/websockets.test.ts
@@ -1,21 +1,19 @@
-import { AccountAddress, type TypeTag } from "@aptos-labs/ts-sdk";
+import { AccountAddress } from "@aptos-labs/ts-sdk";
 
 import { Chat, ProvideLiquidity, RegisterMarket, Swap, SwapWithRewards } from "@/move-modules";
 
+import type { CoinTypeString, MarketEmojiData, SymbolEmoji, Types } from "../../../src";
 import {
   compareBigInt,
   encodeEmojis,
   enumerate,
   getEmojicoinMarketAddressAndTypeTags,
   getEvents,
-  type MarketEmojiData,
   maxBigInt,
   ONE_APT,
   sleep,
   SYMBOL_EMOJI_DATA,
-  type SymbolEmoji,
   toMarketEmojiData,
-  type Types,
   zip,
 } from "../../../src";
 import { convertWebSocketMessageToBrokerEvent } from "../../../src/broker-v2/client";
@@ -202,7 +200,7 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
 
     const moreSharedArgs = {
       marketAddress,
-      typeTags: [emojicoin, emojicoinLP] as [TypeTag, TypeTag],
+      typeTags: [emojicoin, emojicoinLP] as [CoinTypeString, CoinTypeString],
     };
 
     const swapResponse = await Swap.submit({
@@ -255,7 +253,7 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
 
     const moreSharedArgs = {
       marketAddress,
-      typeTags: [emojicoin, emojicoinLP] as [TypeTag, TypeTag],
+      typeTags: [emojicoin, emojicoinLP] as [CoinTypeString, CoinTypeString],
     };
 
     const swapResponse = await SwapWithRewards.submit({
@@ -335,12 +333,18 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
 
     const moreSharedArgsForMarket_1 = {
       marketAddress: marketMetadata_1.marketAddress,
-      typeTags: [marketMetadata_1.emojicoin, marketMetadata_1.emojicoinLP] as [TypeTag, TypeTag],
+      typeTags: [marketMetadata_1.emojicoin, marketMetadata_1.emojicoinLP] as [
+        CoinTypeString,
+        CoinTypeString,
+      ],
     };
 
     const moreSharedArgsForMarket_2 = {
       marketAddress: marketMetadata_2.marketAddress,
-      typeTags: [marketMetadata_2.emojicoin, marketMetadata_2.emojicoinLP] as [TypeTag, TypeTag],
+      typeTags: [marketMetadata_2.emojicoin, marketMetadata_2.emojicoinLP] as [
+        CoinTypeString,
+        CoinTypeString,
+      ],
     };
 
     const swap_1 = await SwapWithRewards.submit({
@@ -425,12 +429,18 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
 
     const moreSharedArgsForMarket_1 = {
       marketAddress: marketMetadata_1.marketAddress,
-      typeTags: [marketMetadata_1.emojicoin, marketMetadata_1.emojicoinLP] as [TypeTag, TypeTag],
+      typeTags: [marketMetadata_1.emojicoin, marketMetadata_1.emojicoinLP] as [
+        CoinTypeString,
+        CoinTypeString,
+      ],
     };
 
     const moreSharedArgsForMarket_2 = {
       marketAddress: marketMetadata_2.marketAddress,
-      typeTags: [marketMetadata_2.emojicoin, marketMetadata_2.emojicoinLP] as [TypeTag, TypeTag],
+      typeTags: [marketMetadata_2.emojicoin, marketMetadata_2.emojicoinLP] as [
+        CoinTypeString,
+        CoinTypeString,
+      ],
     };
 
     const swaps = new Array<Types["SwapEvent"]>();

--- a/src/typescript/sdk/tests/e2e/broker/websockets.test.ts
+++ b/src/typescript/sdk/tests/e2e/broker/websockets.test.ts
@@ -1,8 +1,9 @@
+import type { TypeTag } from "@aptos-labs/ts-sdk";
 import { AccountAddress } from "@aptos-labs/ts-sdk";
 
 import { Chat, ProvideLiquidity, RegisterMarket, Swap, SwapWithRewards } from "@/move-modules";
 
-import type { CoinTypeString, MarketEmojiData, SymbolEmoji, Types } from "../../../src";
+import type { MarketEmojiData, SymbolEmoji, Types } from "../../../src";
 import {
   compareBigInt,
   encodeEmojis,
@@ -200,7 +201,7 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
 
     const moreSharedArgs = {
       marketAddress,
-      typeTags: [emojicoin, emojicoinLP] as [CoinTypeString, CoinTypeString],
+      typeTags: [emojicoin, emojicoinLP] as [TypeTag, TypeTag],
     };
 
     const swapResponse = await Swap.submit({
@@ -253,7 +254,7 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
 
     const moreSharedArgs = {
       marketAddress,
-      typeTags: [emojicoin, emojicoinLP] as [CoinTypeString, CoinTypeString],
+      typeTags: [emojicoin, emojicoinLP] as [TypeTag, TypeTag],
     };
 
     const swapResponse = await SwapWithRewards.submit({
@@ -333,18 +334,12 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
 
     const moreSharedArgsForMarket_1 = {
       marketAddress: marketMetadata_1.marketAddress,
-      typeTags: [marketMetadata_1.emojicoin, marketMetadata_1.emojicoinLP] as [
-        CoinTypeString,
-        CoinTypeString,
-      ],
+      typeTags: [marketMetadata_1.emojicoin, marketMetadata_1.emojicoinLP] as [TypeTag, TypeTag],
     };
 
     const moreSharedArgsForMarket_2 = {
       marketAddress: marketMetadata_2.marketAddress,
-      typeTags: [marketMetadata_2.emojicoin, marketMetadata_2.emojicoinLP] as [
-        CoinTypeString,
-        CoinTypeString,
-      ],
+      typeTags: [marketMetadata_2.emojicoin, marketMetadata_2.emojicoinLP] as [TypeTag, TypeTag],
     };
 
     const swap_1 = await SwapWithRewards.submit({
@@ -429,18 +424,12 @@ describe("tests to ensure that websocket event subscriptions work as expected", 
 
     const moreSharedArgsForMarket_1 = {
       marketAddress: marketMetadata_1.marketAddress,
-      typeTags: [marketMetadata_1.emojicoin, marketMetadata_1.emojicoinLP] as [
-        CoinTypeString,
-        CoinTypeString,
-      ],
+      typeTags: [marketMetadata_1.emojicoin, marketMetadata_1.emojicoinLP] as [TypeTag, TypeTag],
     };
 
     const moreSharedArgsForMarket_2 = {
       marketAddress: marketMetadata_2.marketAddress,
-      typeTags: [marketMetadata_2.emojicoin, marketMetadata_2.emojicoinLP] as [
-        CoinTypeString,
-        CoinTypeString,
-      ],
+      typeTags: [marketMetadata_2.emojicoin, marketMetadata_2.emojicoinLP] as [TypeTag, TypeTag],
     };
 
     const swaps = new Array<Types["SwapEvent"]>();

--- a/src/typescript/sdk/tests/e2e/calculate-curve-price.test.ts
+++ b/src/typescript/sdk/tests/e2e/calculate-curve-price.test.ts
@@ -2,7 +2,7 @@ import type { Account } from "@aptos-labs/ts-sdk";
 import Big from "big.js";
 
 import {
-  APTOS_COIN_TYPE_TAG,
+  APTOS_COIN_TYPE_STRING,
   calculateCurvePrice,
   getCoinBalanceFromChanges,
   getMarketAddress,
@@ -11,7 +11,7 @@ import {
   ONE_APT_BIGINT,
   PreciseBig,
   type SymbolEmoji,
-  toCoinTypes,
+  toEmojicoinTypes,
   zip,
 } from "../../src";
 import { EmojicoinClient } from "../../src/client/emojicoin-client";
@@ -97,7 +97,7 @@ describe(`curve price calculations w/ geometric mean, at least ${accuracy * 100}
     emoji: bigint;
   }> => {
     const marketAddress = getMarketAddress(symbolEmojis);
-    const coinTypes = toCoinTypes(marketAddress);
+    const coinTypes = toEmojicoinTypes(marketAddress);
     return await getMarketResource({ aptos, marketAddress })
       .then((market) => calculateCurvePrice(market))
       .then((beforePrice) =>
@@ -130,7 +130,7 @@ describe(`curve price calculations w/ geometric mean, at least ${accuracy * 100}
         const apt = getCoinBalanceFromChanges({
           response,
           userAddress: registrant.accountAddress,
-          coinType: APTOS_COIN_TYPE_TAG,
+          coinType: APTOS_COIN_TYPE_STRING,
         })!;
         const emoji = getCoinBalanceFromChanges({
           response,

--- a/src/typescript/sdk/tests/e2e/calculate-reserves-and-supply.test.ts
+++ b/src/typescript/sdk/tests/e2e/calculate-reserves-and-supply.test.ts
@@ -1,12 +1,12 @@
 import type { UserTransactionResponse } from "@aptos-labs/ts-sdk";
 
+import type { SymbolEmoji } from "../../src";
 import {
   calculateCirculatingSupply,
   calculateRealReserves,
   fetchCirculatingSupply,
   fetchRealReserves,
-  type SymbolEmoji,
-  toCoinTypes,
+  toEmojicoinTypes,
   zip,
 } from "../../src";
 import { EmojicoinClient } from "../../src/client/emojicoin-client";
@@ -40,7 +40,7 @@ describe("tests the calculation functions for circulating supply and real reserv
     const [swapper, symbolEmojis] = [registrants[idx], marketSymbols[idx]];
     const buyAmount = ONE_APT_BIGINT;
     const coinAddress = getMarketAddress(symbolEmojis);
-    const coinType = toCoinTypes(coinAddress).emojicoin;
+    const { emojicoin: coinType } = toEmojicoinTypes(coinAddress);
     const userAddress = swapper.accountAddress;
 
     const { supplyAfterBuy, userBalance } = await emojicoin
@@ -110,7 +110,7 @@ describe("tests the calculation functions for circulating supply and real reserv
     const sellAmountEmojicoin = ONE_APT_BIGINT * 2n;
     const userAddress = swapper.accountAddress;
     const coinAddress = getMarketAddress(symbolEmojis);
-    const coinType = toCoinTypes(coinAddress).emojicoin;
+    const { emojicoin: coinType } = toEmojicoinTypes(coinAddress);
 
     await emojicoin
       .buy(swapper, symbolEmojis, buyAmountQuote)
@@ -155,7 +155,7 @@ describe("tests the calculation functions for circulating supply and real reserv
     const buyAmount = ONE_APT_BIGINT;
     const userAddress = swapper.accountAddress;
     const coinAddress = getMarketAddress(symbolEmojis);
-    const coinType = toCoinTypes(coinAddress).emojicoin;
+    const { emojicoin: coinType } = toEmojicoinTypes(coinAddress);
 
     const { userBalance, baseAfterBuy } = await emojicoin
       .buy(swapper, symbolEmojis, buyAmount)
@@ -211,7 +211,7 @@ describe("tests the calculation functions for circulating supply and real reserv
 
     const userAddress = swapper.accountAddress;
     const coinAddress = getMarketAddress(symbolEmojis);
-    const coinType = toCoinTypes(coinAddress).emojicoin;
+    const { emojicoin: coinType } = toEmojicoinTypes(coinAddress);
 
     // Verify the real reserves equals the total supply - circulating supply.
     const verifyCSAndReserves = (response: UserTransactionResponse, swap: SwapEventModel) => {

--- a/src/typescript/sdk/tests/e2e/calculate-swap.test.ts
+++ b/src/typescript/sdk/tests/e2e/calculate-swap.test.ts
@@ -7,7 +7,7 @@ import {
   getMarketResource,
   maxBigInt,
   type SymbolEmoji,
-  toCoinTypes,
+  toEmojicoinTypes,
   zip,
 } from "../../src";
 import { EmojicoinClient } from "../../src/client/emojicoin-client";
@@ -185,7 +185,7 @@ describe("tests the swap functionality", () => {
     expect(model.market.marketNonce).toEqual(market.sequenceInfo.nonce);
 
     // Transfer the emojicoins from the first swapper to the second.
-    const { emojicoin: emojicoinType } = toCoinTypes(marketAddress);
+    const { emojicoin: emojicoinType } = toEmojicoinTypes(marketAddress);
     const transferRes = await TransferCoins.submit({
       aptosConfig: aptos.config,
       from: firstSwapper,
@@ -236,7 +236,7 @@ describe("tests the swap functionality", () => {
     expect(model.market.marketNonce).toEqual(market.sequenceInfo.nonce);
 
     // Transfer the emojicoins from the first swapper to the second.
-    const { emojicoin: emojicoinType } = toCoinTypes(marketAddress);
+    const { emojicoin: emojicoinType } = toEmojicoinTypes(marketAddress);
     const transferRes = await TransferCoins.submit({
       aptosConfig: aptos.config,
       from: firstSwapper,

--- a/src/typescript/sdk/tests/e2e/queries/address.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/address.test.ts
@@ -1,6 +1,6 @@
 import { Chat } from "@/move-modules/emojicoin-dot-fun";
 
-import { getEvents, toCoinTypesForEntry } from "../../../src";
+import { getEvents, toEmojicoinTypesForEntry } from "../../../src";
 import { EmojicoinClient } from "../../../src/client/emojicoin-client";
 import { fetchChatEvents } from "../../../src/indexer-v2/queries";
 import { getAptosClient } from "../../utils";
@@ -18,7 +18,6 @@ describe("address standardization tests", () => {
     const { marketAddress, emojis } = await emojicoin
       .register(user, ["🍿"])
       .then((res) => res.registration.model.market);
-    const typeTags = toCoinTypesForEntry(marketAddress);
 
     const res = await Chat.submit({
       aptosConfig: aptos.config,
@@ -26,7 +25,7 @@ describe("address standardization tests", () => {
       marketAddress,
       emojiBytes: emojis.map((e) => e.hex),
       emojiIndicesSequence: new Uint8Array(Array.from({ length: emojis.length }, (_, i) => i)),
-      typeTags,
+      typeTags: toEmojicoinTypesForEntry(marketAddress),
     });
 
     const events = getEvents(res);

--- a/src/typescript/sdk/tests/e2e/queries/liquidity-pools.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/liquidity-pools.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 
-import type { TypeTag, UserTransactionResponse } from "@aptos-labs/ts-sdk";
+import type { UserTransactionResponse } from "@aptos-labs/ts-sdk";
 
 import { ProvideLiquidity, Swap } from "@/move-modules/emojicoin-dot-fun";
 
@@ -20,7 +20,7 @@ describe("queries for liquidity pools", () => {
   const inputAmount = EXACT_TRANSITION_INPUT_AMOUNT;
   const integrator = registrants[0].accountAddress;
 
-  it("queries a user's liquidity pools with the rpc function call", async () => {
+  it("queries a user's liquidity pools", async () => {
     const registrant = registrants[0];
     const [swapper, provider] = [registrant, registrant];
 
@@ -40,7 +40,6 @@ describe("queries for liquidity pools", () => {
 
     const responses: UserTransactionResponse[] = [];
     for (const { marketAddress, emojicoin, emojicoinLP } of markets) {
-      const typeTags = [emojicoin, emojicoinLP] as [TypeTag, TypeTag];
       await Swap.submit({
         aptosConfig,
         swapper,
@@ -50,7 +49,7 @@ describe("queries for liquidity pools", () => {
         minOutputAmount: 1n,
         integrator,
         integratorFeeRateBPs: 0,
-        typeTags,
+        typeTags: [emojicoin, emojicoinLP],
       });
       const res = await ProvideLiquidity.submit({
         aptosConfig,
@@ -58,7 +57,7 @@ describe("queries for liquidity pools", () => {
         marketAddress,
         quoteAmount: 1000n,
         minLpCoinsOut: 1n,
-        typeTags,
+        typeTags: [emojicoin, emojicoinLP],
       });
       responses.push(res);
     }

--- a/src/typescript/sdk/tests/e2e/swap.test.ts
+++ b/src/typescript/sdk/tests/e2e/swap.test.ts
@@ -1,10 +1,6 @@
-import {
-  AccountAddress,
-  isFeePayerSignature,
-  type UserTransactionResponse,
-} from "@aptos-labs/ts-sdk";
+import type { TypeTag, UserTransactionResponse } from "@aptos-labs/ts-sdk";
+import { AccountAddress, isFeePayerSignature } from "@aptos-labs/ts-sdk";
 
-import type { CoinTypeString} from "../../src";
 import { SYMBOL_EMOJI_DATA } from "../../src";
 import { ONE_APT } from "../../src/const";
 import { EmojicoinDotFun } from "../../src/emojicoin_dot_fun";
@@ -45,7 +41,7 @@ describe("tests the swap functionality", () => {
     integrator: randomIntegrator.accountAddress,
     integratorFeeRateBPs: 0,
     minOutputAmount: 1n,
-    typeTags: [pooEmojicoin, pooLPCoin] as [CoinTypeString, CoinTypeString],
+    typeTags: [pooEmojicoin, pooLPCoin] as [TypeTag, TypeTag],
   };
 
   beforeAll(async () => {

--- a/src/typescript/sdk/tests/e2e/swap.test.ts
+++ b/src/typescript/sdk/tests/e2e/swap.test.ts
@@ -1,10 +1,10 @@
 import {
   AccountAddress,
   isFeePayerSignature,
-  type TypeTag,
   type UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 
+import type { CoinTypeString} from "../../src";
 import { SYMBOL_EMOJI_DATA } from "../../src";
 import { ONE_APT } from "../../src/const";
 import { EmojicoinDotFun } from "../../src/emojicoin_dot_fun";
@@ -45,7 +45,7 @@ describe("tests the swap functionality", () => {
     integrator: randomIntegrator.accountAddress,
     integratorFeeRateBPs: 0,
     minOutputAmount: 1n,
-    typeTags: [pooEmojicoin, pooLPCoin] as [TypeTag, TypeTag],
+    typeTags: [pooEmojicoin, pooLPCoin] as [CoinTypeString, CoinTypeString],
   };
 
   beforeAll(async () => {

--- a/src/typescript/sdk/tests/unit/hex.test.ts
+++ b/src/typescript/sdk/tests/unit/hex.test.ts
@@ -1,9 +1,10 @@
 // cspell:word abcdeg
 
-import { AccountAddress, type TypeTagStruct } from "@aptos-labs/ts-sdk";
+import { AccountAddress } from "@aptos-labs/ts-sdk";
 
+import type { CoinTypeString, StructTagString } from "../../src";
 import {
-  APTOS_COIN_TYPE_TAG,
+  APTOS_COIN_TYPE_STRING,
   chunk,
   deserializeToHexString,
   generateRandomSymbol,
@@ -13,10 +14,9 @@ import {
   removeLeadingZeros,
   removeLeadingZerosFromStructString,
   standardizeAddress,
-  type StructTagString,
   toAccountAddress,
   toAccountAddressString,
-  toCoinTypes,
+  toEmojicoinTypes,
   zip,
 } from "../../src";
 
@@ -178,42 +178,36 @@ describe("hex utility functions", () => {
       "0x225708cc6557dcea948575ad85e8849322f7c13ad176f80c51514f36a34a9a0::module::Struct"
     );
     expect(removeLeadingZerosFromStructString(assetType3)).toEqual("0x1::module::Struct");
-    expect(removeLeadingZerosFromStructString(assetType4)).toEqual(APTOS_COIN_TYPE_TAG.toString());
+    expect(removeLeadingZerosFromStructString(assetType4)).toEqual(APTOS_COIN_TYPE_STRING);
   });
 
   it("should remove leading zeroes from an emojicoin type tag with leading zeros", () => {
     // Since the factory address can change, just find an address with leading zeros randomly.
     // There's a 1/16 chance it will start with a leading zero.
-    let base: TypeTagStruct;
-    let lp: TypeTagStruct;
+    let base: CoinTypeString;
+    let lp: CoinTypeString;
     do {
       const { emojis } = generateRandomSymbol();
       const marketAddress = getMarketAddress(emojis.map((v) => v.emoji));
-      const { emojicoin, emojicoinLP } = toCoinTypes(marketAddress);
-      if (
-        emojicoin.toString().startsWith("0x0") &&
-        emojicoin.isStruct() &&
-        emojicoinLP.isStruct()
-      ) {
+      const { emojicoin, emojicoinLP } = toEmojicoinTypes(marketAddress);
+      if (emojicoin.toString().startsWith("0x0")) {
         base = emojicoin;
         lp = emojicoinLP;
         break;
       }
     } while (true);
 
-    const baseTypeString = base.toString();
-    const baseNoLeadingZeros = removeLeadingZerosFromStructString(baseTypeString);
-    const lpTypeString = lp.toString();
-    const lpNoLeadingZeros = removeLeadingZerosFromStructString(lpTypeString);
+    const baseNoLeadingZeros = removeLeadingZerosFromStructString(base);
+    const lpNoLeadingZeros = removeLeadingZerosFromStructString(lp);
 
-    expect(baseTypeString.startsWith("0x0")).toBe(true);
+    expect(base.startsWith("0x0")).toBe(true);
     expect(baseNoLeadingZeros.startsWith("0x0")).toBe(false);
-    expect(baseTypeString.endsWith("::coin_factory::Emojicoin")).toBe(true);
+    expect(base.endsWith("::coin_factory::Emojicoin")).toBe(true);
     expect(baseNoLeadingZeros.endsWith("::coin_factory::Emojicoin")).toBe(true);
 
-    expect(lpTypeString.startsWith("0x0")).toBe(true);
+    expect(lp.startsWith("0x0")).toBe(true);
     expect(lpNoLeadingZeros.startsWith("0x0")).toBe(false);
-    expect(lpTypeString.endsWith("::coin_factory::EmojicoinLP")).toBe(true);
+    expect(lp.endsWith("::coin_factory::EmojicoinLP")).toBe(true);
     expect(lpNoLeadingZeros.endsWith("::coin_factory::EmojicoinLP")).toBe(true);
   }, 2000);
 

--- a/src/typescript/sdk/tests/unit/hex.test.ts
+++ b/src/typescript/sdk/tests/unit/hex.test.ts
@@ -1,8 +1,9 @@
 // cspell:word abcdeg
 
+import type { TypeTagStruct } from "@aptos-labs/ts-sdk";
 import { AccountAddress } from "@aptos-labs/ts-sdk";
 
-import type { CoinTypeString, StructTagString } from "../../src";
+import type { StructTagString } from "../../src";
 import {
   APTOS_COIN_TYPE_STRING,
   chunk,
@@ -184,30 +185,36 @@ describe("hex utility functions", () => {
   it("should remove leading zeroes from an emojicoin type tag with leading zeros", () => {
     // Since the factory address can change, just find an address with leading zeros randomly.
     // There's a 1/16 chance it will start with a leading zero.
-    let base: CoinTypeString;
-    let lp: CoinTypeString;
+    let base: TypeTagStruct;
+    let lp: TypeTagStruct;
     do {
       const { emojis } = generateRandomSymbol();
       const marketAddress = getMarketAddress(emojis.map((v) => v.emoji));
       const { emojicoin, emojicoinLP } = toEmojicoinTypes(marketAddress);
-      if (emojicoin.toString().startsWith("0x0")) {
+      if (
+        emojicoin.toString().startsWith("0x0") &&
+        emojicoin.isStruct() &&
+        emojicoinLP.isStruct()
+      ) {
         base = emojicoin;
         lp = emojicoinLP;
         break;
       }
     } while (true);
 
-    const baseNoLeadingZeros = removeLeadingZerosFromStructString(base);
-    const lpNoLeadingZeros = removeLeadingZerosFromStructString(lp);
+    const baseTypeString = base.toString();
+    const baseNoLeadingZeros = removeLeadingZerosFromStructString(baseTypeString);
+    const lpTypeString = lp.toString();
+    const lpNoLeadingZeros = removeLeadingZerosFromStructString(lpTypeString);
 
-    expect(base.startsWith("0x0")).toBe(true);
+    expect(baseTypeString.startsWith("0x0")).toBe(true);
     expect(baseNoLeadingZeros.startsWith("0x0")).toBe(false);
-    expect(base.endsWith("::coin_factory::Emojicoin")).toBe(true);
+    expect(baseTypeString.endsWith("::coin_factory::Emojicoin")).toBe(true);
     expect(baseNoLeadingZeros.endsWith("::coin_factory::Emojicoin")).toBe(true);
 
-    expect(lp.startsWith("0x0")).toBe(true);
+    expect(lpTypeString.startsWith("0x0")).toBe(true);
     expect(lpNoLeadingZeros.startsWith("0x0")).toBe(false);
-    expect(lp.endsWith("::coin_factory::EmojicoinLP")).toBe(true);
+    expect(lpTypeString.endsWith("::coin_factory::EmojicoinLP")).toBe(true);
     expect(lpNoLeadingZeros.endsWith("::coin_factory::EmojicoinLP")).toBe(true);
   }, 2000);
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

- [x] Add a `Nominal` type for future types. We can use this to pass around already validated primitives like strings instead of instances of `AccountAddress` or `TypeTag`
- [x] Change `symbol1, symbol2` form in arena helpers to match the move code that uses `symbol0, symbol1` terminology
- [x] Fix lots of coin types used everywhere in the app and SDK to use the new Nominal `CoinTypeString` type
