### PR TITLE
fix(ECO-3266): Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,6 @@ src/cloud-formation @alnoki
 src/docker          @xbtmatt
 src/move            @alnoki
 src/python          @xbtmatt
-src/rust            @CRBl69
+src/rust            @xbtmatt
 src/sh              @alnoki
 src/typescript      @xbtmatt


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Replaces @CRBl69 with @xbtmatt as code owner for folder src/rust
