### PR TITLE
fix(ECO-3276): Fix arena chat emoji picker on small screen

### DIFF
--- a/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
+++ b/src/typescript/frontend/src/components/emoji-picker/EmojiPickerWithInput.tsx
@@ -290,7 +290,7 @@ const EmojiPickerWithInput = ({
         <div
           className="fixed bg-transparent right-0"
           style={{
-            zIndex: 100,
+            zIndex: 101,
             ...(mode === "chat" ? { top: 0 } : { bottom: 0 }),
           }}
           ref={containerRef}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description
Increases the z-index of emoji picker. It was hidden behind the tab on mobile.

# Testing
Go to Arena page, reduce window size to mobile, select chat and press on the input. Emoji picker should now appear.