### PR TITLE
chore(ECO-3144): Format local test private key strings per Aptos SDK warning

### DIFF
--- a/src/typescript/frontend/src/components/pages/test-utils/local-publisher.ts
+++ b/src/typescript/frontend/src/components/pages/test-utils/local-publisher.ts
@@ -1,4 +1,10 @@
-import { Account, Ed25519PrivateKey, Hex, Network } from "@aptos-labs/ts-sdk";
+import {
+  Account,
+  Ed25519PrivateKey,
+  Network,
+  PrivateKey,
+  PrivateKeyVariants,
+} from "@aptos-labs/ts-sdk";
 
 import { APTOS_NETWORK } from "@/sdk/const";
 
@@ -11,6 +17,7 @@ export const getLocalPublisher = () => {
   }
   const privateKeyString = process.env.PUBLISHER_PRIVATE_KEY;
   if (!privateKeyString) throw new Error("Publisher private key not set.");
-  const privateKey = new Ed25519PrivateKey(Hex.fromHexString(privateKeyString).toUint8Array());
+  const formatted = PrivateKey.formatPrivateKey(privateKeyString, PrivateKeyVariants.Ed25519);
+  const privateKey = new Ed25519PrivateKey(formatted);
   return Account.fromPrivateKey({ privateKey });
 };

--- a/src/typescript/sdk/tests/utils/helpers.ts
+++ b/src/typescript/sdk/tests/utils/helpers.ts
@@ -1,4 +1,10 @@
-import { Account, Ed25519PrivateKey, Hex, type UserTransactionResponse } from "@aptos-labs/ts-sdk";
+import {
+  Account,
+  Ed25519PrivateKey,
+  PrivateKey,
+  PrivateKeyVariants,
+  type UserTransactionResponse,
+} from "@aptos-labs/ts-sdk";
 import findGitRoot from "find-git-root";
 import path from "path";
 
@@ -25,8 +31,11 @@ export const getPublisherPrivateKey = () => {
   if (!process.env.PUBLISHER_PRIVATE_KEY) {
     throw new Error("process.env.PUBLISHER_PRIVATE_KEY must be set.");
   }
-  const privateKeyString = process.env.PUBLISHER_PRIVATE_KEY;
-  const privateKey = new Ed25519PrivateKey(Hex.fromHexString(privateKeyString).toUint8Array());
+  const privateKeyString = PrivateKey.formatPrivateKey(
+    process.env.PUBLISHER_PRIVATE_KEY,
+    PrivateKeyVariants.Ed25519
+  );
+  const privateKey = new Ed25519PrivateKey(privateKeyString);
   return privateKey;
 };
 

--- a/src/typescript/sdk/tests/utils/test-accounts.ts
+++ b/src/typescript/sdk/tests/utils/test-accounts.ts
@@ -1,4 +1,10 @@
-import { Account, type Ed25519Account, Ed25519PrivateKey } from "@aptos-labs/ts-sdk";
+import {
+  Account,
+  type Ed25519Account,
+  Ed25519PrivateKey,
+  PrivateKey,
+  PrivateKeyVariants,
+} from "@aptos-labs/ts-sdk";
 
 import testAccountData from "./test-accounts.json";
 
@@ -17,7 +23,11 @@ const fundedAccounts = new Map<FundedAccountIndex, Ed25519Account>(
       throw new Error("Prefix and suffix for the addresses should be the same.");
     }
     const index = prefix as FundedAccountIndex;
-    const privateKey = new Ed25519PrivateKey(privateKeyString);
+    const formattedPrivateKeyString = PrivateKey.formatPrivateKey(
+      privateKeyString,
+      PrivateKeyVariants.Ed25519
+    );
+    const privateKey = new Ed25519PrivateKey(formattedPrivateKeyString);
     const account = Account.fromPrivateKey({ privateKey });
     return [index, account];
   })


### PR DESCRIPTION
# Description

- [x] Format private keys before creating them with the Aptos TS SDK to silence the warning about properly formatted inputs

Example warning (from another PR's CI outputs):

```shell
 console.warn
    [Aptos SDK] It is recommended that private keys are AIP-80 compliant (https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-80.md). You can fix the private key by formatting it with `PrivateKey.formatPrivateKey(privateKey: string, type: 'ed25519' | 'secp256k1'): string`.

      18 |     }
      19 |     const index = prefix as FundedAccountIndex;
    > 20 |     const privateKey = new Ed25519PrivateKey(privateKeyString);
         |                        ^
      21 |     const account = Account.fromPrivateKey({ privateKey });
      22 |     return [index, account];
      23 |   })

      at Function.parseHexInput (../node_modules/.pnpm/@aptos-labs+ts-sdk@1.37.1_axios@1.8.4_got@11.8.6/node_modules/@aptos-labs/ts-sdk/src/core/authenticationKey.ts:56:86)
      at new Ae (../node_modules/.pnpm/@aptos-labs+ts-sdk@1.37.1_axios@1.8.4_got@11.8.6/node_modules/@aptos-labs/ts-sdk/src/core/authenticationKey.ts:56:86)
      at tests/utils/test-accounts.ts:20:24
          at Array.map (<anonymous>)
      at Object.<anonymous> (tests/utils/test-accounts.ts:9:35)
      at Object.<anonymous> (tests/e2e/broker/websockets.test.ts:32:1)
```