### PR TITLE
feat(ECO-3131): Add USD/APT toggle to user settings in local storage

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -3,7 +3,7 @@ import { FormattedNumber } from "components/FormattedNumber";
 import Popup from "components/popup";
 import { Planet, TwitterOutlineIcon } from "components/svg";
 import AptosIconBlack from "components/svg/icons/AptosBlack";
-import { useEventStore } from "context/event-store-context";
+import { useEventStore, useUserSettings } from "context/event-store-context";
 import { translationFunction } from "context/language-context";
 import { useAptos } from "context/wallet-context/AptosContextProvider";
 import { motion } from "framer-motion";
@@ -83,7 +83,8 @@ const MainInfo = ({ data }: MainInfoProps) => {
   const [allTimeVolume, setAllTimeVolume] = useState(
     BigInt(data.state.state.cumulativeStats.quoteVolume)
   );
-  const [showUSD, setShowUSD] = useState<boolean>(false);
+  const showUsd = useUserSettings((s) => s.showUsd);
+  const setShowUsd = useUserSettings((s) => s.setShowUsd);
 
   useEffect(() => {
     if (stateEvents.length === 0) return;
@@ -164,13 +165,13 @@ const MainInfo = ({ data }: MainInfoProps) => {
   const switcher = (
     <Switcher
       disabled={usdMarketCap === undefined}
-      checked={showUSD}
-      onChange={() => setShowUSD((v) => !v)}
+      checked={showUsd}
+      onChange={() => setShowUsd(!showUsd)}
     />
   );
 
   function aptOrUsd(value: bigint, valueUsd: number | undefined) {
-    if (valueUsd !== undefined && showUSD) {
+    if (valueUsd !== undefined && showUsd) {
       return (
         <>
           <FormattedNumber value={valueUsd} scramble />

--- a/src/typescript/frontend/src/lib/store/user-settings-store.ts
+++ b/src/typescript/frontend/src/lib/store/user-settings-store.ts
@@ -4,14 +4,17 @@ import { createStore } from "zustand";
 type UserSettingsState = {
   animate: boolean;
   showEmptyBars: boolean;
+  showUsd: boolean;
 };
 
 type UserSettingsActions = {
   setAnimate: (value: boolean) => void;
   setShowEmptyBars: (fn: (prev: boolean) => boolean) => void;
+  setShowUsd: (value: boolean) => void;
   userAgent: string;
   toggleAnimate: () => void;
   getShowEmptyBars: () => boolean;
+  getShowUsd: () => boolean;
 };
 
 export type UserSettingsStore = UserSettingsState & UserSettingsActions;
@@ -23,6 +26,7 @@ const saveSettings = (state: UserSettingsState) => {
 const defaultValues: UserSettingsState = {
   animate: true,
   showEmptyBars: true,
+  showUsd: false,
 };
 
 const readSettings = (): UserSettingsState => readLocalStorageCache("settings") ?? defaultValues;
@@ -31,6 +35,13 @@ const createUserSettingsStore = (userAgent: string) =>
   createStore<UserSettingsStore>()((set, get) => ({
     ...readSettings(),
     userAgent,
+    getShowUsd: () => get().showUsd,
+    setShowUsd: (value) =>
+      set((state) => {
+        const newState = { ...state, showUsd: value };
+        saveSettings(newState);
+        return newState;
+      }),
     getShowEmptyBars: () => get().showEmptyBars,
     setShowEmptyBars: (fn: (prev: boolean) => boolean) =>
       set((state) => {


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Adds USD/APT toggle to user settings in local storage

# Testing

Go to /market/droplet page, toggle the APT/USD$ switch on, and reload the page. The state should be saved.