### PR TITLE
fix(ECO-3170): Fix swaps incorrect sorting; update chat sorting

### DIFF
--- a/src/typescript/frontend/src/components/pages/arena/tabs/ChatTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/ChatTab.tsx
@@ -49,9 +49,9 @@ export const ChatTab = ({ market0, market1, position }: Props) => {
     return _.orderBy(
       _.uniqBy(
         [...market1chatsFromStore, ...market0chatsFromStore, ...(chats.data?.pages.flat() || [])],
-        (i) => i.transaction.version
+        (i) => i.market.marketNonce
       ),
-      (i) => i.transaction.version,
+      (i) => i.market.marketNonce,
       "desc"
     ).map((s, i) => ({
       message: {

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -34,9 +34,9 @@ const ChatBox = (props: ChatProps) => {
     return _.orderBy(
       _.uniqBy(
         [...chatsFromStore, ...(chatsQuery.data?.pages.flat() || [])],
-        (i) => i.transaction.version
+        (i) => i.market.marketNonce
       ),
-      (i) => i.transaction.version,
+      (i) => i.market.marketNonce,
       "desc"
     ).map((s, i) => ({
       message: {

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/trade-history/trade-history.tsx
@@ -38,10 +38,11 @@ export const TradeHistory = (props: TradeHistoryProps) => {
 
   const sortedSwaps = useMemo(() => {
     return _.orderBy(
-      _.uniqBy([...swapsFromStore, ...(swapsQuery.data?.pages.flat() || [])], (i) =>
-        i.transaction.version.toString()
+      _.uniqBy(
+        [...swapsFromStore, ...(swapsQuery.data?.pages.flat() || [])],
+        (i) => i.market.marketNonce
       ),
-      (i) => i.transaction.version.toString(),
+      (i) => i.market.marketNonce,
       "desc"
     ).map(toTableItem);
   }, [swapsQuery.data?.pages, swapsFromStore]);


### PR DESCRIPTION
# Description

- [x] It was sorting by a string rather than by a number-like value in the swaps history.
- [x] Make them both consistent and correct and use the market nonce.
