### PR TITLE
fix(ECO-3221): Fix sell all buttons alignment

### DIFF
--- a/src/typescript/frontend/src/components/EmojiPill.tsx
+++ b/src/typescript/frontend/src/components/EmojiPill.tsx
@@ -21,7 +21,7 @@ export const EmojiPill = ({
         className="flex justify-center items-center w-10 h-6 border border-dark-gray border-solid rounded-xl"
         onClick={onClick}
       >
-        <Emoji className="translate-y-[2px]" emojis={emoji(emojiName)} />
+        <Emoji emojis={emoji(emojiName)} />
       </div>
     </Popup>
   );

--- a/src/typescript/frontend/src/utils/emoji.tsx
+++ b/src/typescript/frontend/src/utils/emoji.tsx
@@ -30,7 +30,7 @@ export const Emoji = ({
     // Wrap this in div so that any font families from tailwind utility classes don't clash with the emoji font class
     // name. This means it's not necessary to manually change each usage of font utility classes in the codebase, and
     // instead just let the font size / line height cascade downwards but override the font family with the emoji font.
-    <span className={props.className}>
+    <span className={cn(props.className, !emojiFontClassName && "translate-y-[2px]")}>
       <span
         {...props}
         className={emojiFontClassName}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description
After a closer look, I noticed that apple emojis always have a 2px offset compared to the Noto emojis.
So, I added a 2px translation in the `Emoji` component when using Apple emojis, which will fix it globally.

# Testing
Visit /pools or /market page and check alignment
