### PR TITLE
fix(ECO-2277): Add both horizontal and vertical lines to the grid no matter how many items are in a row

### DIFF
--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
@@ -25,6 +25,7 @@ import { MAX_NUM_FAVORITES } from "@/sdk/index";
 import { SortMarketsBy } from "@/sdk/indexer-v2/types/common";
 
 import { EMOJI_GRID_ITEM_WIDTH, MAX_WIDTH } from "../const";
+import EmptyTableCard from "../table-card/EmptyTableCard";
 import { LiveClientGrid } from "./AnimatedClientGrid";
 import { ClientGrid } from "./ClientGrid";
 import { ButtonsBlock } from "./components/buttons-block";
@@ -105,6 +106,11 @@ const EmojiTable = (props: EmojiTableProps) => {
   );
 
   const rowLength = useGridRowLength();
+
+  const emptyCells = useMemo(() => {
+    const maxPossibleCells = Math.ceil(markets.length / rowLength) * rowLength;
+    return maxPossibleCells - markets.length;
+  }, [markets.length, rowLength]);
 
   // Update cookies and refresh the page.
   const setIsFilterFavorites = (newVal: boolean) => {
@@ -219,6 +225,16 @@ const EmojiTable = (props: EmojiTableProps) => {
                       ) : (
                         <ClientGrid markets={markets} page={page} sortBy={sort} />
                       )}
+                      {!!emptyCells &&
+                        Array.from({ length: emptyCells }).map((_, i) => (
+                          <EmptyTableCard
+                            key={`empty-table-card-${page - 1 * MARKETS_PER_PAGE + (markets.length - 1 + i)}`}
+                            index={markets.length - 1 + i}
+                            rowLength={rowLength}
+                            pageOffset={page - 1 * MARKETS_PER_PAGE}
+                            sortBy={sort}
+                          />
+                        ))}
                     </div>
                   </motion.div>
                 </AnimatePresence>

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/EmptyTableCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/EmptyTableCard.tsx
@@ -1,0 +1,44 @@
+import { motion, type MotionProps } from "framer-motion";
+import { useMemo } from "react";
+
+import { calculateGridData, tableCardVariants } from "./animation-variants/grid-variants";
+import type { GridLayoutInformation, TableCardProps } from "./types";
+
+/**
+ * Emulates the `TableCard` component styles without any of the unnecessary calculations or animations.
+ * @param param0
+ */
+export default function EmptyTableCard({
+  index,
+  rowLength,
+  pageOffset,
+  sortBy,
+}: Pick<TableCardProps, "index"> & GridLayoutInformation & MotionProps) {
+  const { curr } = useMemo(() => calculateGridData({ index, rowLength }), [index, rowLength]);
+  return (
+    <motion.div
+      layout
+      layoutId={`empty-card-${sortBy}-${pageOffset + index}`}
+      initial={{
+        opacity: 0,
+      }}
+      className="group border-solid bg-black border border-dark-gray hover:z-10 hover:border-ec-blue"
+      variants={tableCardVariants}
+      animate={"initial"}
+      custom={{ curr }}
+      transition={{
+        type: "just",
+        delay: 0,
+        duration: 0,
+      }}
+      whileHover={{
+        filter: "brightness(1.05) saturate(1.1)",
+        boxShadow: "0 0 9px 7px rgba(8, 108, 217, 0.2)",
+        transition: {
+          filter: { duration: 0.05 },
+          boxShadow: { duration: 0.05 },
+        },
+      }}
+    ></motion.div>
+  );
+}

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/TableCard.tsx
@@ -156,7 +156,7 @@ const TableCard = ({
               }
             : undefined
       }
-      className="grid-emoji-card group cursor-pointer border-solid bg-black border border-dark-gray hover:z-10 hover:border-ec-blue"
+      className="group cursor-pointer border-solid bg-black border border-dark-gray hover:z-10 hover:border-ec-blue"
       variants={tableCardVariants}
       animate={variant}
       custom={{ curr, prev, layoutDelay }}
@@ -185,7 +185,7 @@ const TableCard = ({
       <EmojiMarketPageLink emojis={emojis}>
         <motion.div animate={controls} variants={animationsOn ? glowVariants : {}}>
           <motion.div
-            className="flex flex-col relative grid-emoji-card w-full h-full py-[10px] px-[19px] overflow-hidden"
+            className="flex flex-col relative w-full h-full py-[10px] px-[19px] overflow-hidden"
             whileHover="hover"
             animate={controls}
             variants={animationsOn ? borderVariants : onlyHoverVariant}

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/grid-variants.ts
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/animation-variants/grid-variants.ts
@@ -145,7 +145,7 @@ type GridCoordinateHistory = {
   curr: GridCoordinate;
 };
 
-type GridCoordinate = {
+export type GridCoordinate = {
   row: number;
   col: number;
   index: number;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Right now, the space for an item in a grid is empty. Make the grid consistently show all vertical and horizontal lines even if there's only one item populating that row.

Previously:

<img width="1077" alt="Screenshot 2025-06-24 at 1 34 03 PM" src="https://github.com/user-attachments/assets/3db8ea73-7181-43b9-b8c2-bb1bec8ec359" />

Now:

<img width="1077" alt="Screenshot 2025-06-24 at 1 31 36 PM" src="https://github.com/user-attachments/assets/66f9ce66-6cd5-4c30-b124-dddd64e2a2be" />
