### PR TITLE
feat(ECO-3207): Update match amount UI

### DIFF
--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
@@ -1,12 +1,13 @@
-import Big from "big.js";
 import { useEventStore } from "context/event-store-context/hooks";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useCurrentPosition } from "lib/hooks/positions/use-current-position";
 import { useEnterTransactionBuilder } from "lib/hooks/transaction-builders/use-enter-builder";
+import { Lock } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import Button from "@/components/button";
 import ButtonWithConnectWalletFallback from "@/components/header/wallet-button/ConnectWalletButton";
+import Popup from "@/components/popup";
 import { Switcher } from "@/components/switcher";
 import { useCurrentMeleeInfo } from "@/hooks/use-current-melee-info";
 import useRewardsRemaining from "@/hooks/use-rewards-remaining";
@@ -14,6 +15,7 @@ import { getEvents, type MarketStateModel } from "@/sdk/index";
 
 import { useArenaPhaseStore } from "../../phase/store";
 import { FormattedNominalNumber } from "../utils";
+import { MatchAmount } from "./MatchAmount";
 
 export default function EnterTabLockPhase({
   market,
@@ -23,18 +25,23 @@ export default function EnterTabLockPhase({
   amount: bigint;
 }) {
   const { position } = useCurrentPosition();
-  const [innerLock, setInnerLock] = useState<boolean>(false);
   const { account, submit } = useAptos();
   const { market0, market1 } = useCurrentMeleeInfo();
   const setPhase = useArenaPhaseStore((s) => s.setPhase);
   const setError = useArenaPhaseStore((s) => s.setError);
   const rewardsRemaining = useRewardsRemaining();
   const arenaInfo = useEventStore((s) => s.arenaInfoFromServer);
+  // Lock in by default if there are rewards remaining.
+  const [innerLock, setInnerLock] = useState<boolean>(position?.lockedIn || !!rewardsRemaining);
 
-  const lockedIn = useMemo(
-    () => innerLock || position?.lockedIn === true,
-    [innerLock, position?.lockedIn]
-  );
+  const { mustLockIn, lockedIn } = useMemo(() => {
+    const mustLockIn = position?.lockedIn === true;
+    const lockedIn = innerLock || mustLockIn;
+    return {
+      mustLockIn,
+      lockedIn,
+    };
+  }, [innerLock, position?.lockedIn]);
 
   const transactionBuilder = useEnterTransactionBuilder(
     amount,
@@ -44,51 +51,33 @@ export default function EnterTabLockPhase({
     market.market.marketAddress
   );
 
-  const matchAmount = useMemo(() => {
-    try {
-      if (!arenaInfo) {
-        return 0n;
-      }
-      if (!rewardsRemaining) {
-        return 0n;
-      }
-
-      const duration = Number(arenaInfo.duration / 1000n);
-      const remainingTime = duration - (new Date().getTime() - arenaInfo.startTime.getTime());
-      if (remainingTime < 0) return 0n;
-      const durationPercentage = Big(remainingTime / duration).mul(100);
-
-      let matchAmount = BigInt(
-        Big(amount.toString())
-          .mul(durationPercentage)
-          .div(100)
-          .mul(arenaInfo.maxMatchPercentage.toString())
-          .div(100)
-          .round(0)
-          .toString()
-      );
-      const eligibleMatchAmount = arenaInfo.maxMatchAmount - (position?.matchAmount ?? 0n);
-      if (matchAmount > eligibleMatchAmount) {
-        matchAmount = eligibleMatchAmount;
-      }
-      if (matchAmount > rewardsRemaining) {
-        matchAmount = rewardsRemaining;
-      }
-      return matchAmount;
-    } catch (_) {
-      return 0n;
-    }
-  }, [rewardsRemaining, arenaInfo, position?.matchAmount, amount]);
-
   return (
     <div className="flex flex-col gap-[2em] pt-14 m-auto items-center w-[100%]">
       <div className="flex justify-between w-[300px]">
         <div className="font-forma text-2xl uppercase text-white text-center">Lock in</div>
         <div className="flex gap-[1em] items-center">
           <div className="uppercase text-light-gray text-xl">
-            {lockedIn ? "Enabled" : "Disabled"}
+            {mustLockIn ? (
+              <Popup
+                content={
+                  <span>
+                    Your existing position is already locked
+                    <br />
+                    in, so you must remain locked in.
+                  </span>
+                }
+              >
+                <Lock className="m-auto ml-[3px] text-ec-blue" size={16} />
+              </Popup>
+            ) : lockedIn ? (
+              <span className="text-green">Enabled</span>
+            ) : (
+              <span className="text-pink">Disabled</span>
+            )}
           </div>
-          <Switcher checked={lockedIn} onChange={(v) => setInnerLock(v.target.checked)} />
+          {!mustLockIn && (
+            <Switcher checked={lockedIn} onChange={(v) => setInnerLock(v.target.checked)} />
+          )}
         </div>
       </div>
       <div className="max-w-[350px] w-[100%]">
@@ -98,10 +87,13 @@ export default function EnterTabLockPhase({
         </div>
         <div className="flex uppercase justify-between text-2xl text-light-gray py-[0.8em] mx-[0.8em] border-dashed border-b-[1px] border-light-gray ">
           <div>Match amount</div>
-          <FormattedNominalNumber
-            className={lockedIn && matchAmount ? "text-green" : ""}
-            value={lockedIn ? matchAmount : 0n}
-            suffix=" APT"
+          <MatchAmount
+            lockedIn={lockedIn}
+            mustLockIn={mustLockIn}
+            rewardsRemaining={rewardsRemaining}
+            arenaInfo={arenaInfo}
+            position={position}
+            amount={amount}
           />
         </div>
         <div className="pt-[2em] grid place-items-center">

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
@@ -72,7 +72,7 @@ export default function EnterTabLockPhase({
             ) : lockedIn ? (
               <span className="text-green">Enabled</span>
             ) : (
-              <span className="text-pink">Disabled</span>
+              <span className={rewardsRemaining ? "text-pink" : ""}>Disabled</span>
             )}
           </div>
           {!mustLockIn && (

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
@@ -61,9 +61,11 @@ export default function EnterTabLockPhase({
               <Popup
                 content={
                   <span>
-                    Your existing position is already locked
+                    You&apos;re already locked in.
                     <br />
-                    in, so you must remain locked in.
+                    Any additional deposits
+                    <br />
+                    must also be locked in.
                   </span>
                 }
               >

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
@@ -31,14 +31,14 @@ export default function EnterTabLockPhase({
   const rewardsRemaining = useRewardsRemaining();
   const arenaInfo = useEventStore((s) => s.arenaInfoFromServer);
 
-  const lockedInToggle = useMemo(
+  const lockedIn = useMemo(
     () => innerLock || position?.lockedIn === true,
     [innerLock, position?.lockedIn]
   );
 
   const transactionBuilder = useEnterTransactionBuilder(
     amount,
-    lockedInToggle,
+    lockedIn,
     market0?.market.marketAddress,
     market1?.market.marketAddress,
     market.market.marketAddress
@@ -86,9 +86,9 @@ export default function EnterTabLockPhase({
         <div className="font-forma text-2xl uppercase text-white text-center">Lock in</div>
         <div className="flex gap-[1em] items-center">
           <div className="uppercase text-light-gray text-xl">
-            {lockedInToggle ? "Enabled" : "Disabled"}
+            {lockedIn ? "Enabled" : "Disabled"}
           </div>
-          <Switcher checked={lockedInToggle} onChange={(v) => setInnerLock(v.target.checked)} />
+          <Switcher checked={lockedIn} onChange={(v) => setInnerLock(v.target.checked)} />
         </div>
       </div>
       <div className="max-w-[350px] w-[100%]">
@@ -98,7 +98,11 @@ export default function EnterTabLockPhase({
         </div>
         <div className="flex uppercase justify-between text-2xl text-light-gray py-[0.8em] mx-[0.8em] border-dashed border-b-[1px] border-light-gray ">
           <div>Match amount</div>
-          <FormattedNominalNumber value={lockedInToggle ? matchAmount : 0n} suffix=" APT" />
+          <FormattedNominalNumber
+            className={lockedIn && matchAmount ? "text-green" : ""}
+            value={lockedIn ? matchAmount : 0n}
+            suffix=" APT"
+          />
         </div>
         <div className="pt-[2em] grid place-items-center">
           <ButtonWithConnectWalletFallback>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/MatchAmount.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/MatchAmount.tsx
@@ -43,7 +43,10 @@ export function MatchAmount({
     >
       <FormattedNominalNumber
         className={
-          lockedIn && matchAmount ? "text-green" : !lockedIn && !mustLockIn ? "text-error" : ""
+          // If they're locked in and there's a match amount, make it green.
+          // Otherwise, if they don't have to lock in and there's a match amount being missed out on, show it as pink.
+          // Otherwise, don't color it at all.
+          lockedIn && matchAmount ? "text-green" : !mustLockIn && matchAmount ? "text-error" : ""
         }
         value={lockedIn ? matchAmount : 0n}
         suffix=" APT"

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/MatchAmount.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/MatchAmount.tsx
@@ -1,0 +1,107 @@
+import Big from "big.js";
+import { motion } from "framer-motion";
+import type { CurrentUserPosition } from "lib/hooks/positions/use-current-position";
+import { formatNumberString } from "lib/utils/format-number-string";
+import { useMemo, useState } from "react";
+import { useInterval } from "react-use";
+
+import { type ArenaInfoModel, minBigInt } from "@/sdk/index";
+
+import { FormattedNominalNumber } from "../utils";
+
+const FORMATTED_DECIMALS = 4;
+
+export function MatchAmount({
+  lockedIn,
+  mustLockIn,
+  rewardsRemaining,
+  arenaInfo,
+  position,
+  amount,
+}: {
+  lockedIn: boolean;
+  mustLockIn: boolean;
+  rewardsRemaining: bigint;
+  arenaInfo: ArenaInfoModel | undefined;
+  position: CurrentUserPosition | null;
+  amount: bigint;
+}) {
+  const { matchAmount, formattedAmount } = useLiveMatchAmount(
+    rewardsRemaining,
+    arenaInfo,
+    position,
+    amount
+  );
+
+  return (
+    <motion.div
+      key={`live-match-amount-${formattedAmount}`}
+      animate={{
+        scale: lockedIn ? [1.15, 1] : 1,
+        filter: lockedIn ? ["brightness(1.15)", "brightness(1)"] : "",
+      }}
+    >
+      <FormattedNominalNumber
+        className={
+          lockedIn && matchAmount ? "text-green" : !lockedIn && !mustLockIn ? "text-error" : ""
+        }
+        value={lockedIn ? matchAmount : 0n}
+        suffix=" APT"
+        decimals={FORMATTED_DECIMALS}
+      />
+    </motion.div>
+  );
+}
+
+const DEFAULT_AMOUNT = {
+  matchAmount: 0n,
+  formattedAmount: 0n,
+};
+
+/**
+ * Calculates the match amount based on the input and available rewards, updating on an interval.
+ */
+function useLiveMatchAmount(
+  rewardsRemaining: bigint,
+  arenaInfo: ArenaInfoModel | undefined,
+  position: CurrentUserPosition | null,
+  amount: bigint
+) {
+  const [now, setNow] = useState(Date.now());
+  useInterval(() => setNow(Date.now()), 1000);
+
+  return useMemo(() => {
+    if (!arenaInfo || !rewardsRemaining) return DEFAULT_AMOUNT;
+    try {
+      const duration = Number(arenaInfo.duration / 1000n);
+      const elapsed = now - arenaInfo.startTime.getTime();
+      const remainingTime = duration - elapsed;
+      if (remainingTime < 0) return DEFAULT_AMOUNT;
+      const durationPercentage = Big(remainingTime / duration).mul(100);
+
+      const rawMatchAmount = BigInt(
+        Big(amount.toString())
+          .mul(durationPercentage)
+          .div(100)
+          .mul(arenaInfo.maxMatchPercentage.toString())
+          .div(100)
+          .round(0)
+          .toString()
+      );
+      const eligibleMatchAmount = arenaInfo.maxMatchAmount - (position?.matchAmount ?? 0n);
+      const finalMatchAmount = minBigInt(rawMatchAmount, eligibleMatchAmount, rewardsRemaining);
+      const formattedAmount = formatNumberString({
+        value: finalMatchAmount,
+        decimals: FORMATTED_DECIMALS,
+        nominalize: true,
+      });
+
+      return {
+        matchAmount: finalMatchAmount,
+        formattedAmount,
+      };
+    } catch (_) {
+      return DEFAULT_AMOUNT;
+    }
+  }, [rewardsRemaining, arenaInfo, position?.matchAmount, amount, now]);
+}

--- a/src/typescript/frontend/src/components/pages/arena/tabs/utils.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/utils.tsx
@@ -13,11 +13,12 @@ export const FormattedNominalNumber = (props: {
   prefix?: string;
   suffix?: string;
   scramble?: boolean;
+  decimals?: number;
 }) => (
   <FormattedNumber
     className={props.className}
     value={props.value}
-    decimals={2}
+    decimals={props.decimals ?? 2}
     nominalize
     prefix={props.prefix}
     suffix={props.suffix}


### PR DESCRIPTION
# Description

- [x] Highlight match amount when it's > 0
- [x] Indicate to users why they must remain locked in
- [x] Remove toggle if they must remain locked in
- [x] Make sure it still works even if they're not locked in
- [x] Animate the amount decrement every second
- [x] Update match amount color to pink when they're not locked in  and there's a match amount to be had
- [x] Update "disabled" to pink when there's rewards remaining
- [x] Update "enabled" to green whenever it's on

![image](https://github.com/user-attachments/assets/5f27de4a-7a6a-4ac1-a609-d2ec31cb3dd5)

https://github.com/user-attachments/assets/d5972382-df42-4be2-81b2-6f0159b6524f
