### PR TITLE
chore(ECO-3410): Bump frontend to `2.1.0`

### DIFF
--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -121,5 +121,5 @@
     "test:unit": "pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
-  "version": "2.0.1"
+  "version": "2.1.0"
 }


### PR DESCRIPTION
# Description

- [x] Bump frontend to `2.1.0`

Nothing else needs a version bump since only the frontend is affected.
