### PR TITLE
chore(ECO-3148): Bump frontend version to 1.7.0 and SDK to 0.6.0

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -118,5 +118,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.6.0"
+  "version": "1.7.0"
 }

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -109,5 +109,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.5.4"
+  "version": "0.6.0"
 }


### PR DESCRIPTION
# Description

- Frontend has arena additions.
- SDK's APIs changed so it's technically breaking changes, although it's still in alpha so just a minor bump is fine.

