### PR TITLE
chore(ECO-3365): Update indexer SDK PR to use latest version of the processor

### DIFF
--- a/src/rust/processor/src/db/common/models/default/mod.rs
+++ b/src/rust/processor/src/db/common/models/default/mod.rs
@@ -1,0 +1,1 @@
+pub mod models;

--- a/src/rust/processor/src/db/common/models/default/models/mod.rs
+++ b/src/rust/processor/src/db/common/models/default/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod move_resources;

--- a/src/rust/processor/src/db/common/models/default/models/move_resources.rs
+++ b/src/rust/processor/src/db/common/models/default/models/move_resources.rs
@@ -1,0 +1,160 @@
+// This file is a partial copy of the Aptos indexer SDK `move_resources.rs`:
+// https://github.com/aptos-labs/aptos-indexer-processors-v2/blob/main/processor/src/processors/default/models/move_resources.rs
+
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::extra_unused_lifetimes)]
+
+use anyhow::{Context, Result};
+use aptos_indexer_processor_sdk::{
+    aptos_protos::transaction::v1::{
+        DeleteResource, MoveStructTag as MoveStructTagPB, WriteResource,
+    },
+    utils::convert::standardize_address,
+};
+use serde::{Deserialize, Serialize};
+
+/**
+ * This is the base MoveResource model struct which should be used to build all other extended models such as
+ * ParquetMoveResource, PostgresMoveResource, etc.
+ * In order for this to work with old code, columns names should be kept the same as the old model.
+ */
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MoveResource {
+    pub txn_version: i64,
+    pub write_set_change_index: i64,
+    pub block_height: i64,
+    pub fun: String,
+    pub resource_type: String,
+    pub resource_address: String,
+    pub module: String,
+    pub generic_type_params: Option<serde_json::Value>,
+    pub data: Option<serde_json::Value>,
+    pub is_deleted: bool,
+    pub state_key_hash: String,
+}
+
+pub struct MoveStructTag {
+    resource_address: String,
+    pub module: String,
+    pub fun: String,
+    pub generic_type_params: Option<serde_json::Value>,
+}
+
+impl MoveResource {
+    pub fn from_write_resource(
+        write_resource: &WriteResource,
+        write_set_change_index: i64,
+        txn_version: i64,
+        block_height: i64,
+    ) -> Result<Option<Self>> {
+        if let Some(move_struct_tag) = write_resource.r#type.as_ref() {
+            let parsed_data = Self::convert_move_struct_tag(move_struct_tag);
+
+            let move_resource = Self {
+                txn_version,
+                block_height,
+                write_set_change_index,
+                fun: parsed_data.fun.clone(),
+                resource_type: write_resource.type_str.clone(),
+                resource_address: standardize_address(&write_resource.address.to_string()),
+                module: parsed_data.module.clone(),
+                generic_type_params: parsed_data.generic_type_params,
+                data: serde_json::from_str(write_resource.data.as_str()).ok(),
+                is_deleted: false,
+                state_key_hash: standardize_address(
+                    hex::encode(write_resource.state_key_hash.as_slice()).as_str(),
+                ),
+            };
+            Ok(Some(move_resource))
+        } else {
+            Err(anyhow::anyhow!(
+                "MoveStructTag Does Not Exist for {}",
+                txn_version
+            ))
+        }
+    }
+
+    pub fn from_delete_resource(
+        delete_resource: &DeleteResource,
+        write_set_change_index: i64,
+        txn_version: i64,
+        block_height: i64,
+    ) -> Result<Option<Self>> {
+        if let Some(move_struct_tag) = delete_resource.r#type.as_ref() {
+            let parsed_data = Self::convert_move_struct_tag(move_struct_tag);
+
+            let move_resource = Self {
+                txn_version,
+                block_height,
+                write_set_change_index,
+                fun: parsed_data.fun.clone(),
+                resource_type: delete_resource.type_str.clone(),
+                resource_address: standardize_address(&delete_resource.address.to_string()),
+                module: parsed_data.module.clone(),
+                generic_type_params: parsed_data.generic_type_params,
+                data: None,
+                is_deleted: true,
+                state_key_hash: standardize_address(
+                    hex::encode(delete_resource.state_key_hash.as_slice()).as_str(),
+                ),
+            };
+            Ok(Some(move_resource))
+        } else {
+            Err(anyhow::anyhow!(
+                "MoveStructTag Does Not Exist for {}",
+                txn_version
+            ))
+        }
+    }
+
+    pub fn get_outer_type_from_write_resource(write_resource: &WriteResource) -> String {
+        let move_struct_tag =
+            Self::convert_move_struct_tag(write_resource.r#type.as_ref().unwrap());
+
+        format!(
+            "{}::{}::{}",
+            move_struct_tag.get_address(),
+            move_struct_tag.module,
+            move_struct_tag.fun,
+        )
+    }
+
+    pub fn get_outer_type_from_delete_resource(delete_resource: &DeleteResource) -> String {
+        let move_struct_tag =
+            Self::convert_move_struct_tag(delete_resource.r#type.as_ref().unwrap());
+
+        format!(
+            "{}::{}::{}",
+            move_struct_tag.get_address(),
+            move_struct_tag.module,
+            move_struct_tag.fun,
+        )
+    }
+
+    // TODO: Check if this has to be within MoveResource implementation or not
+    pub fn convert_move_struct_tag(struct_tag: &MoveStructTagPB) -> MoveStructTag {
+        MoveStructTag {
+            resource_address: standardize_address(struct_tag.address.as_str()),
+            module: struct_tag.module.to_string(),
+            fun: struct_tag.name.to_string(),
+            generic_type_params: struct_tag
+                .generic_type_params
+                .iter()
+                .map(|move_type| -> Result<Option<serde_json::Value>> {
+                    Ok(Some(
+                        serde_json::to_value(move_type).context("Failed to parse move type")?,
+                    ))
+                })
+                .collect::<Result<Option<serde_json::Value>>>()
+                .unwrap_or(None),
+        }
+    }
+}
+
+impl MoveStructTag {
+    pub fn get_address(&self) -> String {
+        standardize_address(self.resource_address.as_str())
+    }
+}

--- a/src/rust/processor/src/db/common/models/emojicoin_models/constants.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/constants.rs
@@ -68,20 +68,3 @@ lazy_static! {
 
 // When a market is first registered, the market_nonce field is emitted in the resulting events as 1.
 pub const INITIAL_MARKET_NONCE: u64 = 1;
-
-#[cfg(test)]
-mod tests {
-    use crate::utils::util::standardize_address;
-
-    #[test]
-    fn ensure_module_address_is_standardized() {
-        if standardize_address(env!("EMOJICOIN_MODULE_ADDRESS")) != env!("EMOJICOIN_MODULE_ADDRESS")
-        {
-            panic!(
-                "The non-standardized module address: {} is invalid because it doesn't match the standardized address: {}",
-                env!("EMOJICOIN_MODULE_ADDRESS"),
-                standardize_address(env!("EMOJICOIN_MODULE_ADDRESS"))
-            );
-        }
-    }
-}

--- a/src/rust/processor/src/db/common/models/emojicoin_models/constants.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/constants.rs
@@ -74,11 +74,11 @@ mod tests {
     use crate::utils::util::standardize_address;
 
     #[test]
-    fn ensure_contract_address_is_standardized() {
+    fn ensure_module_address_is_standardized() {
         if standardize_address(env!("EMOJICOIN_MODULE_ADDRESS")) != env!("EMOJICOIN_MODULE_ADDRESS")
         {
             panic!(
-                "The non-standardized contract address: {} is invalid because it doesn't match the standardized address: {}",
+                "The non-standardized module address: {} is invalid because it doesn't match the standardized address: {}",
                 env!("EMOJICOIN_MODULE_ADDRESS"),
                 standardize_address(env!("EMOJICOIN_MODULE_ADDRESS"))
             );

--- a/src/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -189,7 +189,7 @@ pub enum EmojicoinDbEvent {
     ArenaExit(ArenaExitEventModel),
     ArenaSwap(ArenaSwapEventModel),
     ArenaVaultBalanceUpdate(ArenaVaultBalanceUpdateEventModel),
-    // Not an actual event in the contract- but is sent to the broker.
+    // Not an actual event in the Move module- but is sent to the broker.
     ArenaCandlestick(ArenaCandlestickModel),
     Candlestick(CandlestickModel),
 }
@@ -224,7 +224,7 @@ pub enum EmojicoinDbEventType {
     ArenaExit,
     ArenaSwap,
     ArenaVaultBalanceUpdate,
-    // Not an actual event in the contract- but is sent to the broker.
+    // Not an actual event in the Move module- but is sent to the broker.
     ArenaCandlestick,
     Candlestick,
 }

--- a/src/rust/processor/src/db/common/models/emojicoin_models/enums.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/enums.rs
@@ -69,8 +69,7 @@ where
     match Trigger::from_i16(trigger) {
         Some(trigger) => Ok(trigger),
         None => Err(D::Error::custom(format!(
-            "Failed to deserialize Trigger from i16: {}",
-            trigger
+            "Failed to deserialize Trigger from i16: {trigger}"
         ))),
     }
 }
@@ -131,8 +130,7 @@ where
         "14400000000" => Ok(Period::FourHours),
         "86400000000" => Ok(Period::OneDay),
         _ => Err(D::Error::custom(format!(
-            "Failed to deserialize PeriodType from string: {}",
-            period
+            "Failed to deserialize PeriodType from string: {period}"
         ))),
     }
 }

--- a/src/rust/processor/src/db/common/models/emojicoin_models/event_utils.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/event_utils.rs
@@ -79,7 +79,7 @@ impl EventGroupBuilder {
         if event.get_market_id() != self.market_id || event.get_market_nonce() != self.market_nonce
         {
             let msg = "EventGroupBuilder can only have one market_id and market_nonce.";
-            panic!("{} New event: {:?} Initial event: {:?}", msg, event, self);
+            panic!("{msg} New event: {event:?} Initial event: {self:?}");
         }
         match event {
             EventWithMarket::MarketRegistration(e) => {

--- a/src/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/json_types.rs
@@ -634,8 +634,7 @@ impl EventWithMarket {
             _ => Ok(None),
         }
         .context(format!(
-            "version {} failed! Failed to parse type {}, with data: {:?}",
-            txn_version, event_type, data,
+            "version {txn_version} failed! Failed to parse type {event_type}, with data: {data:?}",
         ))
     }
 }
@@ -681,8 +680,7 @@ impl ArenaEvent {
             _ => Ok(None),
         }
         .context(format!(
-            "version {} failed! Failed to parse type {}, with data: {:?}",
-            txn_version, event_type, data,
+            "version {txn_version} failed! Failed to parse type {event_type}, with data: {data:?}",
         ))
     }
 }
@@ -700,8 +698,7 @@ impl GlobalStateEvent {
             _ => Ok(None),
         }
         .context(format!(
-            "version {} failed! Failed to parse type {}, with data: {:?}",
-            txn_version, event_type, data,
+            "version {txn_version} failed! Failed to parse type {event_type}, with data: {data:?}",
         ))
     }
 }

--- a/src/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/models/user_liquidity_pools.rs
@@ -1,23 +1,25 @@
 use super::liquidity_event::LiquidityEventModel;
 use crate::{
-    db::common::models::emojicoin_models::{
-        enums, parsers::emojis::parser::symbol_bytes_to_emojis,
+    db::common::models::{
+        emojicoin_models::{
+            enums,
+            parsers::emojis::parser::symbol_bytes_to_emojis,
+            utils::{to_lp_coin_type, to_lp_primary_store_address},
+        },
+        fungible_asset::{
+            coin_models::coin_utils::{CoinInfoType, CoinResource},
+            fungible_asset_models::v2_fungible_asset_utils::FungibleAssetStore,
+        },
     },
     schema::user_liquidity_pools,
 };
 use aptos_indexer_processor_sdk::{
-    aptos_protos::transaction::v1::{write_set_change::Change, Transaction},
+    aptos_protos::transaction::v1::{write_set_change::Change, Transaction, WriteResource},
     utils::convert::standardize_address,
 };
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
-use once_cell::sync::Lazy;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
-
-static ADDRESSES_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new("^0x0*1::coin::CoinStore<(0x[^:]*)::coin_factory::EmojicoinLP>$").unwrap()
-});
 
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(provider, market_nonce))]
@@ -46,30 +48,73 @@ pub struct UserLiquidityPoolsModel {
     pub lp_coin_balance: BigDecimal,
 }
 
+fn get_lp_coin_balance(
+    write_resource: &WriteResource,
+    txn_version: i64,
+    wsc_index: i64,
+    lp_coin_type: &str,
+) -> Option<BigDecimal> {
+    CoinResource::from_write_resource(write_resource, txn_version)
+        .ok()
+        .flatten()
+        .and_then(|resource| match resource {
+            CoinResource::CoinStoreResource(store) => CoinInfoType::from_move_type(
+                &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
+                write_resource.type_str.as_ref(),
+                txn_version,
+                wsc_index,
+            )
+            .get_coin_type_below_max()
+            .and_then(|coin_type| {
+                if coin_type == lp_coin_type {
+                    Some(store.coin.value)
+                } else {
+                    None
+                }
+            }),
+            _ => None,
+        })
+}
+
+fn get_lp_fungible_asset_balance(
+    write_resource: &WriteResource,
+    lp_primary_store_address: &str,
+) -> Option<BigDecimal> {
+    FungibleAssetStore::try_from(write_resource)
+        .ok()
+        .and_then(|resource| {
+            if standardize_address(write_resource.address.as_str()) == lp_primary_store_address {
+                Some(resource.balance)
+            } else {
+                None
+            }
+        })
+}
+
 impl UserLiquidityPoolsModel {
-    pub fn from_event_and_writeset(
-        txn: &Transaction,
-        evt: LiquidityEventModel,
-        market_address: &str,
-    ) -> Self {
+    pub fn from_event_and_writeset(txn: &Transaction, evt: LiquidityEventModel) -> Self {
+        let lp_coin_type = to_lp_coin_type(&evt.market_address);
+        let lp_primary_store_address =
+            to_lp_primary_store_address(&evt.market_address, &evt.provider);
         txn.info
             .as_ref()
             .expect("Transaction info should exist.")
             .changes
             .iter()
-            .find_map(|wsc| {
-                if let Change::WriteResource(write) = &wsc.change.as_ref().unwrap() {
-                    if !ADDRESSES_REGEX.is_match(&write.type_str) {
-                        return None;
-                    }
-                    let caps = ADDRESSES_REGEX.captures(&write.type_str)?;
-                    if standardize_address(&caps[1]) == standardize_address(market_address) {
-                        let Ok(data) = serde_json::from_str::<serde_json::Value>(&write.data)
-                        else {
-                            return None;
-                        };
-                        let amount = data["coin"]["value"].as_str()?;
-                        Some(UserLiquidityPoolsModel {
+            .enumerate()
+            .find_map(|(wsc_index, wsc)| {
+                if let Change::WriteResource(write_resource) = &wsc.change.as_ref().unwrap() {
+                    let txn_version = txn.version as i64;
+                    get_lp_fungible_asset_balance(write_resource, lp_primary_store_address.as_str())
+                        .or_else(|| {
+                            get_lp_coin_balance(
+                                write_resource,
+                                txn_version,
+                                wsc_index as i64,
+                                lp_coin_type.as_str(),
+                            )
+                        })
+                        .map(|lp_coin_balance| UserLiquidityPoolsModel {
                             provider: evt.provider.clone(),
                             transaction_version: evt.transaction_version,
                             transaction_timestamp: evt.transaction_timestamp,
@@ -85,16 +130,13 @@ impl UserLiquidityPoolsModel {
                             liquidity_provided: evt.liquidity_provided,
                             base_donation_claim_amount: evt.base_donation_claim_amount.clone(),
                             quote_donation_claim_amount: evt.quote_donation_claim_amount.clone(),
-                            lp_coin_balance: amount.parse().unwrap(),
+                            lp_coin_balance,
                             market_address: evt.market_address.clone(),
                         })
-                    } else {
-                        None
-                    }
                 } else {
                     None
                 }
             })
-            .expect("LP coin change should exist.")
+            .expect("LP coin/FA balance change should be in the writeset.")
     }
 }

--- a/src/rust/processor/src/db/common/models/emojicoin_models/tests.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/tests.rs
@@ -1,8 +1,14 @@
 #[cfg(test)]
 mod json_tests {
-    use crate::db::common::models::emojicoin_models::{
-        enums::Trigger,
-        json_types::{EventWithMarket, GlobalStateEvent},
+    use crate::db::common::models::{
+        emojicoin_models::{
+            enums::Trigger,
+            json_types::{EventWithMarket, GlobalStateEvent},
+            utils::{to_lp_coin_type, to_lp_primary_store_address},
+        },
+        fungible_asset_models::v2_fungible_asset_balances::{
+            get_paired_metadata_address, get_primary_fungible_store_address,
+        },
     };
 
     #[test]
@@ -227,7 +233,8 @@ mod json_tests {
               "market_id": "2304"
             },
             "registrant": "0xbad225596d685895aa64d92f4f0e14d2f9d8075d3b8adf1e90ae6037f1fcbabe",
-            "time": "1723253654764692"
+            "time": "1723253654764692",
+            "event_index": "1"
           }
         "#;
 
@@ -327,5 +334,127 @@ mod json_tests {
                 panic!("Failed to parse global state event: {:?}", e);
             }
         }
+    }
+
+    #[test]
+    fn test_fungible_store_address() {
+        // All of these values are copied directly from the writeset changes in the explorer after
+        // a real transaction for a liquidity event on localnet.
+        let metadata_address = "0xf4c801d6592ecf9c24bfe60b505913576ff8e7b12937adb41b0e37e1b4a11a8d";
+        assert_eq!(get_paired_metadata_address("0x58f40ecd236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e44::coin_factory::EmojicoinLP"),
+      metadata_address);
+        let expected_fungible_store_address: &'static str =
+            "0xc6e60ab1124a56340889861289be47b1cf6f62f5ce0e4ba6871d8400ef0b712e";
+        let owner_address = "0x5048c88ba0ab78f78f4da8d2c3c3a35078315a79e28f8e223c1522761d0eec64";
+        assert_eq!(
+            get_primary_fungible_store_address(owner_address, metadata_address)
+                .expect("Should be able to create a primary store address"),
+            expected_fungible_store_address
+        );
+    }
+
+    #[test]
+    fn test_to_lp_coin_type() {
+        let market_address = "0x58f40ecd236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e44";
+        let lp_coin_type = to_lp_coin_type(market_address);
+        assert_eq!(lp_coin_type, "0x58f40ecd236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e44::coin_factory::EmojicoinLP");
+    }
+
+    #[test]
+    fn test_to_lp_coin_type_leading_zero() {
+        let market_address = "0x00000000236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e44";
+        let lp_coin_type = to_lp_coin_type(market_address);
+        assert_eq!(
+            lp_coin_type,
+            "0x236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e44::coin_factory::EmojicoinLP"
+        );
+    }
+
+    #[test]
+    fn test_to_lp_coin_type_trailing_zero() {
+        let market_address = "0x58f40ecd236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e00";
+        let lp_coin_type = to_lp_coin_type(market_address);
+        assert_eq!(lp_coin_type, "0x58f40ecd236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e00::coin_factory::EmojicoinLP");
+    }
+
+    #[test]
+    fn test_to_lp_primary_fungible_store_address() {
+        let market_address = "0x58f40ecd236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e44";
+        let owner_address = "0x5048c88ba0ab78f78f4da8d2c3c3a35078315a79e28f8e223c1522761d0eec64";
+        let expected_fungible_store_address =
+            "0xc6e60ab1124a56340889861289be47b1cf6f62f5ce0e4ba6871d8400ef0b712e";
+        assert_eq!(
+            to_lp_primary_store_address(market_address, owner_address),
+            expected_fungible_store_address
+        );
+    }
+
+    // Uses the same inputs as the other fungible store tests, but with the leading zero included
+    // in the market address.
+    #[test]
+    fn test_primary_store_with_leading_zero() {
+        let market_address = "0x058f40ecd236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e44";
+        let owner_address = "0x5048c88ba0ab78f78f4da8d2c3c3a35078315a79e28f8e223c1522761d0eec64";
+        let expected_fungible_store_address =
+            "0xc6e60ab1124a56340889861289be47b1cf6f62f5ce0e4ba6871d8400ef0b712e";
+        assert_eq!(
+            to_lp_primary_store_address(market_address, owner_address),
+            expected_fungible_store_address
+        );
+    }
+
+    #[test]
+    fn test_sdk_leading_zeros_inputs() {
+        let leading_zero_market_address =
+            "0x058f40ecd236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e44";
+        let no_leading_zero_market_address =
+            "0x58f40ecd236f430c28e30699bf8a7f478c6e4efe9c6d6a2227a86f41e1f0e44";
+        let owner_address = "0x5048c88ba0ab78f78f4da8d2c3c3a35078315a79e28f8e223c1522761d0eec64";
+        assert_eq!(
+            to_lp_coin_type(leading_zero_market_address),
+            to_lp_coin_type(no_leading_zero_market_address),
+        );
+        assert_eq!(
+            to_lp_primary_store_address(no_leading_zero_market_address, owner_address),
+            to_lp_primary_store_address(leading_zero_market_address, owner_address),
+        );
+        // Ensure they all work with owner addresses with/without leading zeros, too.
+        assert_eq!(
+            to_lp_primary_store_address(leading_zero_market_address, "0x012345"),
+            to_lp_primary_store_address(leading_zero_market_address, "0x12345"),
+        );
+        assert_eq!(
+            to_lp_primary_store_address(no_leading_zero_market_address, "0x012345"),
+            to_lp_primary_store_address(no_leading_zero_market_address, "0x12345"),
+        );
+        // Redundant, but just to be sure, exhaustively ensure equality.
+        assert_eq!(
+            to_lp_primary_store_address(leading_zero_market_address, "0x012345"),
+            to_lp_primary_store_address(no_leading_zero_market_address, "0x012345"),
+        );
+    }
+
+    #[test]
+    fn test_all_leading_zero_addresses() {
+        let market_address = "0x0321cb335a38022848c39372c7b3894e41c39c57aac613ac240824081a644630";
+        let coin_type = to_lp_coin_type(market_address);
+        let metadata_address = "0x01e8cdb38d8ddd7263aa019daa1ed57f591a5afa81d80b7764865c1b035b433c";
+        let owner_address = "0x029665e58596cb0b1e7e1efb033d4371505aa26ee3a47c21ae4462098207d6c0";
+        let primary_store_address =
+            "0x0be8f6131ed4c8b8417eee3b5cf3f87012649b626451f01dd3d6c377a33753ea";
+
+        assert_eq!(
+            get_paired_metadata_address(coin_type.as_str()),
+            metadata_address,
+        );
+        assert_eq!(
+            get_primary_fungible_store_address(owner_address, metadata_address)
+                .expect("Should be able to get the primary store address."),
+            primary_store_address,
+        );
+        assert_eq!(
+            to_lp_primary_store_address(market_address, owner_address),
+            primary_store_address,
+        );
     }
 }

--- a/src/rust/processor/src/db/common/models/emojicoin_models/tests.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/tests.rs
@@ -6,7 +6,7 @@ mod json_tests {
             json_types::{EventWithMarket, GlobalStateEvent},
             utils::{to_lp_coin_type, to_lp_primary_store_address},
         },
-        fungible_asset_models::v2_fungible_asset_balances::{
+        fungible_asset::fungible_asset_models::v2_fungible_asset_balances::{
             get_paired_metadata_address, get_primary_fungible_store_address,
         },
     };

--- a/src/rust/processor/src/db/common/models/emojicoin_models/utils.rs
+++ b/src/rust/processor/src/db/common/models/emojicoin_models/utils.rs
@@ -1,6 +1,11 @@
+use aptos_indexer_processor_sdk::utils::convert::standardize_address;
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, NaiveDateTime};
 use num::ToPrimitive;
+
+use crate::db::common::models::fungible_asset::fungible_asset_models::v2_fungible_asset_balances::{
+    get_paired_metadata_address, get_primary_fungible_store_address,
+};
 
 pub fn micros_to_naive_datetime(microseconds: &BigDecimal) -> NaiveDateTime {
     // There should be no truncation issues for almost ~300,000 years.
@@ -15,4 +20,34 @@ pub fn within_past_day(time: NaiveDateTime) -> bool {
     let one_day_ago = chrono::Utc::now() - chrono::Duration::hours(24);
 
     time.and_utc() > one_day_ago
+}
+
+// Since we are relying on serialization from within the VM to get derived fungible asset addresses,
+// we must use the same serialization functions for addresses.
+// In this case, `fungible_asset.move` uses `type_info::type_name`, a native function that you can
+// see here: https://github.com/aptos-labs/aptos-core/blob/c6e47d9b896580f3ff63b2a99ae8ea7f9adbdb2d/aptos-move/framework/src/natives/type_info.rs#L95
+// This ultimately leads here:
+// https://github.com/aptos-labs/aptos-core/blob/c6e47d9b896580f3ff63b2a99ae8ea7f9adbdb2d/third_party/move/move-core/types/src/language_storage.rs#L400
+// where struct tags are formatted into a string with `short_str_lossless`.
+// Ultimately, `short_str_lossless` simply removes leading zeros and ensures there's a prepended
+// `0x` at the beginning of the hex string.
+pub fn to_lp_coin_type(market_address: &str) -> String {
+    let lossless_address = market_address
+        .trim_start_matches("0x")
+        .trim_start_matches("0");
+    format!("0x{lossless_address}::coin_factory::EmojicoinLP")
+}
+
+// Note that `market_address` is standardized to the lossless format in `to_lp_coin_type`.
+// `owner_address` is standardized within this function, so neither arguments need to be standard
+// representations of addresses; they simply need to be valid address strings.
+pub fn to_lp_primary_store_address(market_address: &str, owner_address: &str) -> String {
+    let lp_coin_type = &to_lp_coin_type(market_address);
+    let metadata_address = get_paired_metadata_address(lp_coin_type);
+    let owner_address_standardized = standardize_address(owner_address);
+    get_primary_fungible_store_address(
+        owner_address_standardized.as_str(),
+        metadata_address.as_str(),
+    )
+    .expect("Should be able to get the primary fungible store address")
 }

--- a/src/rust/processor/src/db/common/models/fungible_asset/coin_models/coin_utils.rs
+++ b/src/rust/processor/src/db/common/models/fungible_asset/coin_models/coin_utils.rs
@@ -1,0 +1,369 @@
+// This file is a copy of the Aptos indexer SDK `coin_utils.rs`:
+// https://github.com/aptos-labs/aptos-indexer-processors-v2/blob/main/processor/src/processors/fungible_asset/coin_models/coin_utils.rs
+
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+
+use anyhow::{bail, Context, Result};
+use aptos_indexer_processor_sdk::{
+    aptos_protos::transaction::v1::{move_type::Content, DeleteResource, MoveType, WriteResource},
+    utils::{
+        convert::{deserialize_from_string, standardize_address, truncate_str},
+        extract::hash_str,
+    },
+};
+use bigdecimal::BigDecimal;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use tracing::error;
+
+use crate::db::common::models::default::models::move_resources::MoveResource;
+
+const COIN_ADDR: &str = "0x0000000000000000000000000000000000000000000000000000000000000001";
+const COIN_TYPE_HASH_LENGTH: usize = 5000;
+const COIN_TYPE_MAX: usize = 1000;
+
+/**
+ * This file defines deserialized coin types as defined in our 0x1 contracts.
+ */
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoinInfoResource {
+    name: String,
+    symbol: String,
+    pub decimals: i32,
+    pub supply: OptionalAggregatorWrapperResource,
+}
+
+impl CoinInfoResource {
+    pub fn get_name_trunc(&self) -> String {
+        truncate_str(&self.name, 32)
+    }
+
+    pub fn get_symbol_trunc(&self) -> String {
+        truncate_str(&self.symbol, 32)
+    }
+
+    /// Getting the table item location of the supply aggregator
+    pub fn get_aggregator_metadata(&self) -> Option<AggregatorResource> {
+        if let Some(inner) = self.supply.vec.first() {
+            inner.aggregator.get_aggregator_metadata()
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct OptionalAggregatorWrapperResource {
+    pub vec: Vec<OptionalAggregatorResource>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct OptionalAggregatorResource {
+    pub aggregator: AggregatorWrapperResource,
+    pub integer: IntegerWrapperResource,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AggregatorWrapperResource {
+    pub vec: Vec<AggregatorResource>,
+}
+
+impl AggregatorWrapperResource {
+    /// In case we do want to track supply
+    pub fn get_aggregator_metadata(&self) -> Option<AggregatorResource> {
+        self.vec.first().cloned()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IntegerWrapperResource {
+    pub vec: Vec<IntegerResource>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AggregatorResource {
+    pub handle: String,
+    pub key: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IntegerResource {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub value: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoinStoreResource {
+    pub coin: Coin,
+    pub deposit_events: DepositEventResource,
+    pub withdraw_events: WithdrawEventResource,
+    pub frozen: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Coin {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub value: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DepositEventResource {
+    pub guid: EventGuidResourceWrapper,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WithdrawEventResource {
+    pub guid: EventGuidResourceWrapper,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EventGuidResourceWrapper {
+    pub id: EventGuidResource,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, Eq, PartialEq)]
+pub struct EventGuidResource {
+    pub addr: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub creation_num: i64,
+}
+
+impl EventGuidResource {
+    pub fn get_address(&self) -> String {
+        standardize_address(&self.addr)
+    }
+
+    pub fn get_standardized(&self) -> Self {
+        Self {
+            addr: self.get_address(),
+            creation_num: self.creation_num,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WithdrawCoinEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DepositCoinEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WithdrawCoinEventV2 {
+    pub coin_type: String,
+    pub account: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DepositCoinEventV2 {
+    pub coin_type: String,
+    pub account: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: BigDecimal,
+}
+
+pub struct CoinInfoType {
+    coin_type: String,
+    creator_address: String,
+}
+
+static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(<(.*)>)").unwrap());
+
+static COIN_RESOURCES: Lazy<[String; 2]> = Lazy::new(|| {
+    [
+        format!("{COIN_ADDR}::coin::CoinInfo"),
+        format!("{COIN_ADDR}::coin::CoinStore"),
+    ]
+});
+
+impl CoinInfoType {
+    /// get creator address from move_type, and get coin type from move_type_str
+    /// Since move_type_str will contain things we don't need, e.g. 0x1::coin::CoinInfo<T>. We will use
+    /// regex to extract T.
+    pub fn from_move_type(
+        move_type: &MoveType,
+        move_type_str: &str,
+        txn_version: i64,
+        wsc_index: i64,
+    ) -> Self {
+        if let Content::Struct(struct_tag) = move_type.content.as_ref().unwrap() {
+            let matched = RE.captures(move_type_str).unwrap_or_else(|| {
+                error!(
+                    txn_version = txn_version,
+                    move_type_str = move_type_str,
+                    wsc_index = wsc_index,
+                    "move_type should look like 0x1::coin::CoinInfo<T>"
+                );
+                panic!();
+            });
+            let coin_type = matched.get(2).unwrap().as_str();
+            Self {
+                coin_type: coin_type.to_string(),
+                creator_address: struct_tag.address.clone(),
+            }
+        } else {
+            error!(txn_version = txn_version, move_type = ?move_type, "Expected struct tag");
+            panic!();
+        }
+    }
+
+    pub fn get_creator_address(&self) -> String {
+        standardize_address(&self.creator_address)
+    }
+
+    pub fn to_hash(&self) -> String {
+        hash_str(&self.coin_type.to_string())
+    }
+
+    pub fn get_coin_type_trunc(&self) -> String {
+        truncate_str(&self.coin_type, COIN_TYPE_HASH_LENGTH)
+    }
+
+    pub fn get_coin_type_below_max(&self) -> Option<String> {
+        if self.coin_type.len() > COIN_TYPE_MAX {
+            None
+        } else {
+            Some(self.coin_type.clone())
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum CoinResource {
+    CoinInfoResource(CoinInfoResource),
+    CoinStoreResource(CoinStoreResource),
+    CoinInfoDeletion,
+    CoinStoreDeletion,
+}
+
+impl CoinResource {
+    pub fn is_resource_supported(data_type: &str) -> bool {
+        COIN_RESOURCES.contains(&data_type.to_string())
+    }
+
+    pub fn from_resource(
+        data_type: &str,
+        data: &serde_json::Value,
+        txn_version: i64,
+    ) -> Result<CoinResource> {
+        match data_type {
+            x if x == format!("{COIN_ADDR}::coin::CoinInfo") => {
+                serde_json::from_value(data.clone())
+                    .map(|inner| Some(CoinResource::CoinInfoResource(inner)))
+            },
+            x if x == format!("{COIN_ADDR}::coin::CoinStore") => {
+                serde_json::from_value(data.clone())
+                    .map(|inner| Some(CoinResource::CoinStoreResource(inner)))
+            },
+            _ => Ok(None),
+        }
+        .context(format!(
+            "version {txn_version} failed! failed to parse type {data_type}, data {data:?}"
+        ))?
+        .context(format!(
+            "Resource unsupported! Call is_resource_supported first. version {txn_version} type {data_type}"
+        ))
+    }
+
+    fn from_delete_resource_internal(data_type: &str, txn_version: i64) -> Result<CoinResource> {
+        match data_type {
+            x if x == format!("{COIN_ADDR}::coin::CoinInfo") => Ok(CoinResource::CoinInfoDeletion),
+            x if x == format!("{COIN_ADDR}::coin::CoinStore") => {
+                Ok(CoinResource::CoinStoreDeletion)
+            }
+            _ => bail!(
+                "Resource unsupported! Call is_resource_supported first. version {} type {}",
+                txn_version,
+                data_type
+            ),
+        }
+    }
+
+    pub fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+    ) -> Result<Option<CoinResource>> {
+        let type_str = MoveResource::get_outer_type_from_write_resource(write_resource);
+        if !CoinResource::is_resource_supported(type_str.as_str()) {
+            return Ok(None);
+        }
+        let resource = match MoveResource::from_write_resource(
+            write_resource,
+            0, // Placeholder, this isn't used anyway
+            txn_version,
+            0, // Placeholder, this isn't used anyway
+        ) {
+            Ok(Some(res)) => res,
+            Ok(None) => {
+                error!("No resource found for transaction version {}", txn_version);
+                return Ok(None);
+            }
+            Err(e) => {
+                error!("Error processing write resource: {}", e);
+                return Err(anyhow::anyhow!("Error processing write resource: {}", e));
+            }
+        };
+        Ok(Some(Self::from_resource(
+            &type_str,
+            resource.data.as_ref().unwrap(),
+            txn_version,
+        )?))
+    }
+
+    pub fn from_delete_resource(
+        delete_resource: &DeleteResource,
+        txn_version: i64,
+    ) -> Result<Option<CoinResource>> {
+        let type_str = MoveResource::get_outer_type_from_delete_resource(delete_resource);
+        if !CoinResource::is_resource_supported(type_str.as_str()) {
+            return Ok(None);
+        }
+        Ok(Some(Self::from_delete_resource_internal(
+            &type_str,
+            txn_version,
+        )?))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum CoinEvent {
+    WithdrawCoinEvent(WithdrawCoinEvent),
+    DepositCoinEvent(DepositCoinEvent),
+    WithdrawCoinEventV2(WithdrawCoinEventV2),
+    DepositCoinEventV2(DepositCoinEventV2),
+}
+
+impl CoinEvent {
+    pub fn from_event(data_type: &str, data: &str, txn_version: i64) -> Result<Option<CoinEvent>> {
+        match data_type {
+            "0x1::coin::WithdrawEvent" => {
+                serde_json::from_str(data).map(|inner| Some(CoinEvent::WithdrawCoinEvent(inner)))
+            }
+            "0x1::coin::DepositEvent" => {
+                serde_json::from_str(data).map(|inner| Some(CoinEvent::DepositCoinEvent(inner)))
+            }
+            "0x1::coin::CoinWithdraw" => {
+                serde_json::from_str(data).map(|inner| Some(CoinEvent::WithdrawCoinEventV2(inner)))
+            }
+            "0x1::coin::CoinDeposit" => {
+                serde_json::from_str(data).map(|inner| Some(CoinEvent::DepositCoinEventV2(inner)))
+            }
+            _ => Ok(None),
+        }
+        .context(format!(
+            "version {txn_version} failed! failed to parse type {data_type}, data {data:?}"
+        ))
+    }
+}

--- a/src/rust/processor/src/db/common/models/fungible_asset/coin_models/mod.rs
+++ b/src/rust/processor/src/db/common/models/fungible_asset/coin_models/mod.rs
@@ -1,0 +1,1 @@
+pub mod coin_utils;

--- a/src/rust/processor/src/db/common/models/fungible_asset/fungible_asset_models/mod.rs
+++ b/src/rust/processor/src/db/common/models/fungible_asset/fungible_asset_models/mod.rs
@@ -1,0 +1,2 @@
+pub mod v2_fungible_asset_balances;
+pub mod v2_fungible_asset_utils;

--- a/src/rust/processor/src/db/common/models/fungible_asset/fungible_asset_models/v2_fungible_asset_balances.rs
+++ b/src/rust/processor/src/db/common/models/fungible_asset/fungible_asset_models/v2_fungible_asset_balances.rs
@@ -1,0 +1,29 @@
+use aptos_indexer_processor_sdk::utils::{
+    constants::{APTOS_COIN_TYPE_STR, APT_METADATA_ADDRESS_HEX, APT_METADATA_ADDRESS_RAW},
+    convert::{hex_to_raw_bytes, sha3_256, standardize_address},
+};
+
+// Copied directly from:
+// https://github.com/aptos-labs/aptos-indexer-processors-v2/blob/8f3fca6c057a1b550342b560773021a4865fb2ca/processor/src/processors/fungible_asset/fungible_asset_models/v2_fungible_asset_balances.rs#L90
+pub fn get_paired_metadata_address(coin_type_name: &str) -> String {
+    if coin_type_name == APTOS_COIN_TYPE_STR {
+        APT_METADATA_ADDRESS_HEX.clone()
+    } else {
+        let mut preimage = APT_METADATA_ADDRESS_RAW.to_vec();
+        preimage.extend(coin_type_name.as_bytes());
+        preimage.push(0xFE);
+        format!("0x{}", hex::encode(sha3_256(&preimage)))
+    }
+}
+
+// Copied directly from:
+// https://github.com/aptos-labs/aptos-indexer-processors-v2/blob/8f3fca6c057a1b550342b560773021a4865fb2ca/processor/src/processors/fungible_asset/fungible_asset_models/v2_fungible_asset_balances.rs#L101
+pub fn get_primary_fungible_store_address(
+    owner_address: &str,
+    metadata_address: &str,
+) -> anyhow::Result<String> {
+    let mut preimage = hex_to_raw_bytes(owner_address)?;
+    preimage.append(&mut hex_to_raw_bytes(metadata_address)?);
+    preimage.push(0xFC);
+    Ok(standardize_address(&hex::encode(sha3_256(&preimage))))
+}

--- a/src/rust/processor/src/db/common/models/fungible_asset/fungible_asset_models/v2_fungible_asset_utils.rs
+++ b/src/rust/processor/src/db/common/models/fungible_asset/fungible_asset_models/v2_fungible_asset_utils.rs
@@ -1,0 +1,36 @@
+// Directly/indirectly copied from:
+// https://github.com/aptos-labs/aptos-indexer-processors-v2/blob/main/processor/src/processors/fungible_asset/fungible_asset_models/v2_fungible_asset_utils.rs
+
+use aptos_indexer_processor_sdk::{
+    aptos_protos::transaction::v1::WriteResource,
+    utils::convert::{deserialize_from_string, standardize_address},
+};
+use bigdecimal::BigDecimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ResourceReference {
+    inner: String,
+}
+
+impl ResourceReference {
+    pub fn get_reference_address(&self) -> String {
+        standardize_address(&self.inner)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FungibleAssetStore {
+    pub metadata: ResourceReference,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub balance: BigDecimal,
+    pub frozen: bool,
+}
+
+impl TryFrom<&WriteResource> for FungibleAssetStore {
+    type Error = anyhow::Error;
+
+    fn try_from(write_resource: &WriteResource) -> anyhow::Result<Self> {
+        serde_json::from_str(write_resource.data.as_str()).map_err(anyhow::Error::msg)
+    }
+}

--- a/src/rust/processor/src/db/common/models/fungible_asset/mod.rs
+++ b/src/rust/processor/src/db/common/models/fungible_asset/mod.rs
@@ -1,0 +1,2 @@
+pub mod coin_models;
+pub mod fungible_asset_models;

--- a/src/rust/processor/src/db/common/models/mod.rs
+++ b/src/rust/processor/src/db/common/models/mod.rs
@@ -1,4 +1,3 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
-
+pub mod default;
 pub mod emojicoin_models;
+pub mod fungible_asset;

--- a/src/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/up.sql
+++ b/src/rust/processor/src/db/postgres/migrations/2025-02-26-040113_add_user_history_indexes/up.sql
@@ -13,15 +13,15 @@ ALTER TABLE market_registration_events
 --
 -- Most often, these two fields match; however, objects and resource accounts
 -- are often used in place of the transaction "sender" account as a proxy to
--- interact with the contract, meaning that the actual user intending to
--- interact with the contract is often only the "sender" and *not*` the
+-- interact with the module, meaning that the actual user intending to
+-- interact with the module is often only the "sender" and *not*` the
 -- address in the corresponding event field.
 --
 -- It is possible that this assumption could be wrong, in that the "sender"
 -- and individual "swapper"/"user"/"provider"/"registrant" fields don't match,
 -- but the actual user is *not* the sender but in the fact the one in the event
 -- field. A specific example of this would be if an account (the "sender") signs
--- and sends a multi-sig script or wrapper contract in which multiple other
+-- and sends a multi-sig script or wrapper module in which multiple other
 -- accounts sign separate swap/chat/register/liquidity transactions.
 --
 -- However, the difference between "sender" and the corresponding event field

--- a/src/rust/processor/src/db/postgres/migrations/2025-05-01-025837_optimize_price_feed/down.sql
+++ b/src/rust/processor/src/db/postgres/migrations/2025-05-01-025837_optimize_price_feed/down.sql
@@ -1,0 +1,38 @@
+-- This file should undo anything in `up.sql`
+-- Your SQL goes here
+DROP VIEW IF EXISTS price_feed;
+
+CREATE VIEW price_feed AS
+WITH markets AS (
+    SELECT market_id
+    FROM market_state
+    ORDER BY daily_volume DESC
+),
+swap24 AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    WHERE transaction_timestamp <= CURRENT_TIMESTAMP - interval '1 day'
+    ORDER BY
+        market_id,
+        transaction_timestamp DESC
+),
+first_swap AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    ORDER BY
+        market_id,
+        transaction_timestamp ASC
+)
+SELECT 
+    latest_swap.*,
+    COALESCE(swap_open.avg_execution_price_q64, first_swap.avg_execution_price_q64) AS open_price_q64,
+    latest_swap.last_swap_avg_execution_price_q64 AS close_price_q64
+FROM markets
+INNER JOIN market_state AS latest_swap ON markets.market_id = latest_swap.market_id
+INNER JOIN first_swap ON markets.market_id = first_swap.market_id
+LEFT JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+WHERE latest_swap.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day';

--- a/src/rust/processor/src/db/postgres/migrations/2025-05-01-025837_optimize_price_feed/up.sql
+++ b/src/rust/processor/src/db/postgres/migrations/2025-05-01-025837_optimize_price_feed/up.sql
@@ -1,0 +1,64 @@
+-- Your SQL goes here
+
+DROP VIEW IF EXISTS price_feed;
+
+-- This migration optimizes the price_feed view to improve query performance.
+-- 
+-- BACKGROUND:
+-- The original price_feed implementation had significant performance issues:
+-- 1. It scanned the entire swap_events table multiple times
+-- 2. It calculated first_swap for all markets even though it was rarely needed
+-- 3. It performed expensive operations before filtering the dataset
+--
+-- This adds a `WHERE daily_volume > 0` to filter by markets that will never be
+-- displayed (no daily volume means no 24h delta) and a CASE statement to avoid
+-- calculating the `first_swap` for each market unless it's actually necessary.
+--
+-- This reduces the query time by roughly 70% (from 1000ms to 300ms), tested using
+-- `EXPLAIN ANALYZE` on both live indexers. 
+--
+-- It also adds a new field `delta_percentage` to allow sorting on the price delta
+-- as a percentage.
+
+CREATE VIEW price_feed AS
+WITH markets AS (
+    SELECT market_id
+    FROM market_state
+    -- Filter markets that will not be displayed in the price feed. No 24h volume
+    -- means there is no 24h delta.
+    WHERE daily_volume > 0
+),
+swap24 AS (
+    SELECT DISTINCT ON (market_id)
+        market_id,
+        avg_execution_price_q64
+    FROM swap_events
+    WHERE transaction_timestamp <= CURRENT_TIMESTAMP - interval '1 day'
+    AND market_id IN (SELECT market_id FROM markets)
+    ORDER BY
+        market_id,
+        transaction_timestamp DESC
+),
+with_prices AS (
+    SELECT
+        latest_swap.*,
+        CASE
+            WHEN swap_open.avg_execution_price_q64 IS NULL THEN (
+                SELECT avg_execution_price_q64
+                FROM swap_events
+                WHERE market_id = markets.market_id
+                ORDER BY transaction_timestamp ASC
+                LIMIT 1
+            )
+            ELSE swap_open.avg_execution_price_q64
+        END AS open_price_q64,
+        latest_swap.last_swap_avg_execution_price_q64 AS close_price_q64
+    FROM markets
+    INNER JOIN market_state AS latest_swap ON markets.market_id = latest_swap.market_id
+    LEFT JOIN swap24 AS swap_open ON markets.market_id = swap_open.market_id
+    WHERE latest_swap.transaction_timestamp > CURRENT_TIMESTAMP - interval '1 day'
+)
+SELECT *,
+    -- 16 decimals to match the number of decimals in `CANDLESTICK_DECIMALS`.
+    ROUND(((close_price_q64 / open_price_q64) * 100 - 100), 16) AS delta_percentage
+FROM with_prices;

--- a/src/rust/processor/src/db/postgres/migrations/2025-05-21-212304_optimize_stats_queries/down.sql
+++ b/src/rust/processor/src/db/postgres/migrations/2025-05-21-212304_optimize_stats_queries/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+
+DROP VIEW IF EXISTS price_feed_with_nulls;
+
+DROP INDEX IF EXISTS mkt_state_by_last_swap_avg_price_idx;
+DROP INDEX IF EXISTS mkt_state_by_tvl_idx;

--- a/src/rust/processor/src/db/postgres/migrations/2025-05-21-212304_optimize_stats_queries/up.sql
+++ b/src/rust/processor/src/db/postgres/migrations/2025-05-21-212304_optimize_stats_queries/up.sql
@@ -1,0 +1,30 @@
+-- Your SQL goes here
+
+-- Can't create an index on `delta_percentage` since it's a view-only calculated column, otherwise
+-- it'd be good to have an index for it here.
+-- The other un-indexed columns used in market stats queries are below.
+CREATE INDEX IF NOT EXISTS mkt_state_by_last_swap_avg_price_idx 
+ON market_latest_state_event (last_swap_avg_execution_price_q64 DESC);
+
+CREATE INDEX IF NOT EXISTS mkt_state_by_tvl_idx
+ON market_latest_state_event (instantaneous_stats_total_value_locked DESC);
+
+-- Join market_state entries with their corresponding 24h price delta entries, if they exist.
+-- Using `postgrest` filters to achieve the same thing, with `.in` or `or.(eq...eq...eq...)`
+-- is extremely inefficient and slows down the query by a factor of 100-150x.
+-- Thus the below view is necessary to avoid 20+ second query times on a query that should take
+-- less than 200ms.
+-- Note that this view is still ~30-50x less performant than `market_state`. It should only
+-- be used as an optimization for specific queries when necessary.
+-- For markets without any volume in the past 24 hours, the three new `price_feed` columns
+-- are `null`.
+CREATE VIEW price_feed_with_nulls AS
+SELECT
+  ms.*,
+  pf.open_price_q64, -- `null` if no volume in the last 24h.
+  pf.close_price_q64, -- `null` if no volume in the last 24h.
+  pf.delta_percentage -- `null` if no volume in the last 24h.
+FROM
+  market_state ms
+LEFT JOIN price_feed pf
+  ON ms.market_id = pf.market_id;

--- a/src/rust/processor/src/db/utils.rs
+++ b/src/rust/processor/src/db/utils.rs
@@ -81,7 +81,7 @@ fn establish_connection(database_url: &str) -> BoxFuture<ConnectionResult<AsyncP
             .expect("Could not connect to database");
         tokio::spawn(async move {
             if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
+                eprintln!("connection error: {e}");
             }
         });
         AsyncPgConnection::try_from(client).await
@@ -98,7 +98,7 @@ fn parse_and_clean_db_url(url: &str) -> (String, Option<String>) {
         if k == "sslrootcert" {
             cert_path = Some(v.parse().unwrap());
         } else {
-            query.push_str(&format!("{}={}&", k, v));
+            query.push_str(&format!("{k}={v}&"));
         }
     });
     db_url.set_query(Some(&query));

--- a/src/rust/processor/src/processor.rs
+++ b/src/rust/processor/src/processor.rs
@@ -709,14 +709,14 @@ impl EmojicoinProcessor {
                                     &melee.emojicoin_0_market_address,
                                     market_registrations,
                                     states,
-                                    &pool,
+                                    pool,
                                 )
                                 .await?;
                                 let market_1 = get_market_data(
                                     &melee.emojicoin_1_market_address,
                                     market_registrations,
                                     states,
-                                    &pool,
+                                    pool,
                                 )
                                 .await?;
 
@@ -1142,8 +1142,7 @@ impl EmojicoinProcessor {
             }
             Err(e) => Err(anyhow!(e)).with_context(|| {
                 format!(
-                    "Could not insert events into the db (from {} to {}).",
-                    first_transaction_version, last_transaction_version
+                    "Could not insert events into the db (from {first_transaction_version} to {last_transaction_version})."
                 )
             }),
         }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Fix up the indexer SDK PR update so that it uses the latest processor code and formats strings and builds.

