### PR TITLE
fix(ECO-3171): Handle ANS name resolution failure gracefully

### DIFF
--- a/src/typescript/frontend/src/app/wallet/utils.ts
+++ b/src/typescript/frontend/src/app/wallet/utils.ts
@@ -1,5 +1,4 @@
 import { AccountAddress, type AccountAddressInput } from "@aptos-labs/ts-sdk";
-import { APTOS_NETWORK } from "lib/env";
 import { cache } from "react";
 
 import {
@@ -55,14 +54,15 @@ const resolveOwnerName = async (input?: AccountAddressInput | null): Promise<Pos
     }
   } catch (e) {
     if (isValidAptosName(input) || AccountAddress.isValid({ input })) {
-      // There's no ANS service on the local network. Just silently return.
-      if (APTOS_NETWORK === "local") {
-        return {
-          address: AccountAddress.from(input).toString(),
-          name: undefined,
-        };
-      }
+      // The ANS service is either down or the user is on a local network. Just return the address
+      // if it's a valid account address.
       console.warn(`${input} is a valid ANS name or account address but still threw an error ${e}`);
+      return {
+        address: AccountAddress.isValid({ input }).valid
+          ? AccountAddress.from(input).toString()
+          : undefined,
+        name: undefined,
+      };
     }
   }
 

--- a/src/typescript/frontend/src/app/wallet/utils.ts
+++ b/src/typescript/frontend/src/app/wallet/utils.ts
@@ -1,4 +1,5 @@
 import { AccountAddress, type AccountAddressInput } from "@aptos-labs/ts-sdk";
+import { APTOS_NETWORK } from "lib/env";
 import { cache } from "react";
 
 import {
@@ -54,6 +55,13 @@ const resolveOwnerName = async (input?: AccountAddressInput | null): Promise<Pos
     }
   } catch (e) {
     if (isValidAptosName(input) || AccountAddress.isValid({ input })) {
+      // There's no ANS service on the local network. Just silently return.
+      if (APTOS_NETWORK === "local") {
+        return {
+          address: AccountAddress.from(input).toString(),
+          name: undefined,
+        };
+      }
       console.warn(`${input} is a valid ANS name or account address but still threw an error ${e}`);
     }
   }


### PR DESCRIPTION
# Description

A failure to resolve the name could mean one of two things:
- The ANS service is down.
- The user is on a local network (which also means it's down...)

In either case, it's still desirable to return the regular account address if it's valid, so this changes that so that it more gracefully handles the failure to fetch the ANS name, rather than says "User Not Found".
