### PR TITLE
chore(ECO-3330): Update environment variables for `ARENA` and `FAVORITE` module addresses on mainnet

### DIFF
--- a/src/typescript/example.mainnet.env
+++ b/src/typescript/example.mainnet.env
@@ -3,8 +3,8 @@
 # ---------------------------------------------------------------------------- #
 #                           Frontend feature flags
 # ---------------------------------------------------------------------------- #
-NEXT_PUBLIC_ARENA_ENABLED="false"
-NEXT_PUBLIC_FAVORITES_ENABLED="false"
+NEXT_PUBLIC_ARENA_ENABLED="true"
+NEXT_PUBLIC_FAVORITES_ENABLED="true"
 
 # Environment variables here are pre-populated to facilitate a quick setup.
 #
@@ -23,8 +23,8 @@ NEXT_PUBLIC_APTOS_NETWORK="mainnet"
 NEXT_PUBLIC_MODULE_ADDRESS="0xface729284ae5729100b3a9ad7f7cc025ea09739cd6e7252aff0beb53619cafe"
 NEXT_PUBLIC_REWARDS_MODULE_ADDRESS="0xbabe32dbe1cb44c30363894da9f49957d6e2b94a06f2fc5c20a9d1b9e54cface"
 NEXT_PUBLIC_INTEGRATOR_ADDRESS="0x99994f5124fa5cc95538217780cbfc01e4c4f842dfcc453890755b2ce4779999"
-NEXT_PUBLIC_ARENA_MODULE_ADDRESS="0x0" # Emojicoin arena is not on mainnet yet.
-NEXT_PUBLIC_FAVORITES_MODULE_ADDRESS="0x0" # Favorites module is not on mainnet yet.
+NEXT_PUBLIC_ARENA_MODULE_ADDRESS="0xbabe32dbe1cb44c30363894da9f49957d6e2b94a06f2fc5c20a9d1b9e54cface"
+NEXT_PUBLIC_FAVORITES_MODULE_ADDRESS="0xface729284ae5729100b3a9ad7f7cc025ea09739cd6e7252aff0beb53619cafe"
 
 # ---------------------------------------------------------------------------- #
 #                  Emojicoin indexer, broker, and allowlister


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

- [x] `ARENA` module address
- [x] `FAVORITES` module address
- [x] Also add `NEXT_PUBLIC_IS_FAVORITES_ENABLED`, or at least ensure it's everywhere it's supposed to be
- [x] Updated on Vercel, too

