### PR TITLE
chore(ECO-3288): Bump the frontend version to 1.10.0

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -117,5 +117,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.9.0"
+  "version": "1.10.0"
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

THe `sdk` version was already bumped in #834, as well as the `compose.yaml` and `config.yaml` files for the processor tag versions.

Only the frontend version needs a feature version bump (major) because of the new stats page.

