### PR TITLE
chore(ECO-3163): Add new last transaction version types to leaderboard view in the SDK

### DIFF
--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -20,7 +20,7 @@ parameters:
   Environment: 'alpha'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
-  ProcessorImageVersion: '7.0.2-rc.1'
+  ProcessorImageVersion: '7.0.2-rc.2'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  BrokerImageVersion: '7.0.0'
+  BrokerImageVersion: '7.0.2-rc.2'
   DeployAlb: 'true'
   DeployAlbDnsRecord: 'true'
   DeployBastionHost: 'true'

--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  BrokerImageVersion: '7.0.2-rc.2'
+  BrokerImageVersion: '7.0.2'
   DeployAlb: 'true'
   DeployAlbDnsRecord: 'true'
   DeployBastionHost: 'true'
@@ -20,7 +20,7 @@ parameters:
   Environment: 'alpha'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
-  ProcessorImageVersion: '7.0.2-rc.2'
+  ProcessorImageVersion: '7.0.2'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -20,7 +20,7 @@ parameters:
   Environment: 'alpha'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
-  ProcessorImageVersion: '7.0.1'
+  ProcessorImageVersion: '7.0.2-rc.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.1'
+  ProcessorImageVersion: '7.0.2-rc.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '7.0.2-rc.2'
+  BrokerImageVersion: '7.0.2'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.2-rc.2'
+  ProcessorImageVersion: '7.0.2'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '7.0.0'
+  BrokerImageVersion: '7.0.2-rc.2'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.2-rc.1'
+  ProcessorImageVersion: '7.0.2-rc.2'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '7.0.0'
+  BrokerImageVersion: '7.0.2-rc.2'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.2-rc.1'
+  ProcessorImageVersion: '7.0.2-rc.2'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.1'
+  ProcessorImageVersion: '7.0.2-rc.1'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '7.0.2-rc.2'
+  BrokerImageVersion: '7.0.2'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.2-rc.2'
+  ProcessorImageVersion: '7.0.2'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -15,7 +15,7 @@ services:
       PROCESSOR_WS_URL: 'ws://processor:${PROCESSOR_WS_PORT}/ws'
       PORT: '${BROKER_PORT}'
       RUST_LOG: 'info,broker=trace'
-    image: 'econialabs/emojicoin-dot-fun-indexer-broker:7.0.2-rc.2'
+    image: 'econialabs/emojicoin-dot-fun-indexer-broker:7.0.2'
     container_name: 'broker'
     healthcheck:
       test: 'curl -f http://localhost:${BROKER_PORT}/live || exit 1'
@@ -83,7 +83,7 @@ services:
     depends_on:
       postgres:
         condition: 'service_healthy'
-    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.2-rc.2'
+    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.2'
     container_name: 'processor'
     healthcheck:
       test: 'curl -sf http://localhost:${PROCESSOR_WS_PORT} || exit 1'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -15,7 +15,7 @@ services:
       PROCESSOR_WS_URL: 'ws://processor:${PROCESSOR_WS_PORT}/ws'
       PORT: '${BROKER_PORT}'
       RUST_LOG: 'info,broker=trace'
-    image: 'econialabs/emojicoin-dot-fun-indexer-broker:7.0.0'
+    image: 'econialabs/emojicoin-dot-fun-indexer-broker:7.0.2-rc.2'
     container_name: 'broker'
     healthcheck:
       test: 'curl -f http://localhost:${BROKER_PORT}/live || exit 1'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -83,7 +83,7 @@ services:
     depends_on:
       postgres:
         condition: 'service_healthy'
-    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.1'
+    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.2-rc.1'
     container_name: 'processor'
     healthcheck:
       test: 'curl -sf http://localhost:${PROCESSOR_WS_PORT} || exit 1'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -83,7 +83,7 @@ services:
     depends_on:
       postgres:
         condition: 'service_healthy'
-    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.2-rc.1'
+    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.2-rc.2'
     container_name: 'processor'
     healthcheck:
       test: 'curl -sf http://localhost:${PROCESSOR_WS_PORT} || exit 1'

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -869,7 +869,6 @@ export const toArenaLeaderboardHistoryWithArenaInfo = (
   data: DatabaseJsonType["arena_leaderboard_history_with_arena_info"]
 ): Types["ArenaLeaderboardHistoryWithArenaInfo"] => ({
   user: data.user,
-  leaderboardLastTransactionVersion: BigInt(data.leaderboard_last_transaction_version),
   meleeID: BigInt(data.melee_id),
   profits: BigInt(data.profits),
   losses: BigInt(data.losses),
@@ -879,7 +878,6 @@ export const toArenaLeaderboardHistoryWithArenaInfo = (
   lastExit0: data.last_exit_0,
   exited: data.exited,
 
-  arenaInfoLastTransactionVersion: BigInt(data.arena_info_last_transaction_version),
   emojicoin0Symbols: data.emojicoin_0_symbols,
   emojicoin1Symbols: data.emojicoin_1_symbols,
   emojicoin0MarketAddress: data.emojicoin_0_market_address,
@@ -888,6 +886,11 @@ export const toArenaLeaderboardHistoryWithArenaInfo = (
   emojicoin1MarketID: BigInt(data.emojicoin_1_market_id),
   startTime: postgresTimestampToDate(data.start_time),
   duration: BigInt(data.duration),
+
+  leaderboardHistoryLastTransactionVersion: BigInt(
+    data.leaderboard_history_last_transaction_version
+  ),
+  arenaInfoLastTransactionVersion: BigInt(data.arena_info_last_transaction_version),
 });
 
 export const toArenaMeleeModel = (data: DatabaseJsonType["arena_melee_events"]) => ({

--- a/src/typescript/sdk/src/indexer-v2/types/index.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/index.ts
@@ -869,6 +869,7 @@ export const toArenaLeaderboardHistoryWithArenaInfo = (
   data: DatabaseJsonType["arena_leaderboard_history_with_arena_info"]
 ): Types["ArenaLeaderboardHistoryWithArenaInfo"] => ({
   user: data.user,
+  leaderboardLastTransactionVersion: BigInt(data.leaderboard_last_transaction_version),
   meleeID: BigInt(data.melee_id),
   profits: BigInt(data.profits),
   losses: BigInt(data.losses),
@@ -878,6 +879,7 @@ export const toArenaLeaderboardHistoryWithArenaInfo = (
   lastExit0: data.last_exit_0,
   exited: data.exited,
 
+  arenaInfoLastTransactionVersion: BigInt(data.arena_info_last_transaction_version),
   emojicoin0Symbols: data.emojicoin_0_symbols,
   emojicoin1Symbols: data.emojicoin_1_symbols,
   emojicoin0MarketAddress: data.emojicoin_0_market_address,

--- a/src/typescript/sdk/src/indexer-v2/types/json-types.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/json-types.ts
@@ -370,7 +370,10 @@ type ArenaLeaderboardHistoryWithArenaInfoData = Flatten<
       | "emojicoin_1_market_id"
       | "start_time"
       | "duration"
-    >
+    > & {
+      leaderboard_last_transaction_version: Uint64String;
+      arena_info_last_transaction_version: Uint64String;
+    }
 >;
 
 type ArenaLeaderboardData = {

--- a/src/typescript/sdk/src/indexer-v2/types/json-types.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/json-types.ts
@@ -371,7 +371,7 @@ type ArenaLeaderboardHistoryWithArenaInfoData = Flatten<
       | "start_time"
       | "duration"
     > & {
-      leaderboard_last_transaction_version: Uint64String;
+      leaderboard_history_last_transaction_version: Uint64String;
       arena_info_last_transaction_version: Uint64String;
     }
 >;

--- a/src/typescript/sdk/src/indexer-v2/types/json-types.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/json-types.ts
@@ -626,6 +626,7 @@ type Columns = DatabaseJsonType[TableName.GlobalStateEvents] &
   DatabaseJsonType[TableName.ArenaCandlesticks] &
   DatabaseJsonType[TableName.ArenaLeaderboard] &
   DatabaseJsonType[TableName.ArenaLeaderboardHistory] &
+  DatabaseJsonType[TableName.ArenaLeaderboardHistoryWithArenaInfo] &
   DatabaseJsonType[DatabaseRpc.UserPools] &
   DatabaseJsonType[DatabaseRpc.AggregateMarketState];
 

--- a/src/typescript/sdk/src/indexer-v2/types/postgres-numeric-types.ts
+++ b/src/typescript/sdk/src/indexer-v2/types/postgres-numeric-types.ts
@@ -141,6 +141,8 @@ export const bigintColumns: Set<AnyColumnName> = new Set([
   "last_success_version",
   "last_transaction_version",
   "transaction_version",
+  "arena_info_last_transaction_version",
+  "leaderboard_history_last_transaction_version",
 ]);
 
 /**

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -118,7 +118,6 @@ export type ArenaTypes = {
 
   ArenaLeaderboardHistoryWithArenaInfo: {
     user: AccountAddressString;
-    leaderboardLastTransactionVersion: bigint;
     meleeID: bigint;
     profits: bigint;
     losses: bigint;
@@ -128,7 +127,6 @@ export type ArenaTypes = {
     lastExit0: boolean | null;
     exited: boolean;
 
-    arenaInfoLastTransactionVersion: bigint;
     emojicoin0MarketAddress: AccountAddressString;
     emojicoin0Symbols: SymbolEmoji[];
     emojicoin0MarketID: bigint;
@@ -137,6 +135,9 @@ export type ArenaTypes = {
     emojicoin1MarketID: bigint;
     startTime: Date;
     duration: bigint;
+
+    arenaInfoLastTransactionVersion: bigint;
+    leaderboardHistoryLastTransactionVersion: bigint;
   };
 
   ArenaLeaderboard: {

--- a/src/typescript/sdk/src/types/arena-types.ts
+++ b/src/typescript/sdk/src/types/arena-types.ts
@@ -118,6 +118,7 @@ export type ArenaTypes = {
 
   ArenaLeaderboardHistoryWithArenaInfo: {
     user: AccountAddressString;
+    leaderboardLastTransactionVersion: bigint;
     meleeID: bigint;
     profits: bigint;
     losses: bigint;
@@ -127,6 +128,7 @@ export type ArenaTypes = {
     lastExit0: boolean | null;
     exited: boolean;
 
+    arenaInfoLastTransactionVersion: bigint;
     emojicoin0MarketAddress: AccountAddressString;
     emojicoin0Symbols: SymbolEmoji[];
     emojicoin0MarketID: bigint;


### PR DESCRIPTION
# Description

Need to add the new types to the SDK to expose the fields in the view.

See https://github.com/econia-labs/aptos-indexer-processors/pull/116

- [x] Add the corresponding types to the SDK
- [x] Update compose.yaml for the processor tag
- [x] Update the stack files to hot upgrade it to the new 7.0.2 processor tag
- [x] Update broker tags as well, to make sure all fixes are included properly (the new fix in `schema.rs`— see https://github.com/econia-labs/aptos-indexer-processors/pull/117)
- [ ] Once this is merged, re-tag `broker` and push with no rc tag. Ensure the same has been done for the processor tag as well

# Testing

Fairly straighforward to test it manually. The field should show up and be converted properly to bigints in the `route.ts` endpoint for `/api/historical-position?user=0x....`

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
