### PR TITLE
fix(ECO-3377): Remove hover on empty cells and ensure they animate in properly

### DIFF
--- a/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/emoji-table/index.tsx
@@ -228,7 +228,7 @@ const EmojiTable = (props: EmojiTableProps) => {
                       {!!emptyCells &&
                         Array.from({ length: emptyCells }).map((_, i) => (
                           <EmptyTableCard
-                            key={`empty-table-card-${page - 1 * MARKETS_PER_PAGE + (markets.length - 1 + i)}`}
+                            key={`empty-table-card-${sort}-${page - 1 * MARKETS_PER_PAGE + (markets.length - 1 + i)}`}
                             index={markets.length - 1 + i}
                             rowLength={rowLength}
                             pageOffset={page - 1 * MARKETS_PER_PAGE}

--- a/src/typescript/frontend/src/components/pages/home/components/table-card/EmptyTableCard.tsx
+++ b/src/typescript/frontend/src/components/pages/home/components/table-card/EmptyTableCard.tsx
@@ -22,7 +22,7 @@ export default function EmptyTableCard({
       initial={{
         opacity: 0,
       }}
-      className="group border-solid bg-black border border-dark-gray hover:z-10 hover:border-ec-blue"
+      className="group border-solid bg-black border border-dark-gray hover:z-10"
       variants={tableCardVariants}
       animate={"initial"}
       custom={{ curr }}
@@ -30,14 +30,6 @@ export default function EmptyTableCard({
         type: "just",
         delay: 0,
         duration: 0,
-      }}
-      whileHover={{
-        filter: "brightness(1.05) saturate(1.1)",
-        boxShadow: "0 0 9px 7px rgba(8, 108, 217, 0.2)",
-        transition: {
-          filter: { duration: 0.05 },
-          boxShadow: { duration: 0.05 },
-        },
       }}
     ></motion.div>
   );


### PR DESCRIPTION
… properly

<!-- markdownlint-disable-file MD025 -->

# Description

They shouldn't have a hover glow, so I removed it.

I also added the `sort` value to the cell React key so that it properly reanimates when using a new sort order. Otherwise, the boxes don't animate in during the re-animation and look weird.
