### PR TITLE
fix(ECO-3368): Remove `--move-2` from `README.md` files

### DIFF
--- a/src/move/favorites/README.md
+++ b/src/move/favorites/README.md
@@ -23,7 +23,6 @@ NAMED_ADDRESSES=$(
 )
 aptos move publish \
     --assume-yes \
-    --move-2 \
     --named-addresses $NAMED_ADDRESSES \
     --profile $PROFILE
 ```

--- a/src/move/market_metadata/README.md
+++ b/src/move/market_metadata/README.md
@@ -25,7 +25,6 @@ NAMED_ADDRESSES=$(
 )
 aptos move publish \
     --assume-yes \
-    --move-2 \
     --named-addresses $NAMED_ADDRESSES \
     --profile $PROFILE
 ```

--- a/src/move/rewards/README.md
+++ b/src/move/rewards/README.md
@@ -46,7 +46,6 @@ NAMED_ADDRESSES=$(
 )
 aptos move publish \
     --assume-yes \
-    --move-2 \
     --named-addresses $NAMED_ADDRESSES \
     --profile $PROFILE
 ```


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

It is no longer a valid flag and is used by default