### PR TITLE
fix(ECO-3154): Add `staleTime: TEN_SECONDS` to `useSwapEventsQuery` and `useChatEventsQuery`; refactor `useIsMarketRegistered` `staleTime`

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/useChatEventsQuery.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/useChatEventsQuery.tsx
@@ -10,6 +10,8 @@ import { LIMIT } from "@/sdk/indexer-v2/const";
 
 type ChatEvent = Awaited<ReturnType<typeof fetchChatEvents>>[number];
 
+const TEN_SECONDS = 10000;
+
 export const useChatEventsQuery = (args: z.input<typeof GetChatsSchema>) => {
   const query = useInfiniteQuery({
     queryKey: ["fetchChatEvents", args],
@@ -26,6 +28,7 @@ export const useChatEventsQuery = (args: z.input<typeof GetChatsSchema>) => {
       lastPage?.length === LIMIT ? allPages.length + 1 : undefined,
     // Disable the query when a marketID isn't provided
     enabled: !!args.marketID,
+    staleTime: TEN_SECONDS,
   });
 
   return query;

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEmojiPicker } from "context/emoji-picker-context";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
+import { useNumMarkets } from "lib/hooks/queries/use-num-markets";
 
 import { MarketMetadataByEmojiBytes } from "@/move-modules/emojicoin-dot-fun";
 import { SYMBOL_EMOJI_DATA, type SymbolEmoji } from "@/sdk/emoji_data";
@@ -15,9 +16,16 @@ export const useIsMarketRegistered = () => {
   const getMarket = useEventStore((state) => state.getMarket);
   const { aptos } = useAptos();
   const emojiBytes = normalizeHex(encoder.encode(emojis.join("")));
+  const { data: numMarkets } = useNumMarkets();
 
   const { data } = useQuery({
-    queryKey: [MarketMetadataByEmojiBytes.prototype.functionName, aptos.config.network, emojiBytes],
+    queryKey: [
+      MarketMetadataByEmojiBytes.prototype.functionName,
+      aptos.config.network,
+      emojiBytes,
+      // Invalidate the cache when the number of markets change, since `staleTime === Infinity`.
+      numMarkets,
+    ],
     queryFn: async () => {
       const length = sumBytes(emojis);
       const invalidLength = length === 0 || length > 10;
@@ -50,7 +58,9 @@ export const useIsMarketRegistered = () => {
         registered,
       };
     },
-    staleTime: 1,
+    // Once fetched, this data will never change until the # of markets changes, which is tracked in
+    // the queryKey.
+    staleTime: Infinity,
   });
 
   return (

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
@@ -23,7 +23,7 @@ export const useIsMarketRegistered = () => {
       MarketMetadataByEmojiBytes.prototype.functionName,
       aptos.config.network,
       emojiBytes,
-      // Invalidate the cache when the number of markets change, since `staleTime === Infinity`.
+      // Invalidate the cache when the number of markets changes.
       numMarkets,
     ],
     queryFn: async () => {
@@ -58,8 +58,7 @@ export const useIsMarketRegistered = () => {
         registered,
       };
     },
-    // Once fetched, this data will never change until the # of markets changes, which is tracked in
-    // the queryKey.
+    // Once fetched, this data will never change as long as `numMarkets` hasn't changed.
     staleTime: Infinity,
   });
 

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
@@ -3,7 +3,6 @@ import { useEmojiPicker } from "context/emoji-picker-context";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useNumMarkets } from "lib/hooks/queries/use-num-markets";
-import { useEffect, useMemo } from "react";
 
 import { MarketMetadataByEmojiBytes } from "@/move-modules/emojicoin-dot-fun";
 import { SYMBOL_EMOJI_DATA, type SymbolEmoji } from "@/sdk/emoji_data";

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-is-market-registered.ts
@@ -3,6 +3,7 @@ import { useEmojiPicker } from "context/emoji-picker-context";
 import { useEventStore } from "context/event-store-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useNumMarkets } from "lib/hooks/queries/use-num-markets";
+import { useEffect, useMemo } from "react";
 
 import { MarketMetadataByEmojiBytes } from "@/move-modules/emojicoin-dot-fun";
 import { SYMBOL_EMOJI_DATA, type SymbolEmoji } from "@/sdk/emoji_data";

--- a/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
+++ b/src/typescript/frontend/src/components/pages/launch-emojicoin/hooks/use-register-market.ts
@@ -75,7 +75,7 @@ export const useRegisterMarket = (sequenceNumber: bigint | null) => {
         return undefined;
       }
     },
-    staleTime: 1000,
+    staleTime: 2000,
     enabled:
       numMarkets !== undefined && account !== null && (numMarkets === 0 || emojis.length > 0),
   });

--- a/src/typescript/frontend/src/components/pages/wallet/useSwapEventsQuery.ts
+++ b/src/typescript/frontend/src/components/pages/wallet/useSwapEventsQuery.ts
@@ -10,6 +10,8 @@ import { LIMIT } from "@/sdk/indexer-v2/const";
 
 export type SwapEvent = Awaited<ReturnType<typeof fetchSwapEvents>>[number];
 
+const TEN_SECONDS = 10000;
+
 export const useSwapEventsQuery = (
   args: z.input<typeof GetTradesSchema>,
   options?: {
@@ -38,6 +40,7 @@ export const useSwapEventsQuery = (
       lastPageResponse?.length === LIMIT ? allPageResponses.length + 1 : undefined,
     // Disable the query when explicitly disabled or when neither sender nor marketID is provided
     enabled: options?.disabled !== true && (!!args.sender || !!args.marketID),
+    staleTime: TEN_SECONDS,
   });
 
   return query;

--- a/src/typescript/frontend/src/lib/hooks/queries/use-num-markets.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-num-markets.ts
@@ -13,9 +13,7 @@ export const useNumMarkets = () => {
   const numMarkets = useEventStore((s) => s.markets.size);
   const res = useQuery({
     queryKey: ["num-markets", numMarkets],
-    queryFn: () => {
-      return getNumMarkets();
-    },
+    queryFn: () => getNumMarkets(),
     staleTime: 15000,
   });
 

--- a/src/typescript/frontend/src/lib/utils/emojiColors/use-emoji-colors.ts
+++ b/src/typescript/frontend/src/lib/utils/emojiColors/use-emoji-colors.ts
@@ -18,5 +18,6 @@ export const useEmojiColors = (emoji: SymbolEmoji[]) => {
   return useQuery({
     queryKey: ["useEmojiColors", emoji],
     queryFn: async () => await getEmojiColor(emoji),
+    staleTime: Infinity,
   });
 };


### PR DESCRIPTION
# Description

They should be fetched as little as possible. They're fetched every time the window regains focus. The broker/websockets should handle most new incoming events.

I've added `staleTime: TEN_SECONDS` to both of them so that they're not fetched more often than once every 10 seconds. This will still allow users that can't connect over websockets to see new swap/chat events but not every single time the page/component regains focus.

- [x] Also refactored the `staleTime` for `useIsMarketRegistered`, making sure it never refetches unless the number of markets changes. I tested this on a localnet several times to make sure it works.

# Testing

Tested it myself manually by watching the network tab. Ensured each type of request isn't made more than once every 10 seconds.