### PR TITLE
fix(ECO-3249): Add fixes to arena UI improvements

### DIFF
--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -101,7 +101,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
         <div className="flex flex-col w-full">
           {!geoblocked && (
             <ButtonWithConnectWalletFallback
-              className={"w-full pl-0"}
+              className={"w-full"}
               mobile={true}
               onClick={subMenuOnClick}
               arrow

--- a/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
+++ b/src/typescript/frontend/src/components/header/components/mobile-menu/index.tsx
@@ -150,7 +150,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
               </>
             )}
           </AnimatePresence>
-          {linksForCurrentPage.map(({ title, path }) => {
+          {linksForCurrentPage.map(({ title, path }, i) => {
             return (
               <Link
                 key={title}
@@ -161,6 +161,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
               >
                 <MobileMenuItem
                   title={title}
+                  noBorder={i === linksForCurrentPage.length - 1}
                   pill={
                     title === "arena"
                       ? {

--- a/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
+++ b/src/typescript/frontend/src/components/header/wallet-button/ConnectWalletButton.tsx
@@ -110,7 +110,7 @@ const ButtonWithConnectWalletFallback = ({
             <div className={!mobile ? "" : "text-ec-blue text-[32px] leading-[40px]"}>
               <div
                 className="whitespace-nowrap text-overflow-ellipsis overflow-hidden"
-                style={{ minWidth: width }}
+                style={mobile ? {} : { minWidth: width }}
                 ref={ref}
               />
             </div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/EnterTab.tsx
@@ -107,7 +107,7 @@ function Container({
   position?: CurrentUserPosition | null;
 }) {
   return (
-    <div className="relative flex flex-col grow pt-4 pb-7">
+    <div className="relative flex flex-col grow pt-[2em] pb-[3em]">
       <div className="px-2 w-[100%] text-white flex items-center *:grow *:basis-0 h-[20px]">
         {phase === "amount" || phase === "lock" ? (
           <div>

--- a/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/EnterTabSummary.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/enter-tab/summary/EnterTabSummary.tsx
@@ -63,7 +63,7 @@ export default function EnterTabSummary({
   }, [account, swapTransactionBuilder, swap, submit]);
 
   return (
-    <div className="flex flex-col grow pt-4 pb-7">
+    <div className="flex flex-col grow pt-[2em] pb-[3em]">
       {isTappingOut && (
         <TapOutModal position={position} onTapOut={onTapOut} setIsTappingOut={setIsTappingOut} />
       )}

--- a/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
+++ b/src/typescript/frontend/src/components/pages/arena/tabs/index.tsx
@@ -133,7 +133,7 @@ export const MobileNavigation = (props: ArenaProps) => {
       )}
       {!!tab &&
         createPortal(
-          <>
+          <div className="relative z-[100]">
             {/* Backdrop, to hide the app behind the tab overlay */}
             <div className="fixed inset-0 bg-black z-[49]" />
 
@@ -181,7 +181,7 @@ export const MobileNavigation = (props: ArenaProps) => {
                 {tab.component}
               </div>
             </div>
-          </>,
+          </div>,
           document.body
         )}
     </>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/chat/ChatBox.tsx
@@ -52,7 +52,7 @@ const ChatBox = (props: ChatProps) => {
   const { sendChatMessage } = useChatBox(props.data.marketAddress);
 
   return (
-    <Column className="relative w-full min-h-[328px] grow">
+    <Column className="relative w-full min-h-[328px] grow bg-black border-t border-t-dark-gray border-solid z-20">
       {chatsQuery.isLoading ? (
         <Loading />
       ) : (

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/index.tsx
@@ -15,13 +15,11 @@ import SwapComponent from "../trade-emojicoin/SwapComponent";
 import { TradeHistory } from "../trade-history/trade-history";
 import {
   StyledMobileContentBlock,
-  StyledMobileContentHeader,
   StyledMobileContentInner,
   StyledMobileContentWrapper,
 } from "./styled";
 
-const DISPLAY_HEADER_ABOVE_CHART = false;
-const HEIGHT = DISPLAY_HEADER_ABOVE_CHART ? "min-h-[320px]" : "min-h-[365px]";
+const CHART_HEIGHT = "min-h-[365px]";
 
 const tabs = [
   {
@@ -72,10 +70,8 @@ const tabs = [
 const MobileGrid = (props: GridProps) => {
   return (
     <StyledMobileContentWrapper>
-      <StyledMobileContentBlock className="">
-        {/* Add this back in if we decide to use the custom emoji picker search bar. */}
-        {DISPLAY_HEADER_ABOVE_CHART && <StyledMobileContentHeader></StyledMobileContentHeader>}
-        <StyledMobileContentInner className={HEIGHT}>
+      <StyledMobileContentBlock>
+        <StyledMobileContentInner className={CHART_HEIGHT}>
           <Suspense fallback={<Loading />}>
             <ChartContainer symbol={props.data.symbol} className="relative w-full h-[420px]" />
           </Suspense>

--- a/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/styled.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/mobile-grid/styled.tsx
@@ -50,34 +50,3 @@ export const StyledMobileContentBlock = styled.div`
     }
   }
 `;
-
-export const StyledMobileContentHeader = styled.div`
-  display: flex;
-  position: relative;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.darkGray};
-  padding: 3px 10px;
-
-  ${({ theme }) => theme.mediaQueries.tablet} {
-    min-height: 45px;
-    align-items: center;
-  }
-
-  &:after,
-  &:before {
-    content: "";
-    display: block;
-    position: absolute;
-    width: 1200vw;
-    background-color: ${({ theme }) => theme.colors.darkGray};
-    height: 1px;
-    transform: translateX(-20%);
-  }
-
-  &:after {
-    top: -1px;
-  }
-
-  &:before {
-    bottom: -1px;
-  }
-`;

--- a/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
+++ b/src/typescript/frontend/src/components/ui/tabs/tabs.tsx
@@ -55,8 +55,10 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex whitespace-nowrap items-center -mb-[1px] relative rounded-t-xl px-4 py-2 data-[state=active]:border border-dark-gray !text-[1.2rem] pixel-heading-3b uppercase transition-all",
-      "text-light-gray data-[state=active]:border-b-0 data-[state=active]:text-white",
+      "flex whitespace-nowrap items-center -mb-[1px] relative rounded-t-xl px-4 py-2 !text-[1.2rem] pixel-heading-3b",
+      "uppercase transition-all",
+      "border border-transparent data-[state=active]:border-dark-gray data-[state=active]:border-b-transparent",
+      "text-light-gray data-[state=active]:text-white",
       "data-[state=active]:shadow-md data-[state=active]:z-20",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       "disabled:pointer-events-none disabled:opacity-50",

--- a/src/typescript/frontend/src/theme/base.ts
+++ b/src/typescript/frontend/src/theme/base.ts
@@ -51,9 +51,9 @@ export const radii = {
 } as const;
 
 export const zIndices = {
-  modal: 100,
+  modal: 1000,
   tooltip: 101,
-  header: 11,
+  header: 100,
   dropdown: 10,
 } as const;
 


### PR DESCRIPTION
# Description

Fixes a few minor issues:

- [x] Fix the chat tab being gray by adding `bg-black` to the `ChatTab.tsx` component (non-arena). See **picture A** below
- [x] This also ensures the tab doesn't look weird with a non-gray background by setting the z-index higher so that it has a natural border despite no gray body like the others do with their headers.
- [x] Fix the alignment of the `Connect Wallet` and address text in the mobile menu. See **picture B** below
- [x] Removes code that's no longer necessary/used
- [x] Adds a little extra padding to the bottom of the 3 arena buttons (`p-4` to `pt-[2em]` to match the original)
- [x] Fixes an issue where the arena tabs now show up overlaid when the mobile menu is open, see **picture C** below
- [x] Fixes the layout shifting slightly when a tab is unselected by adding transparent borders at all times
- [x] Removes the divider below the last item in the mobile-menu, see **picture C**

## Picture A: Chat tab gray
### Before
![image](https://github.com/user-attachments/assets/db81ab17-d815-4423-8928-6edb1edc6436)
### After
![image](https://github.com/user-attachments/assets/e8c06d1d-bf01-49d7-a48d-3b5d61b29378)

## Picture B: Connect wallet/address name alignment
### Before
![image](https://github.com/user-attachments/assets/8662f325-19d7-4ef9-954a-0d751fe08cf2)
### After
![image](https://github.com/user-attachments/assets/08892a96-fa22-4056-aed8-6ca57c6b9783)

## Picture C: Overlay mobile-menu issue before/after, also divider below last item removal
### Before
![image](https://github.com/user-attachments/assets/37359645-2085-428c-ae87-ffed20c20208)
### After
![image](https://github.com/user-attachments/assets/8a57277d-18ff-4276-9d53-59b026830588)

