### PR TITLE
fix(ECO-3209): Fix arena candlesticks

### DIFF
--- a/src/typescript/frontend/src/lib/store/arena/event/utils.ts
+++ b/src/typescript/frontend/src/lib/store/arena/event/utils.ts
@@ -8,7 +8,6 @@ import {
   isArenaMeleeModel,
   isArenaSwapModel,
 } from "@/sdk/types/arena-types";
-import { toNominal } from "@/sdk/utils";
 
 import type { LatestBar } from "../../event/candlestick-bars";
 import { getCandlestickModelNonce, toBarWithNonce } from "../../event/candlestick-bars";

--- a/src/typescript/frontend/src/lib/store/event/event-store.ts
+++ b/src/typescript/frontend/src/lib/store/event/event-store.ts
@@ -24,7 +24,6 @@ import {
   isArenaSwapModel,
 } from "@/sdk/types/arena-types";
 import { compareBigInt, DEBUG_ASSERT, extractFilter } from "@/sdk/utils";
-import { Bar } from "@/static/charting_library/datafeed-api";
 
 import {
   ensureMeleeInStore,
@@ -38,7 +37,6 @@ import {
   updateLatestBarFromDatafeed,
 } from "../arena/event/utils";
 import { createWebSocketClientStore, type WebSocketClientStore } from "../websocket/store";
-import type { LatestBar } from "./candlestick-bars";
 import {
   cleanReadLocalStorage,
   clearLocalStorage,

--- a/src/typescript/frontend/src/lib/store/event/types.ts
+++ b/src/typescript/frontend/src/lib/store/event/types.ts
@@ -13,7 +13,7 @@ import type { SubscribeBarsCallback } from "@/static/charting_library/datafeed-a
 
 import type { ArenaActions, ArenaState } from "../arena/event/store";
 import type { ClientActions, ClientState } from "../websocket/store";
-import type { LatestBar } from "./candlestick-bars";
+import type { BarWithNonce, LatestBar } from "./candlestick-bars";
 
 // Aliased to avoid repeating the type names over and over.
 type Swap = DatabaseModels["swap_events"];
@@ -79,6 +79,11 @@ type EventActions = {
   loadMarketStateFromServer: (states: DatabaseModels["market_state"][]) => void;
   loadEventsFromServer: (events: BrokerEventModels[]) => void;
   pushEventsFromClient: (event: BrokerEventModels[], pushToLocalStorage?: boolean) => void;
+  maybeUpdateMeleeLatestBar: (
+    bar: BarWithNonce | undefined,
+    period: AnyPeriod,
+    meleeID: bigint
+  ) => void;
   setLatestBars: ({ marketMetadata, latestBars }: SetLatestBarsArgs) => void;
   subscribeToPeriod: ({ symbol, period, cb }: PeriodSubscription) => void;
   unsubscribeFromPeriod: ({ symbol, period }: Omit<PeriodSubscription, "cb">) => void;


### PR DESCRIPTION
# Description

- [x] This fixes arena candlesticks to properly use the previous bar's close as the subsequent bar's open.
- [x] It also fixes the incorrect summing of volume and incorrectly utilizing open/close prices.

# Testing
- [x] I tested it extensively on testnet and made sure it looked good/behaved exactly as expected, even when switching to/from different time periods. It now works great.