### PR TITLE
chore(ECO-3400): Update broker image version in docker/cloud stack configs to use `7.1.0`

### DIFF
--- a/src/cloud-formation/deploy-indexer-alpha.yaml
+++ b/src/cloud-formation/deploy-indexer-alpha.yaml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  BrokerImageVersion: '7.0.2'
+  BrokerImageVersion: '7.1.0'
   DeployAlb: 'true'
   DeployAlbDnsRecord: 'true'
   DeployBastionHost: 'true'

--- a/src/cloud-formation/deploy-indexer-fallback.yaml
+++ b/src/cloud-formation/deploy-indexer-fallback.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '7.0.2'
+  BrokerImageVersion: '7.1.0'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'

--- a/src/cloud-formation/deploy-indexer-production.yaml
+++ b/src/cloud-formation/deploy-indexer-production.yaml
@@ -1,7 +1,7 @@
 ---
 parameters:
   BrokerCpu: 1024
-  BrokerImageVersion: '7.0.2'
+  BrokerImageVersion: '7.1.0'
   BrokerMemory: 2048
   DbMaxCapacity: 8
   DeployAlb: 'true'

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -15,7 +15,7 @@ services:
       PROCESSOR_WS_URL: 'ws://processor:${PROCESSOR_WS_PORT}/ws'
       PORT: '${BROKER_PORT}'
       RUST_LOG: 'info,broker=trace'
-    image: 'econialabs/emojicoin-dot-fun-indexer-broker:7.1.0-rc.0'
+    image: 'econialabs/emojicoin-dot-fun-indexer-broker:7.1.0'
     container_name: 'broker'
     healthcheck:
       test: 'curl -f http://localhost:${BROKER_PORT}/live || exit 1'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

- [x] Update docker compose.yaml file to use broker `7.1.0`
- [x] Update `cloud-formation/*-.yaml` files to use broker `7.1.0`
