### PR TITLE
test(ECO-3175): Add E2E test with processor restarts

### DIFF
--- a/.github/workflows/ts-checks.yaml
+++ b/.github/workflows/ts-checks.yaml
@@ -75,6 +75,7 @@ jobs:
         - pretty-suffix: 'sdk, e2e, base-ws'
         - pretty-suffix: 'sdk, e2e, arena-general'
         - pretty-suffix: 'sdk, e2e, arena-ws'
+        - pretty-suffix: 'sdk, e2e, arena-restart'
         - pretty-suffix: 'sdk, e2e, arena-candlesticks'
         - pretty-suffix: 'sdk, e2e, candlesticks'
     timeout-minutes: 15

--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -20,7 +20,7 @@ parameters:
   Environment: 'alpha'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
-  ProcessorImageVersion: '7.0.2'
+  ProcessorImageVersion: '7.0.3'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.2'
+  ProcessorImageVersion: '7.0.3'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.2'
+  ProcessorImageVersion: '7.0.3'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -83,7 +83,7 @@ services:
     depends_on:
       postgres:
         condition: 'service_healthy'
-    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.2'
+    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.3'
     container_name: 'processor'
     healthcheck:
       test: 'curl -sf http://localhost:${PROCESSOR_WS_PORT} || exit 1'

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -55,6 +55,7 @@
     "test:sdk:e2e:candlesticks": "pnpm run load-env:test -- turbo run test:e2e:candlesticks --filter @econia-labs/emojicoin-sdk --log-prefix none",
     "test:sdk:e2e:arena-candlesticks": "pnpm run load-env:test -- turbo run test:e2e:arena-candlesticks --filter @econia-labs/emojicoin-sdk --log-prefix none",
     "test:sdk:e2e:arena-general": "pnpm run load-env:test -- turbo run test:e2e:arena-general --filter @econia-labs/emojicoin-sdk --log-prefix none",
+    "test:sdk:e2e:arena-restart": "pnpm run load-env:test -- turbo run test:e2e:arena-restart --filter @econia-labs/emojicoin-sdk --log-prefix none",
     "test:sdk:e2e:arena-ws": "pnpm run load-env:test -- turbo run test:e2e:arena-ws --filter @econia-labs/emojicoin-sdk --log-prefix none",
     "test:sdk:unit": "NO_TEST_SETUP=true pnpm run load-env:test -- turbo run test:unit --filter @econia-labs/emojicoin-sdk --force --log-prefix none",
     "test:unit": "NO_TEST_SETUP=true pnpm run load-env:test -- turbo run test:unit --force --log-prefix none --ui tui",

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -104,6 +104,7 @@
     "test:e2e:candlesticks": "pnpm jest tests/e2e/candlesticks.test.ts --runInBand",
     "test:e2e:arena-candlesticks": "pnpm jest tests/e2e/arena/candlesticks.test.ts --runInBand",
     "test:e2e:arena-general": "pnpm jest tests/e2e/arena/general.test.ts --runInBand",
+    "test:e2e:arena-restart": "pnpm jest tests/e2e/arena/restart.test.ts --runInBand",
     "test:e2e:arena-ws": "pnpm jest tests/e2e/arena/websockets.test.ts --runInBand",
     "test:unit": "pnpm jest tests/unit",
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"

--- a/src/typescript/sdk/tests/e2e/arena/restart.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/restart.test.ts
@@ -1,23 +1,20 @@
+import type { MeleeEmojiData } from "../../../src";
 import {
   fetchArenaMeleeView,
   fetchMeleeEmojiData,
-  MeleeEmojiData,
   sleep,
   toArenaLeaderboardHistoryModel,
 } from "../../../src";
 import { EmojicoinClient } from "../../../src/client/emojicoin-client";
-import {
-  postgrest,
-  TableName,
-} from "../../../src/indexer-v2";
+import { postgrest, TableName } from "../../../src/indexer-v2";
+import { getPublisher } from "../../utils";
+import { DockerTestHarness } from "../../utils/docker/docker-test-harness";
 import { waitForProcessor } from "../helpers";
 import {
   ONE_SECOND_MICROSECONDS,
   setNextMeleeDurationAndEnsureCrank,
   waitUntilCurrentMeleeEnds,
 } from "./utils";
-import { getPublisher } from "../../utils";
-import { DockerTestHarness } from "../../utils/docker/docker-test-harness";
 
 describe("ensures arena candlesticks work", () => {
   const emojicoin = new EmojicoinClient();
@@ -35,17 +32,38 @@ describe("ensures arena candlesticks work", () => {
 
   it("verifies that the processor restart with a correct price", async () => {
     await waitUntilCurrentMeleeEnds();
-    const crank = await emojicoin.arena.enter(account, 1n, false, melee.market0.symbolEmojis, melee.market1.symbolEmojis, "symbol0");
+    const crank = await emojicoin.arena.enter(
+      account,
+      1n,
+      false,
+      melee.market0.symbolEmojis,
+      melee.market1.symbolEmojis,
+      "symbol0"
+    );
     melee = await fetchArenaMeleeView(crank.arena.event.meleeID).then(fetchMeleeEmojiData);
 
-    const enter = await emojicoin.arena.enter(account, 1n, false, melee.market0.symbolEmojis, melee.market1.symbolEmojis, "symbol0");
+    const enter = await emojicoin.arena.enter(
+      account,
+      1n,
+      false,
+      melee.market0.symbolEmojis,
+      melee.market1.symbolEmojis,
+      "symbol0"
+    );
     expect(enter.events.arenaEnterEvents.length).toEqual(1);
     await waitUntilCurrentMeleeEnds();
     await DockerTestHarness.restartProcessor();
     await sleep(10000);
 
     // Crank
-    const res = await emojicoin.arena.enter(account, 1n, false, melee.market0.symbolEmojis, melee.market1.symbolEmojis, "symbol0");
+    const res = await emojicoin.arena.enter(
+      account,
+      1n,
+      false,
+      melee.market0.symbolEmojis,
+      melee.market1.symbolEmojis,
+      "symbol0"
+    );
 
     await waitForProcessor(res);
 

--- a/src/typescript/sdk/tests/e2e/arena/restart.test.ts
+++ b/src/typescript/sdk/tests/e2e/arena/restart.test.ts
@@ -1,0 +1,68 @@
+import {
+  fetchArenaMeleeView,
+  fetchMeleeEmojiData,
+  MeleeEmojiData,
+  sleep,
+  toArenaLeaderboardHistoryModel,
+} from "../../../src";
+import { EmojicoinClient } from "../../../src/client/emojicoin-client";
+import {
+  postgrest,
+  TableName,
+} from "../../../src/indexer-v2";
+import { waitForProcessor } from "../helpers";
+import {
+  ONE_SECOND_MICROSECONDS,
+  setNextMeleeDurationAndEnsureCrank,
+  waitUntilCurrentMeleeEnds,
+} from "./utils";
+import { getPublisher } from "../../utils";
+import { DockerTestHarness } from "../../utils/docker/docker-test-harness";
+
+describe("ensures arena candlesticks work", () => {
+  const emojicoin = new EmojicoinClient();
+  const account = getPublisher();
+  let melee: MeleeEmojiData;
+
+  beforeAll(async () => {
+    await emojicoin.register(account, ["🥇"]);
+    await emojicoin.register(account, ["🥈"]);
+    await setNextMeleeDurationAndEnsureCrank(ONE_SECOND_MICROSECONDS * 10n).then((res) => {
+      melee = res.melee;
+      return waitForProcessor(res);
+    });
+  }, 70000);
+
+  it("verifies that the processor restart with a correct price", async () => {
+    await waitUntilCurrentMeleeEnds();
+    const crank = await emojicoin.arena.enter(account, 1n, false, melee.market0.symbolEmojis, melee.market1.symbolEmojis, "symbol0");
+    melee = await fetchArenaMeleeView(crank.arena.event.meleeID).then(fetchMeleeEmojiData);
+
+    const enter = await emojicoin.arena.enter(account, 1n, false, melee.market0.symbolEmojis, melee.market1.symbolEmojis, "symbol0");
+    expect(enter.events.arenaEnterEvents.length).toEqual(1);
+    await waitUntilCurrentMeleeEnds();
+    await DockerTestHarness.restartProcessor();
+    await sleep(10000);
+
+    // Crank
+    const res = await emojicoin.arena.enter(account, 1n, false, melee.market0.symbolEmojis, melee.market1.symbolEmojis, "symbol0");
+
+    await waitForProcessor(res);
+
+    const leaderboard = await postgrest
+      .from(TableName.ArenaLeaderboardHistory)
+      .select("*")
+      .eq("melee_id", melee.view.meleeID)
+      .then((r) => r.data)
+      .then((r) => (r === null ? null : r.map(toArenaLeaderboardHistoryModel)));
+
+    expect(leaderboard).not.toBeNull();
+    expect(leaderboard!.length).toEqual(1);
+
+    const element = leaderboard![0];
+    const pnl = Number(element.profits) / Number(element.losses);
+
+    expect(pnl).toBeGreaterThan(0.9);
+    expect(pnl).toBeLessThan(1.1);
+  }, 40000);
+});

--- a/src/typescript/sdk/tests/utils/docker/docker-test-harness.ts
+++ b/src/typescript/sdk/tests/utils/docker/docker-test-harness.ts
@@ -72,7 +72,9 @@ export class DockerTestHarness {
   }
 
   static async restartProcessor() {
-    await execPromise(`docker compose -f ${LOCAL_COMPOSE_PATH} --env-file ${LOCAL_ENV_PATH} restart processor`);
+    await execPromise(
+      `docker compose -f ${LOCAL_COMPOSE_PATH} --env-file ${LOCAL_ENV_PATH} restart processor`
+    );
   }
 
   /**

--- a/src/typescript/sdk/tests/utils/docker/docker-test-harness.ts
+++ b/src/typescript/sdk/tests/utils/docker/docker-test-harness.ts
@@ -71,6 +71,10 @@ export class DockerTestHarness {
     return execPromise(`bash ${PRUNE_SCRIPT} --reset-localnet --yes`);
   }
 
+  static async restartProcessor() {
+    await execPromise(`docker compose -f ${LOCAL_COMPOSE_PATH} --env-file ${LOCAL_ENV_PATH} restart processor`);
+  }
+
   /**
    * Stops the Docker containers.
    */

--- a/src/typescript/turbo.json
+++ b/src/typescript/turbo.json
@@ -89,6 +89,10 @@
       "cache": false,
       "outputs": []
     },
+    "test:e2e:arena-restart": {
+      "cache": false,
+      "outputs": []
+    },
     "test:e2e:arena-ws": {
       "cache": false,
       "outputs": []


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

This PR adds E2E tests that include processor restarts to test the initialization of data in the processor.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
