### PR TITLE
fix(ECO-3251): Fix arena section on home page on mobile device

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "pnpm --prefix src/typescript run dev",
     "dev:debug": "pnpm --prefix src/typescript run dev:debug",
     "dev:debug-verbose": "pnpm --prefix src/typescript run dev:debug-verbose",
+    "dev:lan": "pnpm --prefix src/typescript run dev:lan",
     "docker:prune": "pnpm --prefix src/typescript run docker:prune",
     "docker:restart": "pnpm --prefix src/typescript run docker:restart",
     "docker:up": "pnpm --prefix src/typescript run docker:up",

--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -108,6 +108,7 @@
     "check:tests": "tsc -p tests/tsconfig.json",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
     "dev": "NODE_OPTIONS='--inspect' next dev --turbo --port 3001",
+    "dev:lan": "NODE_OPTIONS='--inspect' next dev --turbo -H 0.0.0.0 --port 3001",
     "format": "pnpm _format --list-different --write",
     "format:check": "pnpm _format --check",
     "lint": "eslint --max-warnings=0 -c .eslintrc.js --ext .js,.jsx,.ts,.tsx .",

--- a/src/typescript/frontend/src/app/home/HomePage.tsx
+++ b/src/typescript/frontend/src/app/home/HomePage.tsx
@@ -38,7 +38,7 @@ export default async function HomePageComponent({
     <div className="relative">
       <div className="flex-col mb-[31px]">
         {priceFeed.length > 0 ? <PriceFeed data={priceFeed} /> : <TextCarousel />}
-        <div className="flex justify-center items-center px-[16px] mobile-lg:px-[24px] mx-auto w-full max-w-full max-h-[60dvh]">
+        <div className="flex justify-center items-center px-[16px] mobile-lg:px-[24px] mx-auto w-full max-w-full">
           {FEATURE_FLAGS.Arena && meleeData ? (
             <ArenaCard meleeData={meleeData} />
           ) : (

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -29,6 +29,7 @@
     "clean:full": "pnpm run clean && rm -rf node_modules && rm -rf sdk/node_modules && rm -rf frontend/node_modules",
     "dev": "pnpm load-env -- turbo run dev --force --parallel --continue --log-prefix none",
     "dev:debug": "FETCH_DEBUG=true pnpm load-env -- pnpm run dev",
+    "dev:lan": "pnpm load-env -- turbo run dev:lan --force --parallel --continue --log-prefix none",
     "dev:debug-verbose": "FETCH_DEBUG_VERBOSE=true pnpm load-env -- pnpm run dev",
     "docker:prune": "../docker/utils/prune.sh --reset-localnet --yes",
     "docker:restart": "pnpm run docker:prune && pnpm run docker:up",

--- a/src/typescript/turbo.json
+++ b/src/typescript/turbo.json
@@ -55,6 +55,10 @@
       "cache": false,
       "persistent": true
     },
+    "dev:lan": {
+      "cache": false,
+      "persistent": true
+    },
     "format": {
       "outputs": []
     },


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

There was a max height css property that would create overlapping issues on mobile devices.
I removed it completely since it didn't seem to have any effect other than breaking the layout on mobile. 

# Testing

The bug can be reproduced on desktop by increasing the browser scaling to a high value (175-200%)