### PR TITLE
feat(ECO-3369): Add a hard limit to `countBack` to address the candlestick DoS vector

### DIFF
--- a/src/typescript/frontend/src/app/api/arena/candlesticks/search-params-schema.ts
+++ b/src/typescript/frontend/src/app/api/arena/candlesticks/search-params-schema.ts
@@ -1,3 +1,4 @@
+import { MAX_CANDLESTICK_COUNT_BACK } from "const";
 import { z } from "zod";
 
 import { Schemas } from "@/sdk/utils";
@@ -7,7 +8,11 @@ import { SupportedPeriodSchemaArena } from "./supported-period-schema";
 export const ArenaCandlesticksSearchParamsSchema = z.object({
   meleeID: Schemas["PositiveInteger"].describe("`meleeID` must be a positive integer."),
   to: Schemas["PositiveInteger"].describe("`to` must be a positive integer."),
-  countBack: Schemas["PositiveInteger"].describe("`countBack` must be a positive integer."),
+  countBack: Schemas["PositiveInteger"]
+    .refine((v) => v <= MAX_CANDLESTICK_COUNT_BACK)
+    .describe(
+      `\`countBack\` must be a positive integer and less than ${MAX_CANDLESTICK_COUNT_BACK}`
+    ),
   period: SupportedPeriodSchemaArena,
 });
 

--- a/src/typescript/frontend/src/app/api/candlesticks/search-params-schema.ts
+++ b/src/typescript/frontend/src/app/api/candlesticks/search-params-schema.ts
@@ -1,3 +1,4 @@
+import { MAX_CANDLESTICK_COUNT_BACK } from "const";
 import { z } from "zod";
 
 import { Schemas } from "@/sdk/utils";
@@ -7,7 +8,11 @@ import { SupportedPeriodSchema } from "./supported-period-schema";
 export const CandlesticksSearchParamsSchema = z.object({
   marketID: Schemas["PositiveInteger"].describe("`marketID` must be a positive integer."),
   to: Schemas["PositiveInteger"].describe("`to` must be a positive integer."),
-  countBack: Schemas["PositiveInteger"].describe("`countBack` must be a positive integer."),
+  countBack: Schemas["PositiveInteger"]
+    .refine((v) => v <= MAX_CANDLESTICK_COUNT_BACK)
+    .describe(
+      `\`countBack\` must be a positive integer and less than ${MAX_CANDLESTICK_COUNT_BACK}`
+    ),
   period: SupportedPeriodSchema,
 });
 

--- a/src/typescript/frontend/src/components/charts/use-datafeed.ts
+++ b/src/typescript/frontend/src/components/charts/use-datafeed.ts
@@ -1,3 +1,4 @@
+import { MAX_CANDLESTICK_COUNT_BACK } from "const";
 import { useEventStore, useUserSettings } from "context/event-store-context";
 import { decodeSymbolsForChart, isArenaChartSymbol, parseSymbolWithParams } from "lib/chart-utils";
 import { useRouter } from "next/navigation";
@@ -62,7 +63,11 @@ export const useDatafeed = (symbol: string) => {
         const symbolInfo = constructLibrarySymbolInfo(baseChartSymbol, emptyBars);
         setTimeout(() => onSymbolResolvedCallback(symbolInfo), 0);
       },
-      getBars: async (symbolInfo, resolution, periodParams, onHistoryCallback, onErrorCallback) => {
+      getBars: async (symbolInfo, resolution, periParamsIn, onHistoryCallback, onErrorCallback) => {
+        const periodParams = {
+          ...periParamsIn,
+          countBack: Math.min(periParamsIn.countBack, MAX_CANDLESTICK_COUNT_BACK),
+        };
         const { firstDataRequest } = periodParams;
         const period = ResolutionStringToPeriod[resolution];
         const periodDuration = periodEnumToRawDuration(period);

--- a/src/typescript/frontend/src/const.ts
+++ b/src/typescript/frontend/src/const.ts
@@ -6,3 +6,6 @@ export const DEFAULT_TOAST_CONFIG = {
 
 export const REVALIDATE_TEST = 2;
 export const DEFAULT_MAX_SLIPPAGE = 500n;
+
+// Allow a max count back of ~7 days worth of 1m candles; aka ~420 days of 1h candles, etc.
+export const MAX_CANDLESTICK_COUNT_BACK = 10000;


### PR DESCRIPTION
# Description

Addresses the candlestick DoS vector issue by limiting `countBack` in:

- [x] The API endpoint (with the input schema validation)
- [x] The datafeed API (by using the lesser of two values, the requested `countBack` and the max value set by `const.ts`)
