### PR TITLE
chore(ECO-3345): Bump the frontend version to 1.14.0

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -121,5 +121,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.13.0"
+  "version": "1.14.0"
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

- [x] Bump version up one minor version, due to the new PnL sharing features

The SDK does not need to be bumped because nothing changed since the last release.
