### PR TITLE
chore(ECO-3357): Bump frontend to 1.14.1 and SDK to 0.11.0

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -121,5 +121,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.14.0"
+  "version": "1.14.1"
 }

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -110,5 +110,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.10.0"
+  "version": "0.11.0"
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Mostly fixes, but the SDK has a few changes in its APIs, so it gets a major bump.

Frontend gets a minor.
