### PR TITLE
feat(ECO-2323): Add tabs UX/UI to the emojicoin page

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -107,7 +107,7 @@
     "check:ci": "tsc -p tests/tsconfig-ci.json",
     "check:tests": "tsc -p tests/tsconfig.json",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
-    "dev": "NODE_OPTIONS='--inspect' next dev --turbo -H 0.0.0.0 --port 3001",
+    "dev": "NODE_OPTIONS='--inspect' next dev --turbo --port 3001",
     "format": "pnpm _format --list-different --write",
     "format:check": "pnpm _format --check",
     "lint": "eslint --max-warnings=0 -c .eslintrc.js --ext .js,.jsx,.ts,.tsx .",

--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -107,7 +107,7 @@
     "check:ci": "tsc -p tests/tsconfig-ci.json",
     "check:tests": "tsc -p tests/tsconfig.json",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
-    "dev": "NODE_OPTIONS='--inspect' next dev --turbo --port 3001",
+    "dev": "NODE_OPTIONS='--inspect' next dev --turbo -H 0.0.0.0 --port 3001",
     "format": "pnpm _format --list-different --write",
     "format:check": "pnpm _format --check",
     "lint": "eslint --max-warnings=0 -c .eslintrc.js --ext .js,.jsx,.ts,.tsx .",

--- a/src/typescript/frontend/src/components/inputs/search-bar.tsx
+++ b/src/typescript/frontend/src/components/inputs/search-bar.tsx
@@ -36,14 +36,14 @@ const Border = styled(Flex)`
   }
 `;
 
-const SearchBar = () => {
+const SearchBar = ({ className }: { className?: string }) => {
   const setMode = useEmojiPicker((state) => state.setMode);
   useEffect(() => {
     setMode("search");
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
   return (
-    <Container>
+    <Container className={className}>
       <Border>
         <div
           style={{

--- a/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
@@ -3,6 +3,7 @@
 import type { ClassValue } from "clsx";
 import { Countdown } from "components/Countdown";
 import { useEventStore } from "context/event-store-context/hooks";
+import { cn } from "lib/utils/class-name";
 import React, { useEffect } from "react";
 import { createPortal } from "react-dom";
 
@@ -21,27 +22,28 @@ const Desktop = React.memo((props: ArenaProps) => {
   const { arenaInfo, market0, market1 } = props;
   return (
     <div
-      className="grid h-[90%] w-full p-[2em] gap-[2em]"
+      className="grid p-[2em] gap-[2em]"
       style={{
-        gridTemplateRows: "1fr minmax(0, 3.5fr)",
         gridTemplateColumns: "1fr 0.65fr 0.85fr 1fr",
       }}
     >
       <Box className="grid place-items-center">
         <EmojiTitle />
       </Box>
-      <Box className="col-start-2 col-end-4 text-5xl lg:text-6xl xl:text-7xl grid place-items-center">
+      <Box className="col-span-2 text-5xl lg:text-6xl xl:text-7xl grid place-items-center">
         <Countdown startTime={arenaInfo.startTime} duration={arenaInfo.duration / 1000n / 1000n} />
       </Box>
       <RewardsRemainingBox />
-      <Box className={chartBoxClassName}>
+      {/* These should have a fixed height. Otherwise they get smaller as the screen height decreases
+      which creates a vertical scroll on some screens because the content doesn't fit anymore.*/}
+      <Box className={cn(chartBoxClassName, "h-[450px]")}>
         <ChartContainer
           symbol={market0.market.symbolData.symbol}
           secondarySymbol={market1.market.symbolData.symbol}
           className="w-full h-full"
         />
       </Box>
-      <Box className="col-start-3 col-end-5 h-[100%]">
+      <Box className="col-start-3 col-end-5 h-[450px]">
         <TabContainer {...props} />
       </Box>
     </div>

--- a/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/ArenaClient.tsx
@@ -22,8 +22,9 @@ const Desktop = React.memo((props: ArenaProps) => {
   const { arenaInfo, market0, market1 } = props;
   return (
     <div
-      className="grid p-[2em] gap-[2em]"
+      className="grid h-[90%] w-full p-[2em] gap-[2em]"
       style={{
+        gridTemplateRows: "1fr minmax(0, 3.5fr)",
         gridTemplateColumns: "1fr 0.65fr 0.85fr 1fr",
       }}
     >
@@ -34,16 +35,14 @@ const Desktop = React.memo((props: ArenaProps) => {
         <Countdown startTime={arenaInfo.startTime} duration={arenaInfo.duration / 1000n / 1000n} />
       </Box>
       <RewardsRemainingBox />
-      {/* These should have a fixed height. Otherwise they get smaller as the screen height decreases
-      which creates a vertical scroll on some screens because the content doesn't fit anymore.*/}
-      <Box className={cn(chartBoxClassName, "h-[450px]")}>
+      <Box className={cn(chartBoxClassName, "min-h-[440px]")}>
         <ChartContainer
           symbol={market0.market.symbolData.symbol}
           secondarySymbol={market1.market.symbolData.symbol}
           className="w-full h-full"
         />
       </Box>
-      <Box className="col-start-3 col-end-5 h-[450px]">
+      <Box className="col-start-3 col-end-5 min-h-[440px]">
         <TabContainer {...props} />
       </Box>
     </div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/ArenaLoading.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/ArenaLoading.tsx
@@ -9,7 +9,7 @@ export const ArenaLoading = ({ text = "Loading" }: { text?: string }) => {
   const [position, setPosition] = useState(0);
 
   useEffect(() => {
-    const interval = setInterval(() => setPosition((prev) => (prev + 1) % 4), 700);
+    const interval = setInterval(() => setPosition((prev) => (prev + 1) % 4), 2000 / 3);
     return () => clearInterval(interval);
   }, []);
   return (

--- a/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
@@ -61,8 +61,8 @@ const INFO = [
 
 export default function InfoTab() {
   return (
-    <div className="w-[100%] h-[100%]">
-      <div className="w-[100%] p-[1em] flex flex-col gap-[2em] max-w-[80ch] m-auto overflow-scroll">
+    <div className="grow">
+      <div className="p-[1em] flex flex-col max-w-[80ch] m-auto">
         {INFO.map((i, index) => (
           <div key={`info-p-${index}`} className="flex flex-col gap-[1em]">
             <div className="text-3xl uppercase text-white">{i.title}</div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
@@ -98,8 +98,8 @@ function Container({
 }) {
   return (
     <div className="relative flex flex-col grow py-4">
-      <div className="px-2 w-[100%] text-white flex items-center *:grow *:basis-0">
-        {(phase === "amount" || phase === "lock") && (
+      <div className="px-2 w-[100%] text-white flex items-center *:grow *:basis-0 h-[20px]">
+        {phase === "amount" || phase === "lock" ? (
           <div>
             <Button
               scale="lg"
@@ -113,9 +113,13 @@ function Container({
               Back
             </Button>
           </div>
+        ) : (
+          <div />
         )}
-        <div>
-          <ProgressBar length={3} position={progress} />
+        <div className="flex flex-col items-center">
+          <div className="max-w-[160px]">
+            <ProgressBar length={3} position={progress} />
+          </div>
         </div>
         <div />
       </div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
@@ -117,7 +117,7 @@ function Container({
           <div />
         )}
         <div className="flex flex-col items-center">
-          <div className="max-w-[160px]">
+          <div className="max-w-[250px]">
             <ProgressBar length={3} position={progress} />
           </div>
         </div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
@@ -1,4 +1,5 @@
 import Loading from "components/loading";
+import { useAptos } from "context/wallet-context/AptosContextProvider";
 import type { CurrentUserPosition } from "lib/hooks/positions/use-current-position";
 import { useCurrentPosition } from "lib/hooks/positions/use-current-position";
 import type { PropsWithChildren } from "react";
@@ -8,6 +9,7 @@ import Button from "@/components/button";
 import ProgressBar from "@/components/ProgressBar";
 
 import { useArenaPhaseStore, useSelectedMarket } from "../../phase/store";
+import { ArenaLoading } from "../ArenaLoading";
 import EnterTabAmountPhase from "./EnterTabAmountPhase";
 import EnterTabLockPhase from "./EnterTabLockPhase";
 import EnterTabPickPhase from "./EnterTabPickPhase";
@@ -23,6 +25,17 @@ export default function EnterTab() {
   const amount = useArenaPhaseStore((s) => s.amount);
 
   const { position, isLoading } = useCurrentPosition();
+  const { status } = useAptos();
+  const [showLoading, setShowLoading] = React.useState(false);
+
+  useEffect(() => {
+    if (status === "pending") {
+      setShowLoading(true);
+      setTimeout(() => {
+        setShowLoading(false);
+      }, 2300);
+    }
+  }, [status]);
 
   useEffect(() => {
     const { open } = position ?? {};
@@ -35,6 +48,8 @@ export default function EnterTab() {
   }, [phase, position, setPhase]);
 
   if (isLoading) return <Loading />;
+
+  if (showLoading || status === "pending") return <ArenaLoading />;
 
   if (phase === "summary") {
     if (!position) return <Loading />;

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
@@ -1,5 +1,4 @@
 import Loading from "components/loading";
-import { useAptos } from "context/wallet-context/AptosContextProvider";
 import type { CurrentUserPosition } from "lib/hooks/positions/use-current-position";
 import { useCurrentPosition } from "lib/hooks/positions/use-current-position";
 import type { PropsWithChildren } from "react";
@@ -9,7 +8,6 @@ import Button from "@/components/button";
 import ProgressBar from "@/components/ProgressBar";
 
 import { useArenaPhaseStore, useSelectedMarket } from "../../phase/store";
-import { ArenaLoading } from "../ArenaLoading";
 import EnterTabAmountPhase from "./EnterTabAmountPhase";
 import EnterTabLockPhase from "./EnterTabLockPhase";
 import EnterTabPickPhase from "./EnterTabPickPhase";
@@ -23,7 +21,6 @@ export default function EnterTab() {
   const setMarket = useArenaPhaseStore((s) => s.setMarket);
   const phase = useArenaPhaseStore((s) => s.phase);
   const amount = useArenaPhaseStore((s) => s.amount);
-  const { status } = useAptos();
 
   const { position, isLoading } = useCurrentPosition();
 
@@ -38,8 +35,6 @@ export default function EnterTab() {
   }, [phase, position, setPhase]);
 
   if (isLoading) return <Loading />;
-
-  if (status === "pending") return <ArenaLoading />;
 
   if (phase === "summary") {
     if (!position) return <Loading />;
@@ -97,7 +92,7 @@ function Container({
   position?: CurrentUserPosition | null;
 }) {
   return (
-    <div className="relative flex flex-col grow py-4">
+    <div className="relative flex flex-col grow pt-4 pb-7">
       <div className="px-2 w-[100%] text-white flex items-center *:grow *:basis-0 h-[20px]">
         {phase === "amount" || phase === "lock" ? (
           <div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
@@ -1,4 +1,5 @@
 import Loading from "components/loading";
+import { useAptos } from "context/wallet-context/AptosContextProvider";
 import type { CurrentUserPosition } from "lib/hooks/positions/use-current-position";
 import { useCurrentPosition } from "lib/hooks/positions/use-current-position";
 import type { PropsWithChildren } from "react";
@@ -8,6 +9,7 @@ import Button from "@/components/button";
 import ProgressBar from "@/components/ProgressBar";
 
 import { useArenaPhaseStore, useSelectedMarket } from "../../phase/store";
+import { ArenaLoading } from "../ArenaLoading";
 import EnterTabAmountPhase from "./EnterTabAmountPhase";
 import EnterTabLockPhase from "./EnterTabLockPhase";
 import EnterTabPickPhase from "./EnterTabPickPhase";
@@ -21,6 +23,7 @@ export default function EnterTab() {
   const setMarket = useArenaPhaseStore((s) => s.setMarket);
   const phase = useArenaPhaseStore((s) => s.phase);
   const amount = useArenaPhaseStore((s) => s.amount);
+  const { status } = useAptos();
 
   const { position, isLoading } = useCurrentPosition();
 
@@ -35,6 +38,8 @@ export default function EnterTab() {
   }, [phase, position, setPhase]);
 
   if (isLoading) return <Loading />;
+
+  if (status === "pending") return <ArenaLoading />;
 
   if (phase === "summary") {
     if (!position) return <Loading />;
@@ -92,13 +97,10 @@ function Container({
   position?: CurrentUserPosition | null;
 }) {
   return (
-    <div className="relative flex flex-col h-[100%] gap-[3em]">
-      <div className="absolute left-0 w-[100%] text-white flex">
-        <div className="m-auto w-[33%] pt-[2em]">
-          <ProgressBar length={3} position={progress} />
-        </div>
+    <div className="relative flex flex-col grow py-4">
+      <div className="px-2 w-[100%] text-white flex items-center *:grow *:basis-0">
         {(phase === "amount" || phase === "lock") && (
-          <div className="absolute top-[1.5em] left-[1em]">
+          <div>
             <Button
               scale="lg"
               onClick={() => {
@@ -112,6 +114,10 @@ function Container({
             </Button>
           </div>
         )}
+        <div>
+          <ProgressBar length={3} position={progress} />
+        </div>
+        <div />
       </div>
       {children}
     </div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabAmountPhase.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabAmountPhase.tsx
@@ -22,24 +22,26 @@ export default function EnterTabAmountPhase({ market }: { market: MarketStateMod
   const setPhase = useArenaPhaseStore((s) => s.setPhase);
   const [innerAmount, setInnerAmount] = useState<bigint>(0n);
   return (
-    <div className="flex flex-col grow justify-center pt-6 items-center gap-[1rem]">
-      <div className="text-6xl">
-        <GlowingEmoji emojis={market.market.symbolEmojis.join("")} />
-      </div>
-      <div className="font-forma text-xl uppercase text-white">Deposit amount</div>
-      <InnerWrapper>
-        <div className="flex flex-col">
-          <div className={grayLabel}>Amount</div>
-          <InputNumeric
-            className={inputAndOutputStyles + " bg-transparent leading-[32px]"}
-            value={innerAmount}
-            onUserInput={(v) => setInnerAmount(v)}
-            onSubmit={() => setAmount(innerAmount)}
-            decimals={8}
-          />
+    <div className="flex flex-col grow justify-center items-center">
+      <div className="w-full flex flex-col grow justify-center items-center gap-[1rem]">
+        <div className="text-6xl">
+          <GlowingEmoji emojis={market.market.symbolEmojis.join("")} />
         </div>
-        <AptosInputLabel />
-      </InnerWrapper>
+        <div className="font-forma text-xl uppercase text-white">Deposit amount</div>
+        <div className="flex justify-between border border-solid border-dark-gray radii-xs px-[18px] py-[7px] items-center h-[55px] md:items-stretch max-w-[300px]">
+          <div className="flex flex-col">
+            <div className={grayLabel}>Amount</div>
+            <InputNumeric
+              className={inputAndOutputStyles + " bg-transparent leading-[32px]"}
+              value={innerAmount}
+              onUserInput={(v) => setInnerAmount(v)}
+              onSubmit={() => setAmount(innerAmount)}
+              decimals={8}
+            />
+          </div>
+          <AptosInputLabel />
+        </div>
+      </div>
       <Button
         scale="lg"
         onClick={() => {
@@ -50,19 +52,6 @@ export default function EnterTabAmountPhase({ market }: { market: MarketStateMod
       >
         Next
       </Button>
-    </div>
-  );
-}
-
-function InnerWrapper({ children }: React.PropsWithChildren) {
-  return (
-    <div
-      className={
-        `flex justify-between border border-solid border-dark-gray ` +
-        `radii-xs px-[18px] py-[7px] items-center h-[55px] md:items-stretch max-w-[300px]`
-      }
-    >
-      {children}
     </div>
   );
 }

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabLockPhase.tsx
@@ -52,75 +52,75 @@ export default function EnterTabLockPhase({
   );
 
   return (
-    <div className="flex flex-col gap-[2em] pt-14 m-auto items-center w-[100%]">
-      <div className="flex justify-between w-[300px]">
-        <div className="font-forma text-2xl uppercase text-white text-center">Lock in</div>
-        <div className="flex gap-[1em] items-center">
-          <div className="uppercase text-light-gray text-xl">
-            {mustLockIn ? (
-              <Popup
-                content={
-                  <span>
-                    You&apos;re already locked in.
-                    <br />
-                    Any additional deposits
-                    <br />
-                    must also be locked in.
-                  </span>
-                }
-              >
-                <Lock className="m-auto ml-[3px] text-ec-blue" size={16} />
-              </Popup>
-            ) : lockedIn ? (
-              <span className="text-green">Enabled</span>
-            ) : (
-              <span className={rewardsRemaining ? "text-pink" : ""}>Disabled</span>
+    <div className="flex flex-col grow items-center">
+      <div className="flex flex-col grow justify-center">
+        <div className="flex justify-between w-[300px]">
+          <div className="font-forma text-2xl uppercase text-white text-center">Lock in</div>
+          <div className="flex gap-[1em] items-center">
+            <div className="uppercase text-light-gray text-xl">
+              {mustLockIn ? (
+                <Popup
+                  content={
+                    <span>
+                      You&apos;re already locked in.
+                      <br />
+                      Any additional deposits
+                      <br />
+                      must also be locked in.
+                    </span>
+                  }
+                >
+                  <Lock className="m-auto ml-[3px] text-ec-blue" size={16} />
+                </Popup>
+              ) : lockedIn ? (
+                <span className="text-green">Enabled</span>
+              ) : (
+                <span className={rewardsRemaining ? "text-pink" : ""}>Disabled</span>
+              )}
+            </div>
+            {!mustLockIn && (
+              <Switcher checked={lockedIn} onChange={(v) => setInnerLock(v.target.checked)} />
             )}
           </div>
-          {!mustLockIn && (
-            <Switcher checked={lockedIn} onChange={(v) => setInnerLock(v.target.checked)} />
-          )}
+        </div>
+        <div className="max-w-[350px] w-[100%]">
+          <div className="flex justify-between p-[0.8em] rounded-[3px] bg-ec-blue text-2xl text-black uppercase">
+            <div>Deposit amount</div>
+            <FormattedNominalNumber value={amount} suffix=" APT" />
+          </div>
+          <div className="flex uppercase justify-between text-2xl text-light-gray py-[0.8em] mx-[0.8em] border-dashed border-b-[1px] border-light-gray ">
+            <div>Match amount</div>
+            <MatchAmount
+              lockedIn={lockedIn}
+              mustLockIn={mustLockIn}
+              rewardsRemaining={rewardsRemaining}
+              arenaInfo={arenaInfo}
+              position={position}
+              amount={amount}
+            />
+          </div>
         </div>
       </div>
-      <div className="max-w-[350px] w-[100%]">
-        <div className="flex justify-between p-[0.8em] rounded-[3px] bg-ec-blue text-2xl text-black uppercase">
-          <div>Deposit amount</div>
-          <FormattedNominalNumber value={amount} suffix=" APT" />
-        </div>
-        <div className="flex uppercase justify-between text-2xl text-light-gray py-[0.8em] mx-[0.8em] border-dashed border-b-[1px] border-light-gray ">
-          <div>Match amount</div>
-          <MatchAmount
-            lockedIn={lockedIn}
-            mustLockIn={mustLockIn}
-            rewardsRemaining={rewardsRemaining}
-            arenaInfo={arenaInfo}
-            position={position}
-            amount={amount}
-          />
-        </div>
-        <div className="pt-[2em] grid place-items-center">
-          <ButtonWithConnectWalletFallback>
-            <Button
-              scale="lg"
-              onClick={() => {
-                if (!account) return;
-                submit(transactionBuilder).then((res) => {
-                  if (getEvents(res?.response).arenaMeleeEvents.length) {
-                    setPhase("pick");
-                  } else {
-                    setPhase("summary");
-                  }
-                  if (!res || res?.error) {
-                    setError(true);
-                  }
-                });
-              }}
-            >
-              Enter
-            </Button>
-          </ButtonWithConnectWalletFallback>
-        </div>
-      </div>
+      <ButtonWithConnectWalletFallback>
+        <Button
+          scale="lg"
+          onClick={() => {
+            if (!account) return;
+            submit(transactionBuilder).then((res) => {
+              if (getEvents(res?.response).arenaMeleeEvents.length) {
+                setPhase("pick");
+              } else {
+                setPhase("summary");
+              }
+              if (!res || res?.error) {
+                setError(true);
+              }
+            });
+          }}
+        >
+          Enter
+        </Button>
+      </ButtonWithConnectWalletFallback>
     </div>
   );
 }

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabPickPhase.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTabPickPhase.tsx
@@ -12,7 +12,7 @@ export default function EnterTabPickPhase() {
   const error = useArenaPhaseStore((s) => s.error);
 
   return (
-    <div className="relative grid gap-[3em] place-items-center h-[100%] w-[100%]">
+    <div className="relative flex flex-col grow gap-[3em] justify-center place-items-center w-[100%]">
       {error && (
         <BlurModal close={() => setError(false)}>
           <div className="flex flex-col gap-[3em] max-w-[58ch]">

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/EnterTabSummary.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/EnterTabSummary.tsx
@@ -63,7 +63,7 @@ export default function EnterTabSummary({
   }, [account, swapTransactionBuilder, swap, submit]);
 
   return (
-    <div className="relative h-[100%]">
+    <div className="flex flex-col grow py-4">
       {isTappingOut && (
         <TapOutModal position={position} onTapOut={onTapOut} setIsTappingOut={setIsTappingOut} />
       )}
@@ -75,13 +75,16 @@ export default function EnterTabSummary({
           loading={isLoading}
         />
       )}
-      <Summary
-        position={position}
-        onTapOut={onTapOut}
-        setIsTappingOut={setIsTappingOut}
-        setIsSwapping={setIsSwapping}
-        topOff={topOff}
-      />
+
+      {!isTappingOut && !isSwapping && (
+        <Summary
+          position={position}
+          onTapOut={onTapOut}
+          setIsTappingOut={setIsTappingOut}
+          setIsSwapping={setIsSwapping}
+          topOff={topOff}
+        />
+      )}
     </div>
   );
 }

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/EnterTabSummary.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/EnterTabSummary.tsx
@@ -63,7 +63,7 @@ export default function EnterTabSummary({
   }, [account, swapTransactionBuilder, swap, submit]);
 
   return (
-    <div className="flex flex-col grow py-4">
+    <div className="flex flex-col grow pt-4 pb-7">
       {isTappingOut && (
         <TapOutModal position={position} onTapOut={onTapOut} setIsTappingOut={setIsTappingOut} />
       )}

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/Summary.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/Summary.tsx
@@ -34,7 +34,7 @@ export default function Summary({
   const { pnl } = useTradingStats();
 
   return (
-    <div className="flex flex-col justify-center grow items-center h-[100%] py-4">
+    <div className="flex flex-col justify-center grow items-center">
       <div className="flex flex-col justify-center gap-[1em] grow items-center">
         {/* The glowing emoji header */}
         <GlowingEmoji className="text-7xl mt-[2em]" emojis={position.currentSymbol} />

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/SwapModal.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/SwapModal.tsx
@@ -3,11 +3,11 @@ import { GlowingEmoji } from "utils/emoji";
 
 import Button from "@/components/button";
 import ButtonWithConnectWalletFallback from "@/components/header/wallet-button/ConnectWalletButton";
+import { CloseIcon } from "@/components/svg";
 import { useCurrentMeleeInfo } from "@/hooks/use-current-melee-info";
 
 import { marketTernary } from "../../../utils";
 import { AnimatedLoadingBoxesWithFallback } from "../../utils";
-import BlurModal from "../BlurModal";
 import { EscrowAptValue } from "./utils";
 
 /**
@@ -27,8 +27,13 @@ export default function SwapModal({
   const { market0, market1, symbol0, symbol1 } = useCurrentMeleeInfo();
 
   return (
-    <BlurModal close={() => setIsSwapping(false)}>
-      <div className="flex flex-col justify-between items-center h-[100%] py-[3em] mt-[1em]">
+    <div className="flex flex-col justify-around items-center grow relative">
+      <CloseIcon
+        onClick={() => setIsSwapping(false)}
+        className="absolute right-[.5em] top-[.5em] p-[.5em] h-[2.5em] w-[2.5em] cursor-pointer"
+        color="econiaBlue"
+      />
+      <div className="flex flex-col items-center justify-center gap-8 grow">
         {symbol0 && symbol1 ? (
           <GlowingEmoji className="text-6xl" emojis={marketTernary(position, symbol1, symbol0)} />
         ) : (
@@ -43,12 +48,12 @@ export default function SwapModal({
             loading={loading}
           />
         </div>
-        <ButtonWithConnectWalletFallback>
-          <Button scale="lg" onClick={onSwap}>
-            Swap
-          </Button>
-        </ButtonWithConnectWalletFallback>
       </div>
-    </BlurModal>
+      <ButtonWithConnectWalletFallback>
+        <Button scale="lg" onClick={onSwap}>
+          Swap
+        </Button>
+      </ButtonWithConnectWalletFallback>
+    </div>
   );
 }

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/TapOutModal.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/TapOutModal.tsx
@@ -27,7 +27,7 @@ export default function TapOutModal({
         className="absolute right-[.5em] top-[.5em] p-[.5em] h-[2.5em] w-[2.5em] cursor-pointer"
         color="econiaBlue"
       />
-      <div className="flex flex-col gap-[1.5em] justify-center uppercase max-w-[58ch] grow">
+      <div className="flex flex-col gap-[1.3em] justify-center uppercase max-w-[58ch] grow">
         <div className="text-4xl text-white text-center">Are you sure you want to tap out?</div>
         <div className="flex flex-col gap-[1.5em]">
           <div className="font-forma text-light-gray leading-6">

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/TapOutModal.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/TapOutModal.tsx
@@ -21,15 +21,15 @@ export default function TapOutModal({
     : undefined;
 
   return (
-    <div className="flex flex-col items-center grow pt-10 relative">
+    <div className="flex flex-col items-center grow relative gap-4 px-4">
       <CloseIcon
         onClick={() => setIsTappingOut(false)}
         className="absolute right-[.5em] top-[.5em] p-[.5em] h-[2.5em] w-[2.5em] cursor-pointer"
         color="econiaBlue"
       />
-      <div className="flex flex-col gap-[1.5em] uppercase max-w-[58ch] grow">
+      <div className="flex flex-col gap-[1.5em] justify-center uppercase max-w-[58ch] grow">
         <div className="text-4xl text-white text-center">Are you sure you want to tap out?</div>
-        <div className="flex flex-col gap-[2em]">
+        <div className="flex flex-col gap-[1.5em]">
           <div className="font-forma text-light-gray leading-6">
             You have been matched a total of{" "}
             <span className="text-warning">{(matchNumberText ?? "?") + " APT"}</span> since your

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/TapOutModal.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/TapOutModal.tsx
@@ -1,8 +1,7 @@
 import Button from "@/components/button";
 import ButtonWithConnectWalletFallback from "@/components/header/wallet-button/ConnectWalletButton";
+import { CloseIcon } from "@/components/svg";
 import type { UserPositionWithInfo } from "@/sdk/indexer-v2/queries/api/user-position/types";
-
-import BlurModal from "../BlurModal";
 
 const formatter = new Intl.NumberFormat("en-US", {
   maximumSignificantDigits: 2,
@@ -22,8 +21,13 @@ export default function TapOutModal({
     : undefined;
 
   return (
-    <BlurModal close={() => setIsTappingOut(false)}>
-      <div className="flex flex-col gap-[1.5em] uppercase max-w-[58ch]">
+    <div className="flex flex-col items-center grow pt-10 relative">
+      <CloseIcon
+        onClick={() => setIsTappingOut(false)}
+        className="absolute right-[.5em] top-[.5em] p-[.5em] h-[2.5em] w-[2.5em] cursor-pointer"
+        color="econiaBlue"
+      />
+      <div className="flex flex-col gap-[1.5em] uppercase max-w-[58ch] grow">
         <div className="text-4xl text-white text-center">Are you sure you want to tap out?</div>
         <div className="flex flex-col gap-[2em]">
           <div className="font-forma text-light-gray leading-6">
@@ -45,6 +49,6 @@ export default function TapOutModal({
           Yes, pay fee and tap out
         </Button>
       </ButtonWithConnectWalletFallback>
-    </BlurModal>
+    </div>
   );
 }

--- a/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
@@ -64,12 +64,7 @@ export const TabContainer = (props: ArenaProps) => {
       >
         <TabsList>
           {tabs.map((tab) => (
-            <TabsTrigger
-              key={tab.name}
-              value={tab.name}
-              className="!text-[1.8rem]"
-              endSlot={<Emoji emojis={tab.emoji} className="text-[1.5rem]" />}
-            >
+            <TabsTrigger key={tab.name} value={tab.name} endSlot={<Emoji emojis={tab.emoji} />}>
               {tab.name}
             </TabsTrigger>
           ))}

--- a/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
@@ -64,7 +64,12 @@ export const TabContainer = (props: ArenaProps) => {
       >
         <TabsList>
           {tabs.map((tab) => (
-            <TabsTrigger key={tab.name} value={tab.name} endSlot={<Emoji emojis={tab.emoji} />}>
+            <TabsTrigger
+              key={tab.name}
+              value={tab.name}
+              className="!text-[1.8rem]"
+              endSlot={<Emoji emojis={tab.emoji} className="text-[1.5rem]" />}
+            >
               {tab.name}
             </TabsTrigger>
           ))}

--- a/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
@@ -55,12 +55,7 @@ export const TabContainer = (props: ArenaProps) => {
   const tabs = useMemo(() => getTabs(props, setSelectedTab), [props]);
 
   return (
-    <div
-      className="flex h-[100%] bg-black"
-      style={{
-        gridTemplateRows: "auto 1fr",
-      }}
-    >
+    <div className="flex h-[100%] bg-black">
       <Tabs
         activeBg="black"
         value={selectedTab}

--- a/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
@@ -62,6 +62,7 @@ export const TabContainer = (props: ArenaProps) => {
       }}
     >
       <Tabs
+        activeBg="black"
         value={selectedTab}
         onValueChange={(tab) => setSelectedTab(tab as TabName)}
         className="h-full flex flex-col w-full"

--- a/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
@@ -1,12 +1,12 @@
 import { CloseIcon } from "components/svg";
-import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
 
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs/tabs";
+
 import type { ArenaProps } from "../utils";
-import { ArenaLoading } from "./ArenaLoading";
 import ChatTab from "./ChatTab";
 import EnterTab from "./enter-tab/EnterTab";
 import InfoTab from "./InfoTab";
@@ -21,12 +21,12 @@ const getTabs = (
   {
     name: "Position" as TabName,
     emoji: emoji("smiling face with horns"),
-    element: <EnterTab />,
+    component: <EnterTab />,
   },
   {
     name: "Profile" as TabName,
     emoji: emoji("ninja"),
-    element: (
+    component: (
       <ProfileTab
         {...{
           market0,
@@ -40,72 +40,49 @@ const getTabs = (
   {
     name: "Chat" as TabName,
     emoji: emoji("left speech bubble"),
-    element: <ChatTab market0={market0} market1={market1} />,
+    component: <ChatTab market0={market0} market1={market1} />,
   },
   {
     name: "Info" as TabName,
     emoji: emoji("books"),
-    element: <InfoTab />,
+    component: <InfoTab />,
   },
 ];
 
 export const TabContainer = (props: ArenaProps) => {
   const [selectedTab, setSelectedTab] = useState<TabName>("Position");
-  const { status } = useAptos();
 
   const tabs = useMemo(() => getTabs(props, setSelectedTab), [props]);
-  const currentTab = useMemo(() => tabs.find((t) => t.name === selectedTab), [selectedTab, tabs]);
 
   return (
     <div
-      className="grid h-[100%] bg-black bg-opacity-80"
+      className="flex h-[100%] bg-black"
       style={{
         gridTemplateRows: "auto 1fr",
       }}
     >
-      <div className="relative flex flex-row mt-[.5em] overflow-y-auto">
-        {tabs.map((t) => {
-          return (
-            <div className="flex flex-row" key={`tab-${t.name}`}>
-              <div className="w-[1em] border-solid border-b-[2px] border-dark-gray"></div>
-              <div className="flex flex-col">
-                <div
-                  onClick={() => setSelectedTab(t.name)}
-                  className={`flex flex-row gap-[.2em] uppercase pixel-heading-3 border-solid cursor-pointer select-none ${t.name === selectedTab ? "rounded-t-[6px] border-t-dark-gray border-x-dark-gray border-x-[2px] border-t-[2px] text-white" : "mt-[2px] text-light-gray"}`}
-                  style={
-                    t.name !== selectedTab
-                      ? {
-                          paddingLeft: "calc(.5em + 2px)",
-                          paddingRight: "calc(.5em + 2px)",
-                        }
-                      : {
-                          paddingLeft: ".5em",
-                          paddingRight: ".5em",
-                        }
-                  }
-                >
-                  <div>{t.name}</div> <Emoji className="text-[.75em]" emojis={t.emoji} />
-                </div>
-                {t.name === selectedTab ? (
-                  <div className="flex flex-row justify-between">
-                    <div className="w-[2px] bg-dark-gray h-[2px]"></div>
-                    <div className="w-[2px] bg-dark-gray h-[2px]"></div>
-                  </div>
-                ) : (
-                  <div className="w-[100%] bg-dark-gray h-[2px]"></div>
-                )}
-              </div>
-            </div>
-          );
-        })}
-        <div className="w-[100%] h-[100%] border-solid border-b-[2px] border-dark-gray"></div>
-      </div>
-      {/* Show ArenaLoading for every transaction that happens on Position tab. */}
-      {status === "pending" && currentTab?.name === "Position" ? (
-        <ArenaLoading />
-      ) : (
-        <div className="overflow-y-auto">{currentTab?.element}</div>
-      )}
+      <Tabs
+        value={selectedTab}
+        onValueChange={(tab) => setSelectedTab(tab as TabName)}
+        className="h-full flex flex-col w-full"
+      >
+        <TabsList>
+          {tabs.map((tab) => (
+            <TabsTrigger key={tab.name} value={tab.name} endSlot={tab.emoji}>
+              {tab.name}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {tabs.map((tab) => (
+          <TabsContent
+            key={tab.name}
+            value={tab.name}
+            className="data-[state=active]:flex data-[state=active]:grow flex-col overflow-auto"
+          >
+            {tab.component}
+          </TabsContent>
+        ))}
+      </Tabs>
     </div>
   );
 };
@@ -141,7 +118,7 @@ export const MobileNavigation = (props: ArenaProps) => {
     <>
       {!tab && (
         <div
-          className="fixed bottom-0 w-full border-solid border-t-[1px] border-dark-gray h-[4em] bg-black"
+          className="fixed bottom-0 border-solid border-t-[1px] border-dark-gray h-[4em] bg-black"
           style={{
             display: "grid",
             gridTemplateColumns: "1fr 1fr 1fr 1fr",
@@ -205,7 +182,7 @@ export const MobileNavigation = (props: ArenaProps) => {
                     <div className="w-[100%] h-[100%] border-solid border-b-[2px] border-dark-gray"></div>
                   </div>
                 </div>
-                {tab.element}
+                {tab.component}
               </div>
             </div>
           </>,

--- a/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
@@ -68,7 +68,7 @@ export const TabContainer = (props: ArenaProps) => {
       >
         <TabsList>
           {tabs.map((tab) => (
-            <TabsTrigger key={tab.name} value={tab.name} endSlot={tab.emoji}>
+            <TabsTrigger key={tab.name} value={tab.name} endSlot={<Emoji emojis={tab.emoji} />}>
               {tab.name}
             </TabsTrigger>
           ))}

--- a/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
@@ -118,7 +118,7 @@ export const MobileNavigation = (props: ArenaProps) => {
     <>
       {!tab && (
         <div
-          className="fixed bottom-0 border-solid border-t-[1px] border-dark-gray h-[4em] bg-black"
+          className="fixed bottom-0 w-full border-solid border-t-[1px] border-dark-gray h-[4em] bg-black"
           style={{
             display: "grid",
             gridTemplateColumns: "1fr 1fr 1fr 1fr",

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -51,38 +51,39 @@ const ChatBox = (props: ChatProps) => {
 
   const { sendChatMessage } = useChatBox(props.data.marketAddress);
 
-  if (chatsQuery.isLoading) return <Loading />;
-
   return (
-    <Column className="relative" width="100%" flexGrow={1}>
-      <Flex
-        flexGrow="1"
-        width="100%"
-        overflowY="auto"
-        maxHeight="328px"
-        flexDirection="column-reverse"
-      >
-        <motion.div
-          layoutScroll
-          className="flex flex-col-reverse w-full justify-center px-[21px] py-0 border-r border-solid border-r-dark-gray"
+    <Column className="relative w-full min-h-[328px] grow">
+      {chatsQuery.isLoading ? (
+        <Loading />
+      ) : (
+        <Flex
+          flexGrow="1"
+          width="100%"
+          overflowY="auto"
+          maxHeight="328px"
+          flexDirection="column-reverse"
         >
-          {sortedChats.map(({ message, shouldAnimateAsInsertion }, index) => (
-            <MessageContainer
-              message={message}
-              key={message.version}
-              index={sortedChats.length - index}
-              alignLeft={message.sender === connectedWalletName}
-              shouldAnimateAsInsertion={shouldAnimateAsInsertion}
+          <motion.div
+            layoutScroll
+            className="flex flex-col-reverse w-full justify-center px-[21px] py-0 border-r border-solid border-r-dark-gray"
+          >
+            {sortedChats.map(({ message, shouldAnimateAsInsertion }, index) => (
+              <MessageContainer
+                message={message}
+                key={message.version}
+                index={sortedChats.length - index}
+                alignLeft={message.sender === connectedWalletName}
+                shouldAnimateAsInsertion={shouldAnimateAsInsertion}
+              />
+            ))}
+            <LoadMore
+              query={chatsQuery}
+              className="mt-2 mb-4"
+              endOfListText="This is the beginning of the chat"
             />
-          ))}
-          <LoadMore
-            query={chatsQuery}
-            className="mt-2 mb-4"
-            endOfListText="This is the beginning of the chat"
-          />
-        </motion.div>
-      </Flex>
-
+          </motion.div>
+        </Flex>
+      )}
       <EmojiPickerWithInput handleClick={sendChatMessage} />
     </Column>
   );

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -60,7 +60,7 @@ const ChatBox = (props: ChatProps) => {
           flexGrow="1"
           width="100%"
           overflowY="auto"
-          maxHeight="328px"
+          maxHeight="350px"
           flexDirection="column-reverse"
         >
           <motion.div

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
@@ -1,10 +1,9 @@
 import ChartContainer from "components/charts/ChartContainer";
 import Loading from "components/loading";
-import Text from "components/text";
-import { translationFunction } from "context/language-context";
-import React, { Suspense, useState } from "react";
+import React, { Suspense } from "react";
 
-import { Flex, FlexGap } from "@/containers";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs/tabs";
+import { namesToEmojis } from "@/sdk/index";
 
 import type { GridProps } from "../../types";
 import ChatBox from "../chat/ChatBox";
@@ -20,12 +19,31 @@ import {
   StyledContentWrapper,
 } from "./styled";
 
-const tabs = ["Trade History", "My Trade History", "Top Holders"] as const;
+const tabs = [
+  {
+    name: "Trade History",
+    emoji: namesToEmojis("money-mouth face"),
+    component: (props: GridProps) => <TradeHistory data={props.data} />,
+  },
+  {
+    name: "My Trade History",
+    emoji: namesToEmojis("person raising hand"),
+    component: (props: GridProps) => <PersonalTradeHistory data={props.data} />,
+  },
+  {
+    name: "Top Holders",
+    emoji: namesToEmojis("1st place medal"),
+    component: (props: GridProps) => (
+      <CoinHolders
+        emojicoin={props.data.symbol}
+        marketView={props.data.marketView}
+        holders={props.data.holders}
+      />
+    ),
+  },
+] as const;
 
 const DesktopGrid = (props: GridProps) => {
-  const [currentTab, setCurrentTab] = useState<(typeof tabs)[number]>("Trade History");
-  const { t } = translationFunction();
-
   return (
     <StyledContentWrapper>
       <StyledContentInner>
@@ -54,30 +72,24 @@ const DesktopGrid = (props: GridProps) => {
 
         <StyledContentColumn>
           <StyledBlock width="57%">
-            <FlexGap className="px-6 h-10 items-center" gap="20px" width="fit-content">
-              {tabs.map((tab) => (
-                <Flex key={tab} cursor="pointer" onClick={() => setCurrentTab(tab)}>
-                  <Text
-                    textScale="pixelHeading4"
-                    color={currentTab === tab ? "lightGray" : "darkGray"}
-                    textTransform="uppercase"
+            <Tabs defaultValue={tabs[0].name}>
+              <TabsList>
+                {tabs.map((tab) => (
+                  <TabsTrigger
+                    key={tab.name}
+                    value={tab.name}
+                    endSlot={<div className="text-[1.1rem]">{tab.emoji}</div>}
                   >
-                    {t(tab)}
-                  </Text>
-                </Flex>
+                    {tab.name}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              {tabs.map((tab) => (
+                <TabsContent key={tab.name} value={tab.name}>
+                  {tab.component(props)}
+                </TabsContent>
               ))}
-            </FlexGap>
-            <StyledBlockWrapper>
-              {currentTab === "My Trade History" && <PersonalTradeHistory data={props.data} />}
-              {currentTab === "Trade History" && <TradeHistory data={props.data} />}
-              {currentTab === "Top Holders" && (
-                <CoinHolders
-                  emojicoin={props.data.symbol}
-                  marketView={props.data.marketView}
-                  holders={props.data.holders}
-                />
-              )}
-            </StyledBlockWrapper>
+            </Tabs>
           </StyledBlock>
 
           <StyledBlock width="43%">

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/desktop-grid/index.tsx
@@ -1,9 +1,10 @@
 import ChartContainer from "components/charts/ChartContainer";
 import Loading from "components/loading";
 import React, { Suspense } from "react";
+import { emoji } from "utils";
+import { Emoji } from "utils/emoji";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs/tabs";
-import { namesToEmojis } from "@/sdk/index";
 
 import type { GridProps } from "../../types";
 import ChatBox from "../chat/ChatBox";
@@ -22,17 +23,17 @@ import {
 const tabs = [
   {
     name: "Trade History",
-    emoji: namesToEmojis("money-mouth face"),
+    emoji: emoji("money-mouth face"),
     component: (props: GridProps) => <TradeHistory data={props.data} />,
   },
   {
     name: "My Trade History",
-    emoji: namesToEmojis("person raising hand"),
+    emoji: emoji("person raising hand"),
     component: (props: GridProps) => <PersonalTradeHistory data={props.data} />,
   },
   {
     name: "Top Holders",
-    emoji: namesToEmojis("1st place medal"),
+    emoji: emoji("1st place medal"),
     component: (props: GridProps) => (
       <CoinHolders
         emojicoin={props.data.symbol}
@@ -78,7 +79,7 @@ const DesktopGrid = (props: GridProps) => {
                   <TabsTrigger
                     key={tab.name}
                     value={tab.name}
-                    endSlot={<div className="text-[1.1rem]">{tab.emoji}</div>}
+                    endSlot={<Emoji emojis={tab.emoji} />}
                   >
                     {tab.name}
                   </TabsTrigger>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
@@ -1,9 +1,10 @@
 import ChartContainer from "components/charts/ChartContainer";
 import Loading from "components/loading";
 import React, { Suspense } from "react";
+import { emoji } from "utils";
+import { Emoji } from "utils/emoji";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs/tabs";
-import { namesToEmojis } from "@/sdk/index";
 
 import type { GridProps } from "../../types";
 import ChatBox from "../chat/ChatBox";
@@ -25,17 +26,17 @@ const HEIGHT = DISPLAY_HEADER_ABOVE_CHART ? "min-h-[320px]" : "min-h-[365px]";
 const tabs = [
   {
     name: "Trades",
-    emoji: namesToEmojis("money-mouth face"),
+    emoji: emoji("money-mouth face"),
     component: (props: GridProps) => <TradeHistory data={props.data} />,
   },
   {
     name: "My Trades",
-    emoji: namesToEmojis("person raising hand"),
+    emoji: emoji("person raising hand"),
     component: (props: GridProps) => <PersonalTradeHistory data={props.data} />,
   },
   {
     name: "Swap",
-    emoji: namesToEmojis("counterclockwise arrows button"),
+    emoji: emoji("counterclockwise arrows button"),
     component: (props: GridProps) => (
       <div className="flex flex-col items-center">
         <LiquidityButton data={props.data} />
@@ -52,12 +53,12 @@ const tabs = [
   },
   {
     name: "Chat",
-    emoji: namesToEmojis("speech balloon"),
+    emoji: emoji("speech balloon"),
     component: (props: GridProps) => <ChatBox data={props.data} />,
   },
   {
     name: "Holders",
-    emoji: namesToEmojis("1st place medal"),
+    emoji: emoji("1st place medal"),
     component: (props: GridProps) => (
       <CoinHolders
         emojicoin={props.data.symbol}
@@ -85,7 +86,7 @@ const MobileGrid = (props: GridProps) => {
         <Tabs defaultValue={tabs[0].name}>
           <TabsList>
             {tabs.map((tab) => (
-              <TabsTrigger key={tab.name} value={tab.name} endSlot={tab.emoji}>
+              <TabsTrigger key={tab.name} value={tab.name} endSlot={<Emoji emojis={tab.emoji} />}>
                 {tab.name}
               </TabsTrigger>
             ))}

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
@@ -1,10 +1,9 @@
-import { Text } from "components";
 import ChartContainer from "components/charts/ChartContainer";
 import Loading from "components/loading";
-import { translationFunction } from "context/language-context";
-import React, { Suspense, useState } from "react";
+import React, { Suspense } from "react";
 
-import { Flex } from "@/containers";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs/tabs";
+import { namesToEmojis } from "@/sdk/index";
 
 import type { GridProps } from "../../types";
 import ChatBox from "../chat/ChatBox";
@@ -23,12 +22,53 @@ import {
 const DISPLAY_HEADER_ABOVE_CHART = false;
 const HEIGHT = DISPLAY_HEADER_ABOVE_CHART ? "min-h-[320px]" : "min-h-[365px]";
 
-const TABS = ["Trades", "My Trades", "Swap", "Chat", "Holders"] as const;
+const tabs = [
+  {
+    name: "Trades",
+    emoji: namesToEmojis("money-mouth face"),
+    component: (props: GridProps) => <TradeHistory data={props.data} />,
+  },
+  {
+    name: "My Trades",
+    emoji: namesToEmojis("person raising hand"),
+    component: (props: GridProps) => <PersonalTradeHistory data={props.data} />,
+  },
+  {
+    name: "Swap",
+    emoji: namesToEmojis("counterclockwise arrows button"),
+    component: (props: GridProps) => (
+      <div className="flex flex-col items-center">
+        <LiquidityButton data={props.data} />
+        <div className="flex items-center justify-center pt-10 py-8 w-full bg-black">
+          <SwapComponent
+            emojicoin={props.data.symbol}
+            marketAddress={props.data.marketAddress}
+            marketEmojis={props.data.symbolEmojis}
+            initNumSwaps={props.data.swaps.length}
+          />
+        </div>
+      </div>
+    ),
+  },
+  {
+    name: "Chat",
+    emoji: namesToEmojis("speech balloon"),
+    component: (props: GridProps) => <ChatBox data={props.data} />,
+  },
+  {
+    name: "Holders",
+    emoji: namesToEmojis("1st place medal"),
+    component: (props: GridProps) => (
+      <CoinHolders
+        emojicoin={props.data.symbol}
+        marketView={props.data.marketView}
+        holders={props.data.holders}
+      />
+    ),
+  },
+] as const;
 
 const MobileGrid = (props: GridProps) => {
-  const [tab, setTab] = useState<(typeof TABS)[number]>("Swap");
-  const { t } = translationFunction();
-
   return (
     <StyledMobileContentWrapper>
       <StyledMobileContentBlock className="">
@@ -42,52 +82,20 @@ const MobileGrid = (props: GridProps) => {
       </StyledMobileContentBlock>
 
       <StyledMobileContentBlock>
-        <StyledMobileContentHeader>
-          <div className="overflow-x-auto">
-            <div className="flex gap-6">
-              {TABS.map((tb) => (
-                <Flex key={tb} cursor="pointer" onClick={() => setTab(tb)}>
-                  <Text
-                    textScale="pixelHeading4"
-                    color={tab === tb ? "lightGray" : "darkGray"}
-                    textTransform="uppercase"
-                    className="whitespace-nowrap"
-                  >
-                    {t(tb)}
-                  </Text>
-                </Flex>
-              ))}
-            </div>
-          </div>
-        </StyledMobileContentHeader>
-        {tab === "Swap" && (
-          <div style={{ width: "100%" }}>
-            <LiquidityButton data={props.data} />
-          </div>
-        )}
-
-        <StyledMobileContentInner>
-          {tab === "Trades" && <TradeHistory data={props.data} />}
-          {tab === "My Trades" && <PersonalTradeHistory data={props.data} />}
-          {tab === "Holders" && (
-            <CoinHolders
-              emojicoin={props.data.symbol}
-              holders={props.data.holders}
-              marketView={props.data.marketView}
-            />
-          )}
-          {tab === "Chat" && <ChatBox data={props.data} />}
-          {tab === "Swap" && (
-            <Flex width="100%" justifyContent="center" px="17px">
-              <SwapComponent
-                emojicoin={props.data.symbol}
-                marketAddress={props.data.marketAddress}
-                marketEmojis={props.data.symbolEmojis}
-                initNumSwaps={props.data.swaps.length}
-              />
-            </Flex>
-          )}
-        </StyledMobileContentInner>
+        <Tabs defaultValue={tabs[0].name}>
+          <TabsList>
+            {tabs.map((tab) => (
+              <TabsTrigger key={tab.name} value={tab.name} endSlot={tab.emoji}>
+                {tab.name}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {tabs.map((tab) => (
+            <TabsContent key={tab.name} value={tab.name}>
+              {tab.component(props)}
+            </TabsContent>
+          ))}
+        </Tabs>
       </StyledMobileContentBlock>
     </StyledMobileContentWrapper>
   );

--- a/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
@@ -14,7 +14,7 @@ import { emoji } from "utils";
 import { Emoji } from "utils/emoji";
 
 import AptosIconBlack from "@/icons/AptosBlack";
-import { namesToEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
+import type { SymbolEmoji } from "@/sdk/emoji_data";
 import { formatDisplayName, type ValidAptosName } from "@/sdk/utils";
 
 import { WalletPortfolioTable } from "./WalletPortfolioTable";

--- a/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
@@ -12,7 +12,7 @@ import { useEffectOnce } from "react-use";
 import { ROUTES } from "router/routes";
 
 import AptosIconBlack from "@/icons/AptosBlack";
-import type { SymbolEmoji } from "@/sdk/emoji_data";
+import { namesToEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
 import { formatDisplayName, type ValidAptosName } from "@/sdk/utils";
 
 import { WalletPortfolioTable } from "./WalletPortfolioTable";
@@ -59,13 +59,19 @@ export const WalletClientPage = ({ address, name }: { address: string; name?: Va
         </span>
       </div>
       <Tabs value={tab} onValueChange={(v) => setTab(v)}>
-        <div className="flex min-h-[45px] items-end justify-between w-full flex-wrap">
-          <TabsList>
-            <TabsTrigger value="portfolio">Portfolio</TabsTrigger>
-            <TabsTrigger value="trade-history">Trade History</TabsTrigger>
-          </TabsList>
-          {tab === "trade-history" && <SearchBar />}
-        </div>
+        <TabsList>
+          <TabsTrigger value="portfolio" endSlot={namesToEmojis("money bag")}>
+            Portfolio
+          </TabsTrigger>
+          <TabsTrigger value="trade-history" endSlot={namesToEmojis("rocket")}>
+            Trade History
+          </TabsTrigger>
+          {tab === "trade-history" && (
+            <div className="flex grow justify-end min-w-[150px]">
+              <SearchBar className="ml-auto" />
+            </div>
+          )}
+        </TabsList>
         <TabsContent value="portfolio">
           <WalletPortfolioTable address={address} />
         </TabsContent>

--- a/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
@@ -10,6 +10,8 @@ import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import { useEffectOnce } from "react-use";
 import { ROUTES } from "router/routes";
+import { emoji } from "utils";
+import { Emoji } from "utils/emoji";
 
 import AptosIconBlack from "@/icons/AptosBlack";
 import { namesToEmojis, type SymbolEmoji } from "@/sdk/emoji_data";
@@ -60,10 +62,10 @@ export const WalletClientPage = ({ address, name }: { address: string; name?: Va
       </div>
       <Tabs value={tab} onValueChange={(v) => setTab(v)}>
         <TabsList>
-          <TabsTrigger value="portfolio" endSlot={namesToEmojis("money bag")}>
+          <TabsTrigger value="portfolio" endSlot={<Emoji emojis={emoji("money bag")} />}>
             Portfolio
           </TabsTrigger>
-          <TabsTrigger value="trade-history" endSlot={namesToEmojis("rocket")}>
+          <TabsTrigger value="trade-history" endSlot={<Emoji emojis={emoji("money bag")} />}>
             Trade History
           </TabsTrigger>
           {tab === "trade-history" && (

--- a/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
+++ b/src/typescript/frontend/src/components/pages/wallet/WalletClientPage.tsx
@@ -65,7 +65,7 @@ export const WalletClientPage = ({ address, name }: { address: string; name?: Va
           <TabsTrigger value="portfolio" endSlot={<Emoji emojis={emoji("money bag")} />}>
             Portfolio
           </TabsTrigger>
-          <TabsTrigger value="trade-history" endSlot={<Emoji emojis={emoji("money bag")} />}>
+          <TabsTrigger value="trade-history" endSlot={<Emoji emojis={emoji("scroll")} />}>
             Trade History
           </TabsTrigger>
           {tab === "trade-history" && (

--- a/src/typescript/frontend/src/components/synced-scrollview.tsx
+++ b/src/typescript/frontend/src/components/synced-scrollview.tsx
@@ -1,0 +1,141 @@
+import { cn } from "lib/utils/class-name";
+import React, { useEffect, useRef } from "react";
+
+/**
+ * A component that provides synchronized horizontal scrolling between two elements,
+ * primarily used to create a custom scrollbar placement for tab lists.
+ *
+ * This is a workaround solution for scenarios where having a scrollbar at the bottom
+ * of a tab list would break the UI. It creates a thin scrollbar at the top that
+ * synchronizes with the content below.
+ *
+ * Features:
+ * - Synchronized scrolling between top scrollbar and content
+ * - Touch scroll support for mobile devices
+ * - Dynamic width adjustment based on content
+ * - Hidden native scrollbars
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {string} [props.className] - Additional CSS classes to apply to the container
+ * @param {React.ReactNode} props.children - Content to be scrolled
+ *
+ * @example
+ * ```tsx
+ * <SyncedScrollView>
+ *   <div>Scrollable content here...</div>
+ * </SyncedScrollView>
+ * ```
+ */
+const SyncedScrollView: React.FC<{ className?: string; children: React.ReactNode }> = ({
+  className,
+  children,
+}) => {
+  const topRef = useRef<HTMLDivElement>(null);
+  const topInnerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const contentInnerRef = useRef<HTMLDivElement>(null);
+
+  // Scroll sync
+  useEffect(() => {
+    const top = topRef.current;
+    const content = contentRef.current;
+    if (!top || !content) return;
+
+    const syncTopToContent = () => {
+      content.scrollLeft = top.scrollLeft;
+    };
+    const syncContentToTop = () => {
+      top.scrollLeft = content.scrollLeft;
+    };
+
+    top.addEventListener("scroll", syncTopToContent);
+    content.addEventListener("scroll", syncContentToTop);
+
+    return () => {
+      top.removeEventListener("scroll", syncTopToContent);
+      content.removeEventListener("scroll", syncContentToTop);
+    };
+  }, []);
+
+  // Resize observer to sync top width
+  useEffect(() => {
+    const topInner = topInnerRef.current;
+    const contentInner = contentInnerRef.current;
+    if (!topInner || !contentInner) return;
+
+    const updateWidth = () => {
+      topInner.style.width = `${contentInner.scrollWidth}px`;
+    };
+
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(contentInner);
+
+    // Initial width calculation
+    updateWidth();
+
+    // Handle window resize
+    window.addEventListener("resize", updateWidth);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateWidth);
+    };
+  }, []);
+
+  // Touch scroll support for top bar
+  useEffect(() => {
+    const top = topRef.current;
+    const content = contentRef.current;
+    if (!top || !content) return;
+
+    let startX = 0;
+    let startScroll = 0;
+
+    const handleTouchStart = (e: TouchEvent) => {
+      startX = e.touches[0].pageX;
+      startScroll = content.scrollLeft;
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      const deltaX = e.touches[0].pageX - startX;
+      content.scrollLeft = startScroll - deltaX;
+    };
+
+    top.addEventListener("touchstart", handleTouchStart);
+    top.addEventListener("touchmove", handleTouchMove);
+
+    return () => {
+      top.removeEventListener("touchstart", handleTouchStart);
+      top.removeEventListener("touchmove", handleTouchMove);
+    };
+  }, []);
+
+  return (
+    <div className={cn("w-full", className)}>
+      {/* Top Scrollbar */}
+      <div ref={topRef} className="overflow-x-auto overflow-y-hidden h-3 touch-pan-x">
+        <div ref={topInnerRef} className="h-[1px]" />
+      </div>
+
+      <div ref={contentRef} className="overflow-auto scrollbar-hide">
+        <div ref={contentInnerRef} className="whitespace-nowrap">
+          {children}
+        </div>
+      </div>
+
+      {/* Custom scrollbar-hide for Chrome/Safari */}
+      <style>{`
+        .scrollbar-hide::-webkit-scrollbar {
+          display: none;
+        }
+        .scrollbar-hide {
+          -ms-overflow-style: none;
+          scrollbar-width: none;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default SyncedScrollView;

--- a/src/typescript/frontend/src/components/ui/table/table.tsx
+++ b/src/typescript/frontend/src/components/ui/table/table.tsx
@@ -59,7 +59,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-8 align-middle tracking-wide font-forma [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] border-y border-solid border-dark-gray",
+      "h-8 py-2 align-middle tracking-wide font-forma [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] border-y border-solid border-dark-gray bg-darker-gray",
       className
     )}
     {...props}

--- a/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
+++ b/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
@@ -1,35 +1,61 @@
+// cspell:word scrollview
 "use client";
 
+import { Slottable } from "@radix-ui/react-slot";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { cn } from "lib/utils/class-name";
 import * as React from "react";
 
-const Tabs = TabsPrimitive.Root;
+import SyncedScrollView from "@/components/synced-scrollview";
+
+const Tabs = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Root ref={ref} className={cn(className)} {...props} />
+));
+Tabs.displayName = TabsPrimitive.Root.displayName;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn("inline-flex h-9 items-center justify-center p-1 gap-4", className)}
-    {...props}
-  />
+  <SyncedScrollView className="-mb-[1px]">
+    <TabsPrimitive.List
+      ref={ref}
+      className={cn(
+        "min-w-full border-b border-solid border-dark-gray inline-flex items-end space-x-2 px-2 pt-2 pb-0 relative",
+        className
+      )}
+      {...props}
+    />
+  </SyncedScrollView>
 ));
 TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
+    startSlot?: React.ReactNode;
+    endSlot?: React.ReactNode;
+  }
+>(({ className, startSlot, endSlot, children, ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap py-1 pixel-heading-3b uppercase transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 text-dark-gray data-[state=active]:text-lighter-gray",
+      "flex whitespace-nowrap items-center -mb-[1px] relative rounded-t-xl px-4 py-2 data-[state=active]:border border-dark-gray !text-[1.2rem] pixel-heading-3b uppercase transition-all",
+      "text-light-gray data-[state=active]:border-b-0 data-[state=active]:text-white data-[state=active]:bg-darker-gray",
+      "data-[state=active]:shadow-md data-[state=active]:z-20",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "disabled:pointer-events-none disabled:opacity-50",
       className
     )}
     {...props}
-  />
+  >
+    {startSlot && <div className="ml-2">{startSlot}</div>}
+    <Slottable>{children}</Slottable>
+    {endSlot && <div className="ml-2">{endSlot}</div>}
+  </TabsPrimitive.Trigger>
 ));
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
@@ -40,7 +66,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "bg-darker-gray focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className
     )}
     {...props}

--- a/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
+++ b/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
@@ -64,7 +64,7 @@ const TabsTrigger = React.forwardRef<
     )}
     {...props}
   >
-    {startSlot && <div className="ml-2">{startSlot}</div>}
+    {startSlot && <div className="mr-2">{startSlot}</div>}
     <Slottable>{children}</Slottable>
     {endSlot && <div className="ml-2">{endSlot}</div>}
   </TabsPrimitive.Trigger>

--- a/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
+++ b/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
@@ -44,7 +44,7 @@ const TabsTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       "flex whitespace-nowrap items-center -mb-[1px] relative rounded-t-xl px-4 py-2 data-[state=active]:border border-dark-gray !text-[1.2rem] pixel-heading-3b uppercase transition-all",
-      "text-light-gray data-[state=active]:border-b-0 data-[state=active]:text-white data-[state=active]:bg-darker-gray",
+      "text-light-gray data-[state=active]:border-b-0 data-[state=active]:text-white data-[state=active]:bg-black",
       "data-[state=active]:shadow-md data-[state=active]:z-20",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       "disabled:pointer-events-none disabled:opacity-50",
@@ -66,7 +66,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "bg-darker-gray focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className
     )}
     {...props}

--- a/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
+++ b/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
@@ -10,9 +10,21 @@ import SyncedScrollView from "@/components/synced-scrollview";
 
 const Tabs = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Root ref={ref} className={cn(className)} {...props} />
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root> & {
+    activeBg?: "gray" | "black";
+  }
+>(({ className, activeBg = "gray", ...props }, ref) => (
+  <TabsPrimitive.Root
+    ref={ref}
+    className={cn(
+      // Apply styles targeting descendant active tabs and direct child tab panels
+      activeBg === "black"
+        ? "[&_[role=tab][data-state=active]]:bg-black [&>[role=tabpanel][data-state=active]]:bg-black"
+        : "[&_[role=tab][data-state=active]]:bg-darker-gray [&>[role=tabpanel][data-state=active]]:bg-darker-gray",
+      className
+    )}
+    {...props}
+  />
 ));
 Tabs.displayName = TabsPrimitive.Root.displayName;
 
@@ -44,7 +56,7 @@ const TabsTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       "flex whitespace-nowrap items-center -mb-[1px] relative rounded-t-xl px-4 py-2 data-[state=active]:border border-dark-gray !text-[1.2rem] pixel-heading-3b uppercase transition-all",
-      "text-light-gray data-[state=active]:border-b-0 data-[state=active]:text-white data-[state=active]:bg-black",
+      "text-light-gray data-[state=active]:border-b-0 data-[state=active]:text-white",
       "data-[state=active]:shadow-md data-[state=active]:z-20",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       "disabled:pointer-events-none disabled:opacity-50",
@@ -61,7 +73,7 @@ TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> & {}
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Content
     ref={ref}

--- a/src/typescript/frontend/tailwind.config.js
+++ b/src/typescript/frontend/tailwind.config.js
@@ -95,6 +95,7 @@ module.exports = {
       "light-gray": "#717386",
       "medium-gray": "#4F5160",
       "dark-gray": "#33343D",
+      "darker-gray": "#111214",
       black: "#000000",
       blue: "#64A7FF",
       green: "#2FA90F",


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description
- Add new design for tabs: https://www.figma.com/design/gPCK4ByZV718N8GPd7MPm0/Econia-Labs-%7C-emojicoin.fun?node-id=15869-1526&p=f&t=OPdjA0H3FiLidbQN-0
- Update market page with new tabs
- Update portfolio page with new tabs
- Update arena page with new tabs
- Add a workaround to move the scollbar to the top of the tabs
- Some cleanup in the arena tabs content to make it consistent

# Testing
- Visit pages /arena, 

# Notes
- I took some liberties for some of the designs. For example the background of the tabs content on the Arena page is now a different tint to match with the tint of the selected header. Some of these designs are to be discussed

# Checklist
No checklist

# Screenshots
<img width="682" alt="image" src="https://github.com/user-attachments/assets/6bfaec02-1c8e-40c5-a02c-76432553152a" />
<img width="708" alt="image" src="https://github.com/user-attachments/assets/54a90b4a-5392-4780-9cd0-104bf82c8c28" />
<img width="717" alt="image" src="https://github.com/user-attachments/assets/a08cb1f3-3f3b-46c2-a64e-f0e4292d7f7d" />
<img width="620" alt="image" src="https://github.com/user-attachments/assets/29c3f818-7d90-4aa3-a85f-d96ef42b9af1" />
<img width="430" alt="image" src="https://github.com/user-attachments/assets/1c2e20e4-ca12-4291-ac86-f0aec3144d81" />

