### PR TITLE
fix(ECO-3307): Fix `My Trades` tab on the market page

### DIFF
--- a/src/typescript/frontend/src/components/ui/table/ecTable.tsx
+++ b/src/typescript/frontend/src/components/ui/table/ecTable.tsx
@@ -188,17 +188,12 @@ export const EcTable = <T,>({
   }, [rowHeight, containerHeight]);
 
   return (
-    <div
-      ref={containerRef}
-      className={cn("relative flex w-full", className)}
-      // Prevents scrollbar from appearing when there are empty rows
-      style={{ overflowY: items.length < minRows ? "hidden" : "auto" }}
-    >
+    <div ref={containerRef} className={cn("relative flex w-full", className)}>
       {(items.length === 0 || isLoading) && (
         <div
           className={cn(
-            "fixed top-0 left-1 bottom-1 right-1 bg-black bg-opacity-30 z-10 flex justify-center text-light-gray items-center pixel-heading-4",
-            isLoading && "bg-opacity-80"
+            "absolute inset-0 z-10 flex justify-center items-center text-light-gray bg-black pixel-heading-4",
+            isLoading ? "bg-opacity-80" : "bg-opacity-30"
           )}
         >
           <div>
@@ -210,38 +205,48 @@ export const EcTable = <T,>({
           </div>
         </div>
       )}
-      <Table className={cn("border-solid border-l border-r border-dark-gray")}>
-        <TableHeader>
-          <TableRow isHeader>
-            {columns.map((column, i) => (
-              <EcTableHead
-                index={i}
-                columnsCount={columns.length}
-                key={column.id}
-                id={column.id}
-                sort={sort}
-                width={column.width}
-                setSort={column.sortFn || column.isServerSideSortable ? setSortHandler : undefined}
-                className={cn(column.className, column.headClassName)}
-                text={column.headerContent}
-              />
-            ))}
-          </TableRow>
-        </TableHeader>
-        <EcTableBody
-          className={textFormat}
-          onClick={onClick}
-          rowHeight={rowHeight}
-          minRows={minRows}
-          items={sorted}
-          columns={columns}
-          renderRow={renderRow}
-          getKey={getKey}
-          pagination={pagination}
-          isLoading={isLoading}
-          emptyText={emptyText}
-        />
-      </Table>
+      {/* Wrap the table to separate the scrollbar from the content, making the content scrollable while allowing the
+      parent div above to fill the entire table area rather than just the visible table area. */}
+      <div
+        className={cn("w-full")}
+        // Prevents scrollbar from appearing when there are empty rows
+        style={{ overflowY: items.length < minRows ? "hidden" : "auto" }}
+      >
+        <Table className={cn("border-solid border-l border-r border-dark-gray")}>
+          <TableHeader>
+            <TableRow isHeader>
+              {columns.map((column, i) => (
+                <EcTableHead
+                  index={i}
+                  columnsCount={columns.length}
+                  key={column.id}
+                  id={column.id}
+                  sort={sort}
+                  width={column.width}
+                  setSort={
+                    column.sortFn || column.isServerSideSortable ? setSortHandler : undefined
+                  }
+                  className={cn(column.className, column.headClassName)}
+                  text={column.headerContent}
+                />
+              ))}
+            </TableRow>
+          </TableHeader>
+          <EcTableBody
+            className={textFormat}
+            onClick={onClick}
+            rowHeight={rowHeight}
+            minRows={minRows}
+            items={sorted}
+            columns={columns}
+            renderRow={renderRow}
+            getKey={getKey}
+            pagination={pagination}
+            isLoading={isLoading}
+            emptyText={emptyText}
+          />
+        </Table>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The original implementation of the container for `EcTable.tsx` used an `absolute`-positioned overlay inside a `relative` container to show a loading or empty-state indicator over the table. However, this overlay was incorrectly constrained to the visible area of the scroll container. As a result, when users scrolled down, the overlay would not cover the full content height, making it appear broken or partially rendered.

An attempted fix used `position: fixed` to force the overlay to cover the full viewport. While this resolved the coverage issue, it introduced a new problem: the overlay detached from the table context and blocked the entire screen—including unrelated UI—effectively freezing interaction with the rest of the page, especially when no rows were rendered.

The final and correct fix restores `absolute` positioning but restructures the layout:

The scrollable content is moved to an inner div with overflow-y: auto.

The outer `relative` container allows the `absolute inset-0` overlay to span the full scrollable area, regardless of user scroll position.

The overlay itself uses `flex justify-center items-center` to center its contents, ensuring consistent layout whether showing a spinner or empty message.

This approach cleanly isolates scrolling behavior from overlay positioning and resolves both the visual and interaction bugs.