### PR TITLE
chore(ECO-3191): Bump processor submodule for 7.0.4 (fixes rewards remaining calculations)

### DIFF
--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -20,7 +20,7 @@ parameters:
   Environment: 'alpha'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
-  ProcessorImageVersion: '7.0.3'
+  ProcessorImageVersion: '7.0.4'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.3'
+  ProcessorImageVersion: '7.0.4'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.3'
+  ProcessorImageVersion: '7.0.4'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -83,7 +83,7 @@ services:
     depends_on:
       postgres:
         condition: 'service_healthy'
-    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.3'
+    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.4'
     container_name: 'processor'
     healthcheck:
       test: 'curl -sf http://localhost:${PROCESSOR_WS_PORT} || exit 1'


### PR DESCRIPTION
# Description

- [x] Bump processor submodule after It's merged to emojicoin-dot-fun
- [x] Build the tag for 7.0.4 with the fix
- [x] Update the tag in docker compose.yaml
- [x] Update the tag in cloud-formation yaml files
- [x] Update this checklist once the tag is built and CI is re-run

# Testing

Tested the image locally to make sure it works. It did!

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
