### PR TITLE
fix(ECO-3340): Fix small width inconsistencies

### DIFF
--- a/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
+++ b/src/typescript/frontend/src/components/pages/emojicoin/components/main-info/MainInfo.tsx
@@ -186,7 +186,7 @@ const MainInfo = ({ data }: MainInfoProps) => {
         borderTop: `1px solid ${darkTheme.colors.darkGray}`,
       }}
     >
-      <div className="flex flex-col lg:grid gap-4 lg:gap-8 lg:grid-cols-[25fr_35fr_40fr] lg:py-5 py-10 px-0 w-full mx-[2vw] max-w-max">
+      <div className="flex flex-col lg:grid gap-4 lg:gap-8 lg:grid-cols-[25fr_35fr_40fr] lg:py-5 py-10 px-0 w-full mx-[2vw] max-w-[1362px]">
         <div className={`relative grid place-items-center text-center ${borderStyle}`}>
           <Link href={explorerLink} target="_blank">
             <Emoji className="display-2" emojis={data.emojis} />

--- a/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
+++ b/src/typescript/frontend/src/components/pages/pools/ClientPoolsPage.tsx
@@ -53,7 +53,7 @@ const ClientPoolsPage = ({ initialData }: { initialData: PoolsData[] }) => {
 
   return (
     <div className="flex flex-col justify-center items-center mt-[15px] border-y border-solid border-dark-gray">
-      <div className="w-full max-w-max mx-auto">
+      <div className="w-full max-w-max mx-auto xl:px-2">
         <div className="w-full px-8">
           <div className="flex-col-reverse md:flex-row justify-between flex px-3 w-full border-x border-solid border-dark-gray *:grow *:basis-0">
             <SearchBar />

--- a/src/typescript/frontend/tailwind.config.js
+++ b/src/typescript/frontend/tailwind.config.js
@@ -53,7 +53,7 @@ const tailwindConfig = {
   theme: {
     extend: {
       maxWidth: {
-        max: "1362px",
+        max: "1440px",
       },
       typography: {},
       fontFamily: {


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

- [x] Fixes small width inconsistencies on the pools page by using padding on large sizes instead of the improper max width.
- [x] Use the old max width for the `MainInfo.tsx`
- [x] This fixes the width inconsistency in the header/toolbar (since it was using 1362px instead of the proper 1440px)
