### PR TITLE
fix(ECO-3198): Fix default candlestick time for non-arena charts

### DIFF
--- a/src/typescript/frontend/src/components/charts/PrivateChart.tsx
+++ b/src/typescript/frontend/src/components/charts/PrivateChart.tsx
@@ -1,13 +1,14 @@
 import { createSwitch } from "components/charts/EmptyCandlesSwitch";
 import { useUserSettings } from "context/event-store-context";
-import { encodeSymbolsForChart, formatSymbolWithParams } from "lib/chart-utils";
+import { encodeSymbolsForChart, formatSymbolWithParams, isArenaChartSymbol } from "lib/chart-utils";
 import { cn } from "lib/utils/class-name";
 import { useEffect, useRef } from "react";
 
 import { type IChartingLibraryWidget, type Timezone, widget } from "@/static/charting_library";
 
 import { BrowserNotSupported } from "./BrowserNotSupported";
-import { WIDGET_OPTIONS } from "./const";
+import type { ArenaOrMarketChart } from "./const";
+import { getWidgetOptions } from "./const";
 import type { ChartContainerProps } from "./types";
 import { useDatafeed } from "./use-datafeed";
 
@@ -35,9 +36,12 @@ const Chart = ({
 
   useEffect(() => {
     if (ref.current) {
+      const widgetSymbol = encodeSymbolsForChart(symbol, secondarySymbol);
+      const chartType: ArenaOrMarketChart = isArenaChartSymbol(widgetSymbol) ? "arena" : "market";
+
       tvWidget.current = new widget({
-        ...WIDGET_OPTIONS,
-        symbol: encodeSymbolsForChart(symbol, secondarySymbol),
+        ...getWidgetOptions(chartType),
+        symbol: widgetSymbol,
         datafeed,
         container: ref.current,
         timezone: (Intl.DateTimeFormat().resolvedOptions().timeZone ?? "Etc/UTC") as Timezone,

--- a/src/typescript/frontend/src/components/charts/const.ts
+++ b/src/typescript/frontend/src/components/charts/const.ts
@@ -43,11 +43,17 @@ export const MS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
 
 export const EXCHANGE_NAME = "emojicoin.fun";
 
-const DEFAULT_RESOLUTION_STRING = "15S" as ResolutionString;
+export type ArenaOrMarketChart = "arena" | "market";
+const DEFAULT_RESOLUTIONS = {
+  arena: "15S" as ResolutionString,
+  market: "60" as ResolutionString,
+};
 
-export const WIDGET_OPTIONS: Omit<ChartingLibraryWidgetOptions, "datafeed" | "container"> = {
+export const getWidgetOptions: (
+  chartType: ArenaOrMarketChart
+) => Omit<ChartingLibraryWidgetOptions, "datafeed" | "container"> = (chartType) => ({
   library_path: `${CDN_URL}/charting_library/`,
-  interval: DEFAULT_RESOLUTION_STRING,
+  interval: DEFAULT_RESOLUTIONS[chartType],
   theme: "Dark" as ThemeName,
   locale: "en" as LanguageCode,
   custom_css_url: `${CDN_URL}/charting_library_stylesheets/emojicoin-dot-fun.css`,
@@ -122,4 +128,4 @@ export const WIDGET_OPTIONS: Omit<ChartingLibraryWidgetOptions, "datafeed" | "co
       title: "All",
     },
   ],
-};
+});


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

- [x] Sets the default candlestick time resolution to 1h for regular market charts, `15s` for arena.

# Testing
Tested locally, will also test on the preview.
