### PR TITLE
fix(ECO-3246): Fix/update pre-commit GitHub Action caches

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,38 +14,29 @@ jobs:
     steps:
     - uses: 'actions/checkout@v4'
     - run: 'git submodule update --init --recursive src/rust/processor'
-    - uses: 'actions/setup-python@v3'
+    - id: 'setup-python'
+      uses: 'actions/setup-python@v5'
       with:
         python-version: '${{ env.PYTHON_VERSION }}'
     - name: 'Install libdw-dev'
       run: |
         sudo apt-get update
         sudo apt-get install -y libdw-dev
-    - uses: 'actions/setup-node@v4'
-      with:
-        node-version-file: '${{ env.TS_DIR }}/.node-version'
-        registry-url: 'https://registry.npmjs.org'
-    - uses: 'pnpm/action-setup@v4'
-      with:
-        package_json_file: '${{ env.TS_DIR }}/package.json'
-    - run: 'cd ${{ env.TS_DIR }} && pnpm i'
-    - name: 'Cache Poetry Install'
-      uses: 'actions/cache@v3'
-      with:
-        key: 'poetry-${{ env.POETRY_VERSION }}'
-        path: '${{ runner.home }}/.local/src/python/hooks'
+    - uses: './.github/actions/pnpm-install'
     - name: 'Install Poetry'
-      uses: 'snok/install-poetry@v1.3.4'
+      uses: 'snok/install-poetry@v1.4.1'
       with:
         installer-parallel: true
         version: '${{ env.POETRY_VERSION }}'
         virtualenvs-create: true
         virtualenvs-in-project: true
     - id: 'restore-deps'
-      uses: 'actions/cache/restore@v3'
+      uses: 'actions/cache/restore@v4'
       with:
-        key: |
-          pydeps-${{ hashFiles('./src/python/hooks/poetry.lock') }}
+        key: >
+          pydeps-${{ runner.os }}-
+          ${{ steps.setup-python.outputs.python-version }}-
+          ${{ hashFiles('./src/python/hooks/poetry.lock') }}
         path: './src/python/hooks/.venv'
     - if: |
         steps.restore-deps.outputs.cache-hit != 'true'
@@ -54,12 +45,15 @@ jobs:
         cd ./src/python/hooks
         poetry install --no-interaction --no-root
     - id: 'save-deps'
-      uses: 'actions/cache/save@v3'
+      uses: 'actions/cache/save@v4'
       with:
-        key: |
-          pydeps-${{ hashFiles('./src/python/hooks/poetry.lock') }}
+        # Same key in `restore-deps`.
+        key: >
+          pydeps-${{ runner.os }}-
+          ${{ steps.setup-python.outputs.python-version }}-
+          ${{ hashFiles('./src/python/hooks/poetry.lock') }}
         path: './src/python/hooks/.venv'
-    - uses: 'pre-commit/action@v3.0.0'
+    - uses: 'pre-commit/action@v3.0.1'
       with:
         extra_args: '--all-files --config cfg/pre-commit-config.yaml'
 name: 'pre-commit'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -34,8 +34,8 @@ jobs:
       uses: 'actions/cache/restore@v4'
       with:
         key: >-
-          pydeps-${{ runner.os }}-\
-          ${{ steps.setup-python.outputs.python-version }}-\
+          pydeps-${{ runner.os }}-
+          ${{ steps.setup-python.outputs.python-version }}-
           ${{ hashFiles('./src/python/hooks/poetry.lock') }}
         path: './src/python/hooks/.venv'
     - if: |
@@ -49,8 +49,8 @@ jobs:
       with:
         # Same key in `restore-deps`.
         key: >-
-          pydeps-${{ runner.os }}-\
-          ${{ steps.setup-python.outputs.python-version }}-\
+          pydeps-${{ runner.os }}-
+          ${{ steps.setup-python.outputs.python-version }}-
           ${{ hashFiles('./src/python/hooks/poetry.lock') }}
         path: './src/python/hooks/.venv'
     - uses: 'pre-commit/action@v3.0.1'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -31,7 +31,7 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
     - id: 'restore-deps'
-      uses: 'actions/cache/restore@v4'
+      uses: 'actions/cache@v4'
       with:
         key: >-
           pydeps-${{ runner.os }}-
@@ -44,15 +44,6 @@ jobs:
       run: |
         cd ./src/python/hooks
         poetry install --no-interaction --no-root
-    - id: 'save-deps'
-      uses: 'actions/cache/save@v4'
-      with:
-        # Same key in `restore-deps`.
-        key: >-
-          pydeps-${{ runner.os }}-
-          ${{ steps.setup-python.outputs.python-version }}-
-          ${{ hashFiles('./src/python/hooks/poetry.lock') }}
-        path: './src/python/hooks/.venv'
     - uses: 'pre-commit/action@v3.0.1'
       with:
         extra_args: '--all-files --config cfg/pre-commit-config.yaml'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -33,9 +33,9 @@ jobs:
     - id: 'restore-deps'
       uses: 'actions/cache/restore@v4'
       with:
-        key: >
-          pydeps-${{ runner.os }}-
-          ${{ steps.setup-python.outputs.python-version }}-
+        key: >-
+          pydeps-${{ runner.os }}-\
+          ${{ steps.setup-python.outputs.python-version }}-\
           ${{ hashFiles('./src/python/hooks/poetry.lock') }}
         path: './src/python/hooks/.venv'
     - if: |
@@ -48,9 +48,9 @@ jobs:
       uses: 'actions/cache/save@v4'
       with:
         # Same key in `restore-deps`.
-        key: >
-          pydeps-${{ runner.os }}-
-          ${{ steps.setup-python.outputs.python-version }}-
+        key: >-
+          pydeps-${{ runner.os }}-\
+          ${{ steps.setup-python.outputs.python-version }}-\
           ${{ hashFiles('./src/python/hooks/poetry.lock') }}
         path: './src/python/hooks/.venv'
     - uses: 'pre-commit/action@v3.0.1'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -31,7 +31,7 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
     - id: 'restore-deps'
-      uses: 'actions/cache@v4'
+      uses: 'actions/cache/restore@v4'
       with:
         key: >-
           pydeps-${{ runner.os }}-
@@ -44,6 +44,17 @@ jobs:
       run: |
         cd ./src/python/hooks
         poetry install --no-interaction --no-root
+    - id: 'save-deps'
+      if: |
+        success() && steps.restore-deps.outputs.cache-hit != 'true'
+      uses: 'actions/cache/save@v4'
+      with:
+        # Same key in `restore-deps`.
+        key: >-
+          pydeps-${{ runner.os }}-
+          ${{ steps.setup-python.outputs.python-version }}-
+          ${{ hashFiles('./src/python/hooks/poetry.lock') }}
+        path: './src/python/hooks/.venv'
     - uses: 'pre-commit/action@v3.0.1'
       with:
         extra_args: '--all-files --config cfg/pre-commit-config.yaml'

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -8,6 +8,8 @@
 # cspell:word mypy
 # cspell:word shfmt
 ---
+default_language_version:
+  python: 'python3.10'
 exclude: 'doc\/move\/emojicoin_dot_fun\/.+' # Ignore DocGen.
 repos:
 -

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -136,7 +136,7 @@ repos:
     id: 'pretty-format-json'
   - id: 'trailing-whitespace'
   repo: 'https://github.com/pre-commit/pre-commit-hooks'
-  rev: 'v4.5.0'
+  rev: 'v5.0.0'
 -
   hooks:
   - additional_dependencies:
@@ -179,7 +179,7 @@ repos:
   hooks:
   - id: 'shfmt'
   repo: 'https://github.com/scop/pre-commit-shfmt'
-  rev: 'v3.8.0-1'
+  rev: 'v3.11.0-1'
 -
   hooks:
   -


### PR DESCRIPTION
# Description

`pre-commit` seems to be failing consistently lately in CI due to an invalid venv.

See this failed run: https://github.com/econia-labs/emojicoin-dot-fun/actions/runs/14499155811/job/40676172151?pr=807

I believe the main issue was disparate python versions, which I fixed by pinning the default python version in pre-commit-config.yaml. This also consolidates the pre-commit caches (there were multiple caches with multiple python versions being used, one for each version used in different pre-commit hooks)

I also:

- [x] Updated the cache key for the python dependencies to include more info like os and python version, and only run cache save on cache miss.
- [x] Removed `Cache Poetry Install` job, since it never actually cached anything.
The path used wasn't valid `path: '${{ runner.home }}/.local/src/python/hooks'`.
I believe the poetry install is already cached by the `snok/install-poetry` action.
Proof: old logs output `Cache not found for input keys: poetry-1.8.2`, see here for example https://github.com/econia-labs/emojicoin-dot-fun/actions/runs/14143029337/job/39626956266
- [x] Updated the old node/pnpm installation processes. The pnpm installation process is now in its own action in our repo with proper deps caching, so I updated pre-commit to use that instead.
- [x] Updated the caching actions versions to @v4 and pre-commit action patch version
- [x] Also ran `pre-commit autoupdate --repo https://github.com/<REPO>` for `pre-commit/pre-commit-hooks` and `scop/pre-commit-shfmt` per the warning in `pre-commit/action` logs

#### Fixed the below warnings by running the pre-commit autoupdate command suggested in them:
[WARNING] Hint: often `pre-commit autoupdate --repo https://github.com/scop/pre-commit-shfmt` will fix this.
[WARNING] Hint: often `pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks` will fix this.

#### Fixed by only conditionally running cache save on cache miss:
```shell
Run actions/cache/save@v3
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/emojicoin-dot-fun/emojicoin-dot-fun --files-from manifest.txt --use-compress-program zstdmt
Failed to save: Unable to reserve cache with key pydeps-9a660eeadb5503d2437d6cbfd092308a353f7a4bc8e25352df0ce76f892d6e4f, another job may be creating this cache.
Warning: Cache save failed.
```

# Testing

Should succeed in CI.

