### PR TITLE
chore(ECO-3242): Bump processor to 7.0.5 everywhere; bump frontend/SDK versions

### DIFF
--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -20,7 +20,7 @@ parameters:
   Environment: 'alpha'
   Network: 'testnet'
   ProcessorHealthCheckStartPeriod: 300
-  ProcessorImageVersion: '7.0.4'
+  ProcessorImageVersion: '7.0.5'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'fallback'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.4'
+  ProcessorImageVersion: '7.0.5'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -22,7 +22,7 @@ parameters:
   EnableWafRulesWebSocket: 'false'
   Environment: 'production'
   Network: 'mainnet'
-  ProcessorImageVersion: '7.0.4'
+  ProcessorImageVersion: '7.0.5'
   VpcStackName: 'emoji-vpc'
 tags: null
 template-file-path: 'src/cloud-formation/indexer.cfn.yaml'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -83,7 +83,7 @@ services:
     depends_on:
       postgres:
         condition: 'service_healthy'
-    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.4'
+    image: 'econialabs/emojicoin-dot-fun-indexer-processor:7.0.5'
     container_name: 'processor'
     healthcheck:
       test: 'curl -sf http://localhost:${PROCESSOR_WS_PORT} || exit 1'

--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -119,5 +119,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.8.2"
+  "version": "1.9.0"
 }

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -110,5 +110,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.6.0"
+  "version": "0.7.0"
 }


### PR DESCRIPTION
# Description

- [x] Bump processor image version to 7.0.5 in docker compose files and in the cloud-formation yaml files. The changes are extremely minimal (renaming variables, mainly). But without this, the merge to `production` will inevitably fail due to the mismatched processor submodule commit vs the tag used.
- [x] Update frontend version to `1.9.0` since it adds new features
- [x] Update SDK version to `0.7.0` since it removed exported types and is thus technically a breaking change
