### PR TITLE
chore(ECO-3394): Bump frontend to `2.0.0` and sdk to `0.12.0`

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -121,5 +121,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "1.14.1"
+  "version": "2.0.0"
 }

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -110,5 +110,5 @@
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",
-  "version": "0.11.1"
+  "version": "0.12.0"
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

- [x] Bump frontend to `2.0.0` because of the backwards incompatible API changes to `/api/candlesticks` (it uses a new data model)
- [x] Bump the TS SDK to `0.12.0` due to new features and a few backwards-incompatible changes like `postgrest.rpc` being deprecated and changed to `postgrest.dbRpc` to ensure type safety with `postgrest` RPC function calls

The Docker image version and cloud config/yaml files were already updated to the broker `7.1.0` and processor `7.4.0` recently so they don't need to be changed.
