### PR TITLE
fix(ECO-3239): Fix FA graphql query by removing leading zeros

### DIFF
--- a/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
@@ -1,9 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback } from "react";
 
-import { removeLeadingZerosFromStructString, type StructTagString } from "@/sdk/index";
+import { removeLeadingZerosFromStructString } from "@/sdk/index";
 import { getAptosClient } from "@/sdk/utils/aptos-client";
-import type { CoinTypeString } from "@/sdk/utils/type-tags";
+import type { CoinTypeString, StructTagString } from "@/sdk/utils/type-tags";
 /* eslint-disable-next-line */ // So we can link the import in the doc comment.
 import { type useLatestBalance } from "@/store/latest-balance";
 

--- a/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
+++ b/src/typescript/frontend/src/lib/hooks/queries/use-wallet-balance.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback } from "react";
 
-import type { StructTagString } from "@/sdk/index";
+import { removeLeadingZerosFromStructString, type StructTagString } from "@/sdk/index";
 import { getAptosClient } from "@/sdk/utils/aptos-client";
 import type { CoinTypeString } from "@/sdk/utils/type-tags";
 /* eslint-disable-next-line */ // So we can link the import in the doc comment.
@@ -22,7 +22,7 @@ const fetchFungibleAssetBalanceAndVersion = async (
       limit: 1,
       where: {
         asset_type: {
-          _eq: coinType,
+          _eq: removeLeadingZerosFromStructString(coinType),
         },
         owner_address: {
           _eq: accountAddress,


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Fix FA graphql query by removing leading zeros

This was introduced when I switched from using `Balance.view` to the Aptos TS SDK's `aptos.fungibleAsset.getCurrentFungibleAssetBalances` function.

It slipped my mind that the TS SDK doesn't automatically format addresses for us. It's a fairly simple fix- already tested it.

# Testing

Already tested it with the address given on Discord (the user who reported the problem):

I hard-coded my address to `0x67212a9b61e40c0a543e3b25ba72c78ec74cd17916a68fd3e3bf22ea1b9aba7a` in the frontend and made sure the query works and the balance displays properly with the fix.
