### PR TITLE
fix(ECO-3224): Update the link in the arena Info tab to be properly hyperlinked

### DIFF
--- a/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
@@ -1,10 +1,8 @@
 import { LINKS } from "lib/env";
 
-type Info = {
-  title: string;
-  paragraph: string;
-};
-const INFO: Info[] = [
+import { EXTERNAL_LINK_PROPS } from "@/components/link";
+
+const INFO = [
   {
     title: "What is the emojicoin arena?",
     paragraph:
@@ -45,11 +43,23 @@ const INFO: Info[] = [
     paragraph:
       "emojicoins are selected using Aptos randomness. Nobody, including the developers, can choose or influence which emojicoins are featured in a melee. This ensures fair and unpredictable daily competitions.",
   },
-  {
-    title: "I don't fully understand how the arena works, what should I do?",
-    paragraph: `You can join the discord <a class="underline" target=blank href=${LINKS!.discord}>(${LINKS!.discord})</a> where developers and other community members can help you.`,
-  },
-];
+  ...(LINKS
+    ? [
+        {
+          title: "I don't fully understand how the arena works, what should I do?",
+          paragraph: (
+            <>
+              You can join the discord{" "}
+              <a className="underline" href={LINKS.discord} {...EXTERNAL_LINK_PROPS}>
+                {LINKS.discord}
+              </a>{" "}
+              where developers and other community members can help you.
+            </>
+          ),
+        },
+      ]
+    : []),
+] as const;
 
 export default function InfoTab() {
   return (
@@ -58,10 +68,7 @@ export default function InfoTab() {
         {INFO.map((i, index) => (
           <div key={`info-p-${index}`} className="flex flex-col gap-[1em]">
             <div className="text-3xl uppercase text-white">{i.title}</div>
-            <div
-              className="font-forma text-light-gray"
-              dangerouslySetInnerHTML={{ __html: i.paragraph }}
-            />
+            <div className="font-forma text-light-gray">{i.paragraph}</div>
           </div>
         ))}
       </div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
@@ -47,10 +47,7 @@ const INFO: Info[] = [
   },
   {
     title: "I don't fully understand how the arena works, what should I do?",
-    paragraph:
-      "You can join the discord" + LINKS?.discord
-        ? ` (${LINKS!.discord}) `
-        : " " + "where developers and other community members can help you.",
+    paragraph: `You can join the discord <a class="underline" target=blank href=${LINKS!.discord}>(${LINKS!.discord})</a> where developers and other community members can help you.`,
   },
 ];
 
@@ -61,7 +58,10 @@ export default function InfoTab() {
         {INFO.map((i, index) => (
           <div key={`info-p-${index}`} className="flex flex-col gap-[1em]">
             <div className="text-3xl uppercase text-white">{i.title}</div>
-            <div className="font-forma text-light-gray">{i.paragraph}</div>
+            <div
+              className="font-forma text-light-gray"
+              dangerouslySetInnerHTML={{ __html: i.paragraph }}
+            />
           </div>
         ))}
       </div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
@@ -48,7 +48,7 @@ const INFO = [
     paragraph: (
       <>
         You can join the discord at{" "}
-        {LINKS && (
+        {LINKS?.discord && (
           <a className="underline" href={LINKS.discord} {...EXTERNAL_LINK_PROPS}>
             {LINKS.discord}{" "}
           </a>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/InfoTab.tsx
@@ -43,22 +43,20 @@ const INFO = [
     paragraph:
       "emojicoins are selected using Aptos randomness. Nobody, including the developers, can choose or influence which emojicoins are featured in a melee. This ensures fair and unpredictable daily competitions.",
   },
-  ...(LINKS
-    ? [
-        {
-          title: "I don't fully understand how the arena works, what should I do?",
-          paragraph: (
-            <>
-              You can join the discord{" "}
-              <a className="underline" href={LINKS.discord} {...EXTERNAL_LINK_PROPS}>
-                {LINKS.discord}
-              </a>{" "}
-              where developers and other community members can help you.
-            </>
-          ),
-        },
-      ]
-    : []),
+  {
+    title: "I don't fully understand how the arena works, what should I do?",
+    paragraph: (
+      <>
+        You can join the discord at{" "}
+        {LINKS && (
+          <a className="underline" href={LINKS.discord} {...EXTERNAL_LINK_PROPS}>
+            {LINKS.discord}{" "}
+          </a>
+        )}
+        where developers and other community members can help you.
+      </>
+    ),
+  },
 ] as const;
 
 export default function InfoTab() {

--- a/src/typescript/frontend/src/lib/env.ts
+++ b/src/typescript/frontend/src/lib/env.ts
@@ -6,10 +6,10 @@ import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
 import packageInfo from "../../package.json";
 
 type Links = {
-  x: string;
-  github: string;
-  discord: string;
-  tos: string;
+  x?: string | undefined;
+  github?: string | undefined;
+  discord?: string | undefined;
+  tos?: string | undefined;
 };
 
 const network = process.env.NEXT_PUBLIC_APTOS_NETWORK;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Fixes the text and makes the link clickable
<img width="515" alt="image" src="https://github.com/user-attachments/assets/2acb05fa-3b70-4c2d-a470-ff6d10883e5e" />


# Testing

Visit /arena page, select info tab and scroll to bottom