### PR TITLE
ci(ECO-3153): Update docker test harness to never build docker image in CI tests, always pull

### DIFF
--- a/src/typescript/sdk/tests/utils/docker/docker-test-harness.ts
+++ b/src/typescript/sdk/tests/utils/docker/docker-test-harness.ts
@@ -104,9 +104,17 @@ export class DockerTestHarness {
 
     const command = "docker";
 
-    const args = ["compose", "-f", LOCAL_COMPOSE_PATH, "--env-file", LOCAL_ENV_PATH, "up"].filter(
-      (arg) => arg !== ""
-    );
+    const args = [
+      "compose",
+      "-f",
+      LOCAL_COMPOSE_PATH,
+      "--env-file",
+      LOCAL_ENV_PATH,
+      "up",
+      "--no-build",
+      "--pull",
+      "always",
+    ].filter((arg) => arg !== "");
 
     const process = spawnWrapper(command, args, false, filterLogsFrom);
     writeFileSync(TMP_PID_FILE_PATH, process.pid?.toString() ?? "");


### PR DESCRIPTION
# Description

In TypeScript test suites sometimes the runner will try to build a docker image whenever the tags don't line up.

- [x] Update the docker command in the `docker-test-harness.ts` script to never build and always pull.

