### PR TITLE
chore(ECO-3324): Bump frontend to 1.12.0 and SDK to 0.9.0

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -117,5 +117,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.11.0"
+  "version": "1.12.0"
 }

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -110,5 +110,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.8.0"
+  "version": "0.9.0"
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Very straightforward!

Bumps the frontend because of new features (info tooltip popups and dynamic integrator fees), same with SDK.

