### PR TITLE
chore(ECO-3159): Bump processor submodule to 7.0.1 everywhere and hot upgrade `alpha`

### DIFF
--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -20,7 +20,7 @@ parameters:
   Environment: 'alpha'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
-  ProcessorImageVersion: '7.0.0'
+  ProcessorImageVersion: '7.0.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.0'
+  ProcessorImageVersion: '7.0.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.0'
+  ProcessorImageVersion: '7.0.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -83,7 +83,7 @@ services:
     depends_on:
       postgres:
         condition: 'service_healthy'
-    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.0'
+    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.1'
     container_name: 'processor'
     healthcheck:
       test: 'curl -sf http://localhost:${PROCESSOR_WS_PORT} || exit 1'


### PR DESCRIPTION
# Description

- [x] Merge the 7.0.1 changes to the processor submodule
- [x] Rebuild it with tag `econialabs/emojicoin-dot-fun-indexer-processor:7.0.1`
- [x] Update the stack files to use it
- [x] Update the `compose.yaml` file to use it
- [x] Hot upgrade the `alpha` stack 

