### PR TITLE
test(ECO-3415): Increase the default `waitForProcessor` time in CI

### DIFF
--- a/src/typescript/sdk/src/indexer-v2/queries/utils.ts
+++ b/src/typescript/sdk/src/indexer-v2/queries/utils.ts
@@ -36,9 +36,8 @@ type QueryFunction<
 
 type WithConfig<T> = T & { minimumVersion?: AnyNumberString };
 
-// This is primarily used for testing purposes, otherwise this interval might be too short.
-const POLLING_INTERVAL = 500;
-const POLLING_TIMEOUT = 5000;
+const TEST_POLLING_INTERVAL = 1000;
+const TEST_POLLING_TIMEOUT = 10000;
 
 const extractRow = <T>(res: PostgrestSingleResponse<T>) => res.data;
 const extractRows = <T>(res: PostgrestSingleResponse<Array<T>>) => res.data ?? ([] as T[]);
@@ -93,7 +92,7 @@ export const waitForEmojicoinIndexer = async (
 ) =>
   new Promise<void>((resolve, reject) => {
     let i = 0;
-    const maxTries = Math.floor((maxWaitTimeMs ?? POLLING_TIMEOUT) / POLLING_INTERVAL);
+    const maxTries = Math.floor((maxWaitTimeMs ?? TEST_POLLING_TIMEOUT) / TEST_POLLING_INTERVAL);
 
     const check = async () => {
       try {
@@ -106,7 +105,7 @@ export const waitForEmojicoinIndexer = async (
         } else {
           setTimeout(() => {
             check();
-          }, POLLING_INTERVAL);
+          }, TEST_POLLING_INTERVAL);
         }
         i += 1;
       } catch (e) {


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

I've increased the default `waitForProcessor` time from 5 seconds to 10 seconds to reduce the rate of false negatives in CI.

It was originally set to 5 seconds when I created the test suite on my local Windows machine, but 10 seconds is more appropriate for the CI hardware, since processing speed might be much slower there.

The motivation for this was seeing in CI one of the arena general tests failed due to this, desipte processing the expected version very shortly after. See the logs below from one test in CI that motivated me to do this. Note that the broker received a message from the processor, transaction version `449`, right before the test fails while waiting for `449`, thus meaning that there just wasn't a long enough wait time. Since the `last_success_version` lags behind the *actual* processed values (due to how `last_success_version` is recorded by the Aptos indexer processor harness)

```shell
broker     | [2025-07-25T18:22:18Z INFO  broker::processor_connection] Got message from processor: {"ArenaMelee":{"transaction_version":449,"event_index":2,"sender":"0xf000d910b99722d201c6cf88eb7d1112b43475b9765b118f289b5d65d919000d","entry_function":"0xf000d910b99722d201c6cf88eb7d1112b43475b9765b118f289b5d65d919000d::emojicoin_arena::enter","transaction_timestamp":"2025-07-25T18:22:17.564774","melee_id":"11","emojicoin_0_market_address":"0x89697926e761c24a6ad39d76abad092e90cb5d8b73954571d4c5d7f289055b12","emojicoin_1_market_address":"0x9e11cf68f9b0ff295da8ed0a50bdcbe44931f1e1502d53245efc959bd71e7f9b","start_time":"2025-07-25T18:22:14.999158","duration":"15000000","max_match_percentage":"50","max_match_amount":"500000000","available_rewards":"100000000000"}}.
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:18 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:18 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:19 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:19 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:20 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:20 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:21 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:21 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:22 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:22 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
broker     | [2025-07-25T18:22:23Z INFO  broker::processor_connection] Ping to processor succeeded!
postgrest  | 172.18.0.1 - web_anon [25/Jul/2025:18:22:23 +0000] "GET /processor_status?select=processor%2Clast_success_version%2Clast_updated%2Clast_transaction_timestamp&limit=1 HTTP/1.1" 200 164 "" "node"
  console.error
    Trace: Waiting for 449, got to 447 before failing.
        at check (/home/runner/work/emojicoin-dot-fun/emojicoin-dot-fun/src/typescript/sdk/src/indexer-v2/queries/utils.ts:104:19)
        at processTicksAndRejections (node:internal/process/task_queues:95:5)

      102 |           resolve();
      103 |         } else if (i > maxTries) {
    > 104 |           console.trace(`Waiting for ${minimumVersion}, got to ${latestVersion} before failing.`);
          |                   ^
      105 |           reject(new Error("Timeout waiting for processed version."));
      106 |         } else {
      107 |           setTimeout(() => {

      at check (src/indexer-v2/queries/utils.ts:104:19)

```

https://productionresultssa3.blob.core.windows.net/actions-results/342b039d-8eaf-4d71-b384-ba93a00e8e23/workflow-job-run-f1a1a255-1520-5b4e-b50f-e4488e42d7ce/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-07-25T18%3A42%3A26Z&sig=mnt%2BGSxawA%2FBJbcOGb8QmLL2uqfUl5YaKo54laFR7J0%3D&ske=2025-07-26T03%3A41%3A45Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-07-25T15%3A41%3A45Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-07-25T18%3A32%3A21Z&sv=2025-05-05