### PR TITLE
fix(ECO-3439): Add underflow handling to `getDynamicBaseFeeRateBPs`

### DIFF
--- a/src/typescript/ci.env
+++ b/src/typescript/ci.env
@@ -25,7 +25,7 @@ PUBLISHER_PRIVATE_KEY="eaa964d1353b075ac63b0c5a0c1e92aa93355be1402f6077581e37e2a
 # ---------------------------------------------------------------------------- #
 #                     Miscellaneous frontend configurations
 # ---------------------------------------------------------------------------- #
-NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS="100"
+NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS="0"
 NEXT_PUBLIC_IS_ALLOWLIST_ENABLED="false"
 HASH_SEED="some random string that is not public"
 NEXT_PUBLIC_ARENA_ENABLED="true"

--- a/src/typescript/ci.env
+++ b/src/typescript/ci.env
@@ -25,7 +25,7 @@ PUBLISHER_PRIVATE_KEY="eaa964d1353b075ac63b0c5a0c1e92aa93355be1402f6077581e37e2a
 # ---------------------------------------------------------------------------- #
 #                     Miscellaneous frontend configurations
 # ---------------------------------------------------------------------------- #
-NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS="0"
+NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS="50"
 NEXT_PUBLIC_IS_ALLOWLIST_ENABLED="false"
 HASH_SEED="some random string that is not public"
 NEXT_PUBLIC_ARENA_ENABLED="true"

--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -118,7 +118,7 @@
     "start": "next start --port 3001",
     "submodule": "./submodule.sh",
     "test:e2e": "playwright test --project=firefox",
-    "test:unit": "pnpm jest tests/unit",
+    "test:unit": "pnpm jest tests/unit && NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS=0 pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
   "version": "2.1.0"

--- a/src/typescript/frontend/package.json
+++ b/src/typescript/frontend/package.json
@@ -118,7 +118,7 @@
     "start": "next start --port 3001",
     "submodule": "./submodule.sh",
     "test:e2e": "playwright test --project=firefox",
-    "test:unit": "pnpm jest tests/unit && NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS=0 pnpm jest tests/unit",
+    "test:unit": "pnpm jest tests/unit && pnpm dotenv -v NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS=0 -- pnpm jest tests/unit",
     "vercel-install": "./submodule.sh && pnpm i"
   },
   "version": "2.1.0"

--- a/src/typescript/frontend/src/lib/env.ts
+++ b/src/typescript/frontend/src/lib/env.ts
@@ -2,7 +2,7 @@ import type { Network } from "@aptos-labs/ts-sdk";
 import { parse } from "semver";
 
 import type { AccountAddressString } from "@/sdk/emojicoin_dot_fun";
-import { PositiveIntegerSchema } from "@/sdk/utils/validation/integer";
+import { NonNegativeIntegerSchema } from "@/sdk/utils/validation/integer";
 
 import packageInfo from "../../package.json";
 
@@ -64,7 +64,7 @@ const VERSION = parse(packageInfo.version);
 
 // Must be duplicated from the sdk/src/const.ts file because the SDK exports functions not available
 // in the edge runtime in middleware.
-const INTEGRATOR_FEE_RATE_BPS = PositiveIntegerSchema.parse(
+const INTEGRATOR_FEE_RATE_BPS = NonNegativeIntegerSchema.parse(
   process.env.NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS
 );
 

--- a/src/typescript/frontend/tests/unit/calculate-swap-price.test.ts
+++ b/src/typescript/frontend/tests/unit/calculate-swap-price.test.ts
@@ -18,8 +18,12 @@ describe("swap price calculation with dynamic fees", () => {
   it("sets the fee rates to the same total fee amount for markets pre/post bonding curve", () => {
     const preRate = getDynamicBaseFeeRateBPs({ inBondingCurve: true });
     const postRate = getDynamicBaseFeeRateBPs({ inBondingCurve: false });
-    // There is no pool fee in the bonding curve, so there's no pool fee rate incurred there.
-    expect(preRate).toEqual(postRate + POOL_FEE_RATE_BPS);
+    if (INTEGRATOR_FEE_RATE_BPS > 0) {
+      // There is no pool fee in the bonding curve, so there's no pool fee rate incurred there.
+      expect(preRate).toEqual(postRate + POOL_FEE_RATE_BPS);
+    } else {
+      expect(preRate).toEqual(0);
+    }
   });
 
   it("applies correct dynamic fee inside bonding curve", () => {
@@ -116,19 +120,18 @@ describe("swap price calculation with dynamic fees", () => {
     expect(POOL_FEE_RATE_BPS).not.toEqual(0);
     expect(prePoolFeePercentage).toEqual(0);
 
-    // This assumption is made in the dynamic fee calculation function and is called there as well,
-    // including at build time.
-    expect(INTEGRATOR_FEE_RATE_BPS).toBeGreaterThanOrEqual(POOL_FEE_RATE_BPS);
-
-    // The pre/post integrator fee percentages should not be the same, since the pool fee should
-    // not be zero.
-
-    expect(preIntegratorFeePercentage).not.toEqual(postIntegratorFeePercentage);
-
-    // The pre integrator fee percentage should be very close to the post fee percentages of both
-    // of the fee types.
-    expect(preIntegratorFeePercentage).toBeCloseTo(
-      postIntegratorFeePercentage + postPoolFeePercentage
-    );
+    if (INTEGRATOR_FEE_RATE_BPS > 0) {
+      // The pre/post integrator fee percentages should not be the same, since the pool fee should
+      // not be zero.
+      expect(preIntegratorFeePercentage).not.toEqual(postIntegratorFeePercentage);
+      // The pre integrator fee percentage should be very close to the post fee percentages of both
+      // of the fee types.
+      expect(preIntegratorFeePercentage).toBeCloseTo(
+        postIntegratorFeePercentage + postPoolFeePercentage
+      );
+    } else {
+      expect(preIntegratorFeePercentage).toEqual(0);
+      expect(preIntegratorFeePercentage).toEqual(postIntegratorFeePercentage);
+    }
   }
 });

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -37,6 +37,7 @@
     "start": "pnpm load-env -- turbo run start",
     "submodule": "turbo run submodule",
     "test": "pnpm run test:frontend:unit && pnpm run test:sdk",
+    "test:zero-fee-rates": "pnpm dotenv -v NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS=0 -- pnpm run test",
     "test:frontend": "pnpm run test:frontend:unit && test:frontend:e2e",
     "test:frontend:e2e": "pnpm run load-env:test -- turbo run test:e2e --filter @econia-labs/emojicoin-frontend --log-prefix none",
     "test:frontend:unit": "NO_TEST_SETUP=true pnpm run load-env:test -- turbo run test:unit --filter @econia-labs/emojicoin-frontend --log-prefix none",

--- a/src/typescript/package.json
+++ b/src/typescript/package.json
@@ -37,7 +37,6 @@
     "start": "pnpm load-env -- turbo run start",
     "submodule": "turbo run submodule",
     "test": "pnpm run test:frontend:unit && pnpm run test:sdk",
-    "test:zero-fee-rates": "pnpm dotenv -v NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS=0 -- pnpm run test",
     "test:frontend": "pnpm run test:frontend:unit && test:frontend:e2e",
     "test:frontend:e2e": "pnpm run load-env:test -- turbo run test:e2e --filter @econia-labs/emojicoin-frontend --log-prefix none",
     "test:frontend:unit": "NO_TEST_SETUP=true pnpm run load-env:test -- turbo run test:unit --filter @econia-labs/emojicoin-frontend --log-prefix none",

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -106,7 +106,7 @@
     "test:e2e:arena-general": "pnpm jest tests/e2e/arena/general.test.ts --runInBand",
     "test:e2e:arena-restart": "pnpm jest tests/e2e/arena/restart.test.ts --runInBand",
     "test:e2e:arena-ws": "pnpm jest tests/e2e/arena/websockets.test.ts --runInBand",
-    "test:unit": "pnpm jest tests/unit && NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS=0 pnpm jest tests/unit",
+    "test:unit": "pnpm jest tests/unit && pnpm dotenv -v NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS=0 -- pnpm jest tests/unit",
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",

--- a/src/typescript/sdk/package.json
+++ b/src/typescript/sdk/package.json
@@ -106,7 +106,7 @@
     "test:e2e:arena-general": "pnpm jest tests/e2e/arena/general.test.ts --runInBand",
     "test:e2e:arena-restart": "pnpm jest tests/e2e/arena/restart.test.ts --runInBand",
     "test:e2e:arena-ws": "pnpm jest tests/e2e/arena/websockets.test.ts --runInBand",
-    "test:unit": "pnpm jest tests/unit",
+    "test:unit": "pnpm jest tests/unit && NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS=0 pnpm jest tests/unit",
     "verify-processor-data": "pnpm dotenv -e ../.env -- pnpm tsx --conditions=react-server src/scripts/verify-processor-data.ts"
   },
   "typings": "dist/common/index.d.ts",

--- a/src/typescript/sdk/src/const.ts
+++ b/src/typescript/sdk/src/const.ts
@@ -11,7 +11,7 @@ import type { DatabaseStructType } from "./indexer-v2/types/json-types";
 import type { Types } from "./types";
 import type { CoinTypeString } from "./utils";
 import type { ValueOf } from "./utils/utility-types";
-import { PositiveIntegerSchema } from "./utils/validation/integer";
+import { NonNegativeIntegerSchema } from "./utils/validation/integer";
 
 export const VERCEL = process.env.VERCEL === "1";
 let vercelTargetEnv: "production" | "preview" | "development" | "release-preview";
@@ -118,7 +118,7 @@ export const REWARDS_MODULE_ADDRESS = (() =>
   AccountAddress.from(envVariables.NEXT_PUBLIC_REWARDS_MODULE_ADDRESS))();
 export const INTEGRATOR_ADDRESS = (() =>
   AccountAddress.from(envVariables.NEXT_PUBLIC_INTEGRATOR_ADDRESS))();
-export const INTEGRATOR_FEE_RATE_BPS = PositiveIntegerSchema.parse(
+export const INTEGRATOR_FEE_RATE_BPS = NonNegativeIntegerSchema.parse(
   envVariables.NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS
 );
 export const ONE_APT = 1 * 10 ** 8;

--- a/src/typescript/sdk/src/const.ts
+++ b/src/typescript/sdk/src/const.ts
@@ -121,6 +121,12 @@ export const INTEGRATOR_ADDRESS = (() =>
 export const INTEGRATOR_FEE_RATE_BPS = NonNegativeIntegerSchema.parse(
   envVariables.NEXT_PUBLIC_INTEGRATOR_FEE_RATE_BPS
 );
+/**
+ * See `INTEGRATOR_FEE_RATE_BPS` in
+ * {@link [emojicoin_dot_fun_rewards.move](../../../move/rewards/sources/emojicoin_dot_fun_rewards.move)}
+ * for more info.
+ */
+export const REWARDS_INTEGRATOR_FEE_RATE_BPS = 100;
 export const ONE_APT = 1 * 10 ** 8;
 export const ONE_APT_BIGINT = BigInt(ONE_APT);
 export const APTOS_COIN_TYPE_STRING = parseTypeTag(APTOS_COIN).toString() as CoinTypeString;

--- a/src/typescript/sdk/src/utils/validation/index.ts
+++ b/src/typescript/sdk/src/utils/validation/index.ts
@@ -1,12 +1,13 @@
 import { AccountAddressSchema } from "./account-address";
 import { BigIntSchema, PositiveBigIntSchema } from "./bigint";
-import { IntegerSchema, PositiveIntegerSchema } from "./integer";
+import { IntegerSchema, NonNegativeIntegerSchema, PositiveIntegerSchema } from "./integer";
 import { SymbolEmojisSchema } from "./symbol-emoji";
 
 export const Schemas = {
   Integer: IntegerSchema,
   BigInt: BigIntSchema,
   PositiveInteger: PositiveIntegerSchema,
+  NonNegativeInteger: NonNegativeIntegerSchema,
   PositiveBigInt: PositiveBigIntSchema,
   AccountAddress: AccountAddressSchema,
   SymbolEmojis: SymbolEmojisSchema,

--- a/src/typescript/sdk/src/utils/validation/integer.ts
+++ b/src/typescript/sdk/src/utils/validation/integer.ts
@@ -7,3 +7,5 @@ export const IntegerSchema = z
   .pipe(z.coerce.number().finite().safe().int());
 
 export const PositiveIntegerSchema = IntegerSchema.pipe(z.coerce.number().positive());
+
+export const NonNegativeIntegerSchema = IntegerSchema.pipe(z.coerce.number().nonnegative());

--- a/src/typescript/sdk/tests/e2e/queries/client/submit.test.ts
+++ b/src/typescript/sdk/tests/e2e/queries/client/submit.test.ts
@@ -10,9 +10,9 @@ import {
   APTOS_NETWORK,
   getEmojicoinMarketAddressAndTypeTags,
   INTEGRATOR_ADDRESS,
-  INTEGRATOR_FEE_RATE_BPS,
   MODULE_ADDRESS,
   ONE_APT,
+  REWARDS_INTEGRATOR_FEE_RATE_BPS,
   REWARDS_MODULE_ADDRESS,
   REWARDS_MODULE_NAME,
   type SymbolEmoji,
@@ -337,7 +337,7 @@ describe("all submission types for the emojicoin client", () => {
         expect(swap.event.isSell).toEqual(false);
         expect(swap.event.swapper).toEqual(sender.accountAddress.toString());
         expect(swap.event.integrator).toEqual(INTEGRATOR_ADDRESS.toString());
-        expect(swap.event.integratorFeeRateBPs).toEqual(INTEGRATOR_FEE_RATE_BPS);
+        expect(swap.event.integratorFeeRateBPs).toEqual(REWARDS_INTEGRATOR_FEE_RATE_BPS);
         expect(swap.model.market.emojis.map(({ emoji }) => emoji)).toEqual(emojis);
         expect(swap.model.market.trigger).toEqual(Trigger.SwapBuy);
       });
@@ -371,7 +371,7 @@ describe("all submission types for the emojicoin client", () => {
           expect(sell.event.isSell).toEqual(true);
           expect(sell.event.swapper).toEqual(sender.accountAddress.toString());
           expect(sell.event.integrator).toEqual(INTEGRATOR_ADDRESS.toString());
-          expect(sell.event.integratorFeeRateBPs).toEqual(INTEGRATOR_FEE_RATE_BPS);
+          expect(sell.event.integratorFeeRateBPs).toEqual(REWARDS_INTEGRATOR_FEE_RATE_BPS);
           expect(sell.model.market.emojis.map(({ emoji }) => emoji)).toEqual(emojis);
           expect(sell.model.market.trigger).toEqual(Trigger.SwapSell);
         });


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

- [x] Add underflow handling to `getDynamicBaseFeeRateBPs`
- [x] Remove the unnecessary check about function assumptions now, since this is ultimately more robust/intuitive anyway
- [x] Update tests to accomodate it
- [x] Run tests twice with fee rate BPs of 0 and the value passed in by ci.env
- [x] Update `ci.env` to use `50` instead of `100`
- [x] Hard code the rewards fee rate BPs into consts, use it in tests where rewards functions are tested